### PR TITLE
Changes to allow building ksh93 on FreeBSD

### DIFF
--- a/src/lib/libast/features/standards
+++ b/src/lib/libast/features/standards
@@ -158,6 +158,22 @@ else tst note{ __EXTENSIONS__ works }end compile{
 	}
 endif
 
+if tst note{ __FreeBSD_version works }end compile{
+		#include <sys/param.h>
+		#if !defined(__FreeBSD_version)
+		(
+		#endif
+	}end {
+/*
+ * On FreeBSD we can't define these symbols since doing so causes
+ * problems such as some errno symbols (e.g., EILSEQ) not being visible.
+ */
+            #undef  _POSIX_SOURCE
+            #undef  _POSIX_C_SOURCE
+            #undef  _XOPEN_SOURCE
+	}
+endif
+
 if tst -D_ISOC99_SOURCE -lm note{ _ISOC99_SOURCE plays nice }end link{
 		#include <sys/types.h>
 		#include <sys/stat.h>

--- a/src/lib/libast/features/wchar
+++ b/src/lib/libast/features/wchar
@@ -52,6 +52,10 @@ endif
 run{
 cat <<!
 	#if _hdr_wchar && defined(_nxt_wchar)
+        /* This symbol is needed on FreeBSD to keep `FILE` from being defined as
+         * an incompatible type in the /usr/include/wchar.h header.
+         */
+        #define _STDFILE_DECLARED
 	#include ${_nxt_wchar-_nxt_wchar}	/* the native wchar.h */
 	#endif
 

--- a/src/lib/libast/include/sfio.h
+++ b/src/lib/libast/include/sfio.h
@@ -150,7 +150,7 @@ struct _sffmt_s
 #define SF_IOINTR	0040000	/* return on interrupts			*/
 #define SF_WCWIDTH	0100000	/* wcwidth display stream		*/
 
-#define SF_FLAGS	0177177	/* PUBLIC FLAGS PASSABLE TO SFNEW()	*/
+#define SFIO_FLAGS	0177177	/* PUBLIC FLAGS PASSABLE TO SFNEW()	*/
 #define SF_SETS		0177163	/* flags passable to sfset()		*/
 
 #ifndef _SF_NO_OBSOLETE

--- a/src/lib/libast/include/sfio_t.h
+++ b/src/lib/libast/include/sfio_t.h
@@ -75,7 +75,7 @@
 	  (unsigned char*)(data),			/* endr		*/ \
 	  (unsigned char*)(data),			/* endb		*/ \
 	  (Sfio_t*)0,					/* push		*/ \
-	  (unsigned short)((type)&SF_FLAGS),		/* flags	*/ \
+	  (unsigned short)((type)&SFIO_FLAGS),		/* flags	*/ \
 	  (short)(file),				/* file		*/ \
 	  (unsigned char*)(data),			/* data		*/ \
 	  (ssize_t)(size),				/* size		*/ \

--- a/src/lib/libast/sfio/_sfopen.c
+++ b/src/lib/libast/sfio/_sfopen.c
@@ -81,7 +81,7 @@ char*		mode;		/* mode of the stream */
 	{	SFMTXENTER(f, NIL(Sfio_t*));
 
 		if(f->mode&SF_INIT ) /* stream uninitialized, ok to set flags */
-		{	f->flags |= (sflags & (SF_FLAGS & ~SF_RDWR));
+		{	f->flags |= (sflags & (SFIO_FLAGS & ~SF_RDWR));
 
 			if((sflags &= SF_RDWR) != 0) /* reset read/write modes */
 			{	f->flags = (f->flags & ~SF_RDWR) | sflags;

--- a/src/lib/libast/sfio/sfclrlock.c
+++ b/src/lib/libast/sfio/sfclrlock.c
@@ -57,7 +57,7 @@ Sfio_t	*f;
 	/* throw away all lock bits except for stacking state SF_PUSH */
 	f->mode &= (SF_RDWR|SF_INIT|SF_POOL|SF_PUSH|SF_SYNCED|SF_STDIO);
 
-	rv = (f->mode&SF_PUSH) ? 0 : (f->flags&SF_FLAGS);
+	rv = (f->mode&SF_PUSH) ? 0 : (f->flags&SFIO_FLAGS);
 
 	SFMTXRETURN(f, rv);
 }

--- a/src/lib/libast/sfio/sfnew.c
+++ b/src/lib/libast/sfio/sfnew.c
@@ -106,7 +106,7 @@ int	flags;	/* type of file stream */
 
 	/* stream type */
 	f->mode = (flags&SF_READ) ? SF_READ : SF_WRITE;
-	f->flags = (flags&SF_FLAGS) | (sflags&(SF_MALLOC|SF_STATIC));
+	f->flags = (flags&SFIO_FLAGS) | (sflags&(SF_MALLOC|SF_STATIC));
 	f->bits = (flags&SF_RDWR) == SF_RDWR ? SF_BOTH : 0;
 	f->file = file;
 	f->here = f->extent = 0;

--- a/src/lib/libast/sfio/sfset.c
+++ b/src/lib/libast/sfio/sfset.c
@@ -41,7 +41,7 @@ int		set;
 	SFMTXENTER(f,0);
 
 	if(flags == 0 && set == 0)
-		SFMTXRETURN(f, (f->flags&SF_FLAGS));
+		SFMTXRETURN(f, (f->flags&SFIO_FLAGS));
 
 	if((oflags = (f->mode&SF_RDWR)) != (int)f->mode)
 	{	/* avoid sfsetbuf() isatty() call if user sets (SF_LINE|SF_WCWIDTH) */
@@ -57,7 +57,7 @@ int		set;
 			SFMTXRETURN(f, 0);
 	}
 	if(flags == 0)
-		SFMTXRETURN(f, (f->flags&SF_FLAGS));
+		SFMTXRETURN(f, (f->flags&SFIO_FLAGS));
 
 	SFLOCK(f,0);
 
@@ -95,5 +95,5 @@ int		set;
 		f->flags &= ~SF_PUBLIC;
 
 	SFOPEN(f,0);
-	SFMTXRETURN(f, (oflags&SF_FLAGS));
+	SFMTXRETURN(f, (oflags&SFIO_FLAGS));
 }


### PR DESCRIPTION
This was inspired by changes made by Marcin Cieślak (@saper) and
Cy Schubert (@cschuber) but that hadn't been merged upstream. This
includes one additional change I wrote to deal with how FreeBSD uses the
`_POSIX_SOURCE` symbol to hide some things we need (e.g., errno `EILSEQ`).

Fixes #26