### PR TITLE
Fix how overlapped buffers are handled

### DIFF
--- a/src/cmd/nmake/variable.c
+++ b/src/cmd/nmake/variable.c
@@ -577,7 +577,11 @@ resetvar(register Var_t* p, char* v, int append)
 		p->value = newof(p->value, char, n + 1, 0);
 		p->length = n;
 	}
-	strcpy(p->value, v);
+	/*
+	 * The buffers may overlap so we can't use `strcpy()` since it has
+	 * undefined behavior in that case. See issue #42.
+	 */
+	memmove(p->value, v, n + 1);
 }
 
 /*

--- a/src/lib/libast/sfio/sfputr.c
+++ b/src/lib/libast/sfio/sfputr.c
@@ -105,7 +105,12 @@ int		rc;	/* record separator.	*/
 			break;
 		}
 
-#if _lib_memccpy && !__ia64 /* these guys may never get it right */
+#if _lib_memccpy && !__ia64 && !defined(BSD) /* these guys may never get it right */
+		/*
+		 * Note that `ps`, and `s` may overlap. So this relies on
+		 * undefined behavior. See issue #42 where it is known to fail
+		 * on MacOS (and presumably other BSD variants).
+		 */
 		if((ps = (uchar*)memccpy(ps,s,'\0',p)) != NIL(uchar*))
 			ps -= 1;
 		else	ps  = f->next+p;


### PR DESCRIPTION
Trying to build this project on macOS (a BSD variant) resulted in two
`assert()` failures when running `nmake`. The problem is that there are
at least two places which pass overlapping buffers to functions which are explicitly
defined to have undefined behavior when the buffers overlap.

See issue #42.