### PR TITLE
Add class alias for typeset -T

### DIFF
--- a/src/cmd/ksh93/data/aliases.c
+++ b/src/cmd/ksh93/data/aliases.c
@@ -34,6 +34,7 @@ const struct shtable2 shtab_aliases[] =
 #endif /* SHOPT_FS_3D */
 	"autoload",	NV_NOFREE,		"typeset -fu",
 	"bool",		NV_NOFREE|BLT_DCL,	"_Bool",
+	"class",	NV_NOFREE|BLT_DCL,	"typeset -T",
 	"command",	NV_NOFREE,		"command ",
 	"compound",	NV_NOFREE|BLT_DCL,	"typeset -C",
 	"fc",		NV_NOFREE,		"hist",


### PR DESCRIPTION
I think this would be useful as the word class is much more intuitive and elegant for defining types.
