### PR TITLE
Assume `MAP_ANON` is valid

### DIFF
--- a/src/lib/libast/features/mmap
+++ b/src/lib/libast/features/mmap
@@ -16,14 +16,7 @@ tst	lib_mmap note{ standard mmap interface that works }end execute{
 
 	#define Failed(file)	(remove(file),1)
 
-	int
-	#if _STD_
-	main(int argc, char** argv)
-	#else
-	main(argc,argv)
-	int     argc;
-	char**  argv;
-	#endif
+	int main(int argc, char** argv)
 	{
 		caddr_t		mm;
 		char		*file;
@@ -165,169 +158,18 @@ tst	lib_mmap64 -D_LARGEFILE64_SOURCE note{ mmap64 interface and implementation w
 	}
 }end
 
-tst	mmap_anon note{ use mmap MAP_ANON to get raw memory }end execute{
-	#if !_lib_mmap
-	(
-	#endif
-	#include <unistd.h>
-	#include <fcntl.h>
-	#include <sys/types.h>
-	#include <sys/mman.h>
-	#if defined(MAP_ANONYMOUS) && !defined(MAP_ANON)
-	#define MAP_ANON	MAP_ANONYMOUS
-	#endif
-	int
-	main()
-	{	void	*addr;
-		addr = mmap(0,1024*1024,PROT_READ|PROT_WRITE,MAP_ANON|MAP_PRIVATE,-1,0);
-		return (addr && addr != (void*)(-1)) ? 0 : 1;
-	}
-}end
-
-tst	mmap_devzero note{ use mmap on /dev/zero to get raw memory }end execute{
-	#if !_lib_mmap
-	(
-	#endif
-	#include <unistd.h>
-	#include <fcntl.h>
-	#include <sys/types.h>
-	#include <sys/mman.h>
-	int
-	main()
-	{	int	fd;
-		void	*addr;
-		if((fd = open("/dev/zero", O_RDWR)) < 0)
-			return 1;
-		addr = mmap(0,1024*1024,PROT_READ|PROT_WRITE,MAP_PRIVATE,fd,0);
-		return (addr && addr != (void*)(-1)) ? 0 : 1;
-	}
-}end
-
-tst	-D_LARGEFILE64_SOURCE note{ mmap is worth using }end output{
-	#if !_lib_mmap
-	(
-	#endif
-	#include <unistd.h>
-	#include <fcntl.h>
-	#include <string.h>
-	#include <sys/types.h>
-	#include <sys/mman.h>
-	#include <sys/stat.h>
-	#include <sys/times.h>
-
-	#if _lib_mmap64
-	#undef	mmap
-	#define mmap	mmap64
-	#endif
-
-	#if _lib_munmap64
-	#undef	munmap
-	#define munmap	munmap64
-	#endif
-	
-	#define MAPSIZE (64*1024)
-	#define BUFSIZE	(MAPSIZE/8)
-	#define WRITE   (64)
-	#define RUN	(64)
-	
-	#define Failed(file)	(remove(file),1)
-	
-	int
-	#if _STD_
-	main(int argc, char** argv)
-	#else
-	main(argc,argv)
-	int     argc;
-	char**  argv;
-	#endif
-	{
-		caddr_t		mm;
-		char		*file, *t;
-		int		i, fd, k, run;
-		char		buf[MAPSIZE];
-		struct tms	stm, etm;
-		clock_t		rdtm, mmtm;
-	
-		file = argv[1];
-		if ((fd = open(file, O_CREAT|O_TRUNC|O_WRONLY, 0666)) < 0)
-			return 1;
-	
-		for (i = 0; i < sizeof(buf); ++i)
-			buf[i] = '0' + (i%10);
-		for (i = 0; i < WRITE; ++i)
-			if (write(fd,buf,sizeof(buf)) != sizeof(buf))
-				return Failed(file);
-		close(fd);
-	
-		/* read time */
-		times(&stm);
-		for(run = 0; run < RUN; ++run)
-		{	if((fd = open(file, O_RDWR)) < 0)
-				return Failed(file);
-			for (i = 0; i < WRITE; ++i)
-			{	for(k = 0; k < MAPSIZE; k += BUFSIZE)
-					if (read(fd,buf,BUFSIZE) != BUFSIZE)
-						return Failed(file);
-			}
-			close(fd);
-		}
-		times(&etm);
-		rdtm = (etm.tms_utime-stm.tms_utime) + (etm.tms_stime-stm.tms_stime);
-	
-		/* mmap time */
-		times(&stm);
-		for(run = 0; run < RUN; ++run)
-		{	if ((fd = open(file, O_RDWR)) < 0)
-				return Failed(file);
-			for(i = 0, mm = (caddr_t)0; i < WRITE; ++i)
-			{	if(mm)
-					munmap(mm, MAPSIZE);
-				mm = (caddr_t)mmap((caddr_t)0, MAPSIZE,
-						   (PROT_READ|PROT_WRITE),
-						   MAP_PRIVATE, fd, i*MAPSIZE );
-				if(mm == (caddr_t)(-1) || mm == (caddr_t)0)
-					return Failed(file);
-	
-				/* the memcpy is < BUFSIZE to simulate the
-				   fact that functions like sfreserve/sfgetr do
-				   not do buffer copying.
-				*/
-				t = (char*)mm;
-				for(k = 0; k < MAPSIZE; k += BUFSIZE, t += BUFSIZE)
-					memcpy(buf,t,(3*BUFSIZE)/4);
-			}
-			close(fd);
-		}
-		times(&etm);
-		mmtm = (etm.tms_utime-stm.tms_utime) + (etm.tms_stime-stm.tms_stime);
-
-		remove(file);
-	
-		if(4*mmtm <= 3*rdtm)
-			printf("#define _mmap_worthy	2	/* mmap outperforms read on 64Ki buffers -- use it */\n");
-		else if(4*mmtm <= 5*rdtm)
-			printf("#define _mmap_worthy	2	/* mmap is slightly better than read on 64Ki buffers -- use it */\n");
-		else
-			printf("#define _mmap_worthy	2	/* mmap worse than read on 64Ki buffers -- use it anyway */\n");
-
-		return 0;
-	}
-}end
-
 cat{
+        /* assume MAP_ANON works */
+        #define _mmap_anon 1
 
 	/* some systems get it wrong but escape concise detection */
-	#ifndef _NO_MMAP
 	#if __CYGWIN__
 	#define _NO_MMAP	1
-	#endif
 	#endif
 
 	#if _NO_MMAP
 	#undef	_lib_mmap
 	#undef	_lib_mmap64
-	#undef	_mmap_anon
-	#undef	_mmap_devzero
-	#undef	_mmap_worthy
+	#undef  _mmap_anon
 	#endif
 }end

--- a/src/lib/libast/features/vmalloc
+++ b/src/lib/libast/features/vmalloc
@@ -217,7 +217,4 @@ cat{
 	#if _mmap_anon
 	#define _mem_mmap_anon	1
 	#endif
-	#if _mmap_devzero
-	#define _mem_mmap_zero	1
-	#endif
 }end

--- a/src/lib/libast/port/astcopy.c
+++ b/src/lib/libast/port/astcopy.c
@@ -30,13 +30,9 @@
 #include <ast.h>
 #include <ast_mmap.h>
 
-#if _mmap_worthy > 1
-
 #include <ls.h>
 
 #define MAPSIZE		(1024*256)
-
-#endif
 
 #undef	BUFSIZ
 #define BUFSIZ		4096

--- a/src/lib/libast/sfio/sfclose.c
+++ b/src/lib/libast/sfio/sfclose.c
@@ -104,11 +104,9 @@ Sfio_t*	f;
 
 	if(f->data && (!local || (f->flags&SF_STRING) || (f->bits&SF_MMAP) ) )
 	{	/* free buffer */
-#if _mmap_worthy
 		if(f->bits&SF_MMAP)
 			SFMUNMAP(f,f->data,f->endb-f->data);
 		else
-#endif
 		if(f->flags&SF_MALLOC)
 			data = (Void_t*)f->data;
 

--- a/src/lib/libast/sfio/sfhdr.h
+++ b/src/lib/libast/sfio/sfhdr.h
@@ -209,9 +209,6 @@
 
 /* see if we can use memory mapping for io */
 #if _LARGEFILE64_SOURCE && !_lib_mmap64
-#undef _mmap_worthy
-#endif
-#if !_mmap_worthy
 #undef _hdr_mman
 #undef _sys_mman
 #endif

--- a/src/lib/libast/sfio/sfmode.c
+++ b/src/lib/libast/sfio/sfmode.c
@@ -404,7 +404,6 @@ reg int		local;	/* a local call */
 
 	if(f->mode&SF_GETR)
 	{	f->mode &= ~SF_GETR;
-#if _mmap_worthy
 		if(f->bits&SF_MMAP)
 		{
 			if (!++f->ngetr)
@@ -415,7 +414,6 @@ reg int		local;	/* a local call */
 				f->ngetr = f->tiny[0] = 0;
 			}
 		}
-#endif
 		if(f->getr)
 		{	f->next[-1] = f->getr;
 			f->getr = 0;
@@ -519,12 +517,10 @@ reg int		local;	/* a local call */
 			if((f->flags&(SF_SHARE|SF_PUBLIC)) == (SF_SHARE|SF_PUBLIC) &&
 			   (addr = SFSK(f,0,SEEK_CUR,f->disc)) != f->here)
 			{
-#if _mmap_worthy
 				if((f->bits&SF_MMAP) && f->data)
 				{	SFMUNMAP(f,f->data,f->endb-f->data);
 					f->data = NIL(uchar*);
 				}
-#endif
 				f->endb = f->endr = f->endw = f->next = f->data;
 				f->here = addr;
 			}
@@ -567,13 +563,11 @@ reg int		local;	/* a local call */
 		}
 
 		f->mode = SF_WRITE|SF_LOCK;
-#if _mmap_worthy
 		if(f->bits&SF_MMAP)
 		{	if(f->data)
 				SFMUNMAP(f,f->data,f->endb-f->data);
 			(void)SFSETBUF(f,(Void_t*)f->tiny,(size_t)SF_UNBOUND);
 		}
-#endif
 		if(f->data == f->tiny)
 		{	f->endb = f->data = f->next = NIL(uchar*);
 			f->size = 0;

--- a/src/lib/libast/sfio/sfpurge.c
+++ b/src/lib/libast/sfio/sfpurge.c
@@ -54,7 +54,6 @@ Sfio_t*	f;
 	SFLOCK(f,0);
 
 	/* if memory map must be a read stream, pretend data is gone */
-#if _mmap_worthy
 	if(f->bits&SF_MMAP)
 	{	f->here -= f->endb - f->next;
 		if(f->data)
@@ -64,7 +63,6 @@ Sfio_t*	f;
 		SFOPEN(f,0);
 		SFMTXRETURN(f, 0);
 	}
-#endif
 
 	switch(f->mode&~SF_LOCK)
 	{

--- a/src/lib/libast/sfio/sfrd.c
+++ b/src/lib/libast/sfio/sfrd.c
@@ -92,12 +92,10 @@ Sfdisc_t*	disc;
 			{	f->endb = f->next = f->endr = f->data;
 				f->mode &= ~SF_SYNCED;
 			}
-#if _mmap_worthy
 			if((f->bits&SF_MMAP) && f->data)
 			{	SFMUNMAP(f, f->data, f->endb-f->data);
 				f->data = NIL(uchar*);
 			}
-#endif
 			f->next = f->endb = f->endr = f->endw = f->data;
 		}
 	}
@@ -132,7 +130,6 @@ Sfdisc_t*	disc;
 			}
 		}
 
-#if _mmap_worthy
 		if(f->bits&SF_MMAP)
 		{	reg ssize_t	a, round;
 			sfstat_t	st;
@@ -230,7 +227,6 @@ Sfdisc_t*	disc;
 				}
 			}
 		}
-#endif
 
 		/* sync unseekable write streams to prevent deadlock */
 		if(!dosync && f->extent < 0)

--- a/src/lib/libast/sfio/sfseek.c
+++ b/src/lib/libast/sfio/sfseek.c
@@ -34,12 +34,10 @@ Sfio_t*	f;
 Sfoff_t p;
 #endif
 {
-#if _mmap_worthy
 	if((f->bits&SF_MMAP) && f->data)
 	{	SFMUNMAP(f, f->data, f->endb-f->data);
 		f->data = NIL(uchar*);
 	}
-#endif
 	f->next = f->endr = f->endw = f->data;
 	f->endb = (f->mode&SF_WRITE) ? f->data+f->size : f->data;
 	if((f->here = p) < 0)
@@ -201,23 +199,13 @@ int	type;	/* 0: from org, 1: from here, 2: from end */
 	if((p += type == SEEK_CUR ? s : 0) < 0)
 		goto done;
 
-#if _mmap_worthy
 	if(f->bits&SF_MMAP)
 	{	/* if mmap is not great, stop mmaping if moving around too much */
-#if _mmap_worthy < 2
-		if((f->next - f->data) < ((f->endb - f->data)/4) )
-		{	SFSETBUF(f,(Void_t*)f->tiny,(size_t)SF_UNBOUND);
-			hardseek = 1; /* this forces a hard seek below */
-		}
-		else
-#endif
-		{	/* for mmap, f->here can be virtual except for hardseek */
-			newpos(f,p);
-			if(!hardseek)
-				goto done;
-		}
+		/* for mmap, f->here can be virtual except for hardseek */
+		newpos(f,p);
+		if(!hardseek)
+			goto done;
 	}
-#endif
 
 	if(f->endb > f->next)
 	{	/* reduce wastage in future buffer fillings */

--- a/src/lib/libast/sfio/sfsetbuf.c
+++ b/src/lib/libast/sfio/sfsetbuf.c
@@ -302,7 +302,6 @@ size_t	size;	/* buffer size, -1 for default size */
 	okmmap = (buf || (f->flags&SF_STRING) || (f->flags&SF_RDWR) == SF_RDWR) ? 0 : 1;
 
 	/* save old buffer info */
-#if _mmap_worthy
 	if(f->bits&SF_MMAP)
 	{	if(f->data)
 		{	if(f->getr && (f->mode&SF_GETR) && f->next)
@@ -311,7 +310,6 @@ size_t	size;	/* buffer size, -1 for default size */
 			f->data = NIL(uchar*);
 		}
 	} else
-#endif
 	if(f->data == f->tiny)
 	{	f->data = NIL(uchar*);
 		f->size = 0;
@@ -438,7 +436,6 @@ size_t	size;	/* buffer size, -1 for default size */
 		}
 	}
 
-#if _mmap_worthy
 	if(okmmap && size && (f->mode&SF_READ) && f->extent >= 0 )
 	{	/* see if we can try memory mapping */
 		if(!disc)
@@ -457,7 +454,6 @@ size_t	size;	/* buffer size, -1 for default size */
 			}
 		}
 	}
-#endif
 
 	/* get buffer space */
 setbuf:

--- a/src/lib/libast/sfio/sfsetfd.c
+++ b/src/lib/libast/sfio/sfsetfd.c
@@ -108,12 +108,10 @@ int	newfd;
 					SFMTXRETURN(f, -1);
 				}
 
-#if _mmap_worthy
 				if((f->bits&SF_MMAP) && f->data)
 				{	SFMUNMAP(f,f->data,f->endb-f->data);
 					f->data = NIL(uchar*);
 				}
-#endif
 
 				/* make stream appears uninitialized */
 				f->endb = f->endr = f->endw = f->data;

--- a/src/lib/libast/sfio/sfsize.c
+++ b/src/lib/libast/sfio/sfsize.c
@@ -80,12 +80,10 @@ Sfio_t*	f;
 
 	if(f->here != s && (f->mode&SF_READ) )
 	{	/* buffered data is known to be invalid */
-#if _mmap_worthy
 		if((f->bits&SF_MMAP) && f->data)
 		{	SFMUNMAP(f,f->data,f->endb-f->data);
 			f->data = NIL(uchar*);
 		}
-#endif
 		f->next = f->endb = f->endr = f->endw = f->data;
 	}
 

--- a/src/lib/libast/sfio/sfsk.c
+++ b/src/lib/libast/sfio/sfsk.c
@@ -49,12 +49,10 @@ Sfdisc_t*	disc;
 			SFMTXRETURN(f, (Sfoff_t)(-1));
 		if(SFSYNC(f) < 0)
 			SFMTXRETURN(f, (Sfoff_t)(-1));
-#if _mmap_worthy
 		if(f->mode == SF_READ && (f->bits&SF_MMAP) && f->data)
 		{	SFMUNMAP(f, f->data, f->endb-f->data);
 			f->data = NIL(uchar*);
 		}
-#endif
 		f->next = f->endb = f->endr = f->endw = f->data;
 	}
 

--- a/src/lib/libast/vmalloc/vmdcsystem.c
+++ b/src/lib/libast/vmalloc/vmdcsystem.c
@@ -66,18 +66,16 @@ static Vmemory_f	_Vmemoryf = 0;
 
 #if _std_malloc
 #undef	_mem_mmap_anon
-#undef	_mem_mmap_zero
 #undef	_mem_sbrk
 #undef	_mem_win32
 #endif
 
 #if _mem_win32
 #undef	_mem_mmap_anon
-#undef	_mem_mmap_zero
 #undef	_mem_sbrk
 #endif
 
-#if _mem_mmap_anon || _mem_mmap_zero /* may get space using mmap */
+#if _mem_mmap_anon /* may get space using mmap */
 #include		<sys/mman.h>
 #ifndef MAP_ANON
 #ifdef	MAP_ANONYMOUS
@@ -86,7 +84,7 @@ static Vmemory_f	_Vmemoryf = 0;
 #define MAP_ANON	0
 #endif /*MAP_ANONYMOUS*/
 #endif /*MAP_ANON*/
-#endif /*_mem_mmap_anon || _mem_mmap_zero*/
+#endif /*_mem_mmap_anon*/
 
 /*
  * hint at "transparent huge pages" (=largepages) if
@@ -259,73 +257,6 @@ static Void_t* mmapanonmem(Vmalloc_t* vm, Void_t* caddr, size_t csize, size_t ns
 }
 #endif /* _mem_mmap_anon */
 
-#if _mem_mmap_zero /* get space by mmapping from /dev/zero */
-#include		<fcntl.h>
-#ifndef OPEN_MAX
-#define	OPEN_MAX	64
-#endif
-#define FD_PRIVATE	(3*OPEN_MAX/4)	/* private file descriptor	*/
-#define FD_NONE		(-2)		/* no mapping with file desc	*/
-
-/* this is called after an initial successful call of mmapzeromeminit() */
-static Void_t* mmapzeromem(Vmalloc_t* vm, Void_t* caddr, size_t csize, size_t nsize, Vmdisc_t* disc)
-{
-	Memdisc_t*	mmdc = (Memdisc_t*)disc;
-	off_t		offset;
-
-	GETMEMCHK(vm, caddr, csize, nsize, disc);
-	if(csize == 0)
-	{	nsize = ROUND(nsize, _Vmpagesize);
-		offset = asoaddoff(&mmdc->offset, nsize);
-		RESTARTMEM(caddr, mmap(NIL(Void_t*), nsize, PROT_READ|PROT_WRITE, MAP_PRIVATE, mmdc->fd, offset));
-		ADVISE(vm, caddr, nsize);
-		RETURN(vm, caddr, nsize);
-	}
-	else if(nsize == 0)
-	{	Vmuchar_t	*addr = (Vmuchar_t*)sbrk(0);
-		if(addr < (Vmuchar_t*)caddr ) /* in sbrk space */
-			return NIL(Void_t*);
-		(void)munmap(caddr, csize);
-		RETURN(vm, caddr, nsize);
-	}
-	else	return NIL(Void_t*);
-}
-
-/* if this call succeeds then mmapzeromem() is the implementation */
-static Void_t* mmapzeromeminit(Vmalloc_t* vm, Void_t* caddr, size_t csize, size_t nsize, Vmdisc_t* disc)
-{
-	Memdisc_t*	mmdc = (Memdisc_t*)disc;
-	int		fd;
-
-	GETMEMCHK(vm, caddr, csize, nsize, disc);
-	if(mmdc->fd != FD_INIT)
-		return NIL(Void_t*);
-	RESTARTSYS(fd, open("/dev/zero", O_RDONLY|O_CLOEXEC));
-	if(fd < 0)
-	{	mmdc->fd = FD_NONE;
-		return NIL(Void_t*);
-	}
-#if O_CLOEXEC == 0
-	else
-		SETCLOEXEC(fd);
-#endif
-	if(fd >= FD_PRIVATE || (mmdc->fd = fcntl(fd, F_DUPFD_CLOEXEC, FD_PRIVATE)) < 0)
-		mmdc->fd = fd;
-	else
-	{	close(fd);
-#if F_DUPFD_CLOEXEC == F_DUPFD
-		SETCLOEXEC(mmdc->fd);
-#endif
-	}
-	RESTARTMEM(caddr, mmapzeromem(vm, caddr, csize, nsize, disc));
-	if(!caddr)
-	{	close(mmdc->fd);
-		mmdc->fd = FD_NONE;
-	}
-	RETURN(vm, caddr, nsize);
-}
-#endif /* _mem_mmap_zero */
-
 #if _std_malloc /* using native malloc as a last resort */
 static Void_t* mallocmem(Vmalloc_t* vm, Void_t* caddr, size_t csize, size_t nsize, Vmdisc_t* disc)
 {
@@ -364,12 +295,6 @@ static Void_t* getmemory(Vmalloc_t* vm, Void_t* caddr, size_t csize, size_t nsiz
 		return (Void_t*)addr;
 	}
 #endif
-#if _mem_mmap_zero
-	if((_Vmassert & VM_zero) && (addr = mmapzeromeminit(vm, caddr, csize, nsize, disc)))
-	{	GETMEMUSE(mmapzeromem, disc);
-		return (Void_t*)addr;
-	}
-#endif
 #if _mem_sbrk
 	if((_Vmassert & VM_break) && (addr = sbrkmem(vm, caddr, csize, nsize, disc)))
 	{	GETMEMUSE(sbrkmem, disc);
@@ -386,6 +311,7 @@ static Void_t* getmemory(Vmalloc_t* vm, Void_t* caddr, size_t csize, size_t nsiz
 	if((_Vmassert & VM_native) && (addr = mallocmem(vm, caddr, csize, nsize, disc)))
 	{	GETMEMUSE(mallocmem, disc);
 		return (Void_t*)addr;
+	}
 #endif 
 	write(2, "vmalloc: panic: all memory allocation disciplines failed\n", 57);
 	abort();

--- a/src/lib/libast/vmalloc/vmhdr.h
+++ b/src/lib/libast/vmalloc/vmhdr.h
@@ -86,7 +86,7 @@
 #if defined(_WIN32)
 #define _mem_win32	1	/* use the VirtualAlloc interface	*/
 #endif
-#if !_mem_win32 && !_mem_sbrk && !_mem_mmap_anon && !_mem_mmap_zero
+#if !_mem_win32 && !_mem_sbrk && !_mem_mmap_anon
 #undef _std_malloc
 #define _std_malloc	1	/* use native malloc/free/realloc	*/
 #endif


### PR DESCRIPTION
One of the feature tests involving `mmap()` is dubious since it involves
highly variable timing data that can lead to non-deterministic builds.
Several other feature tests are no longer relevant since, for example, I
can't think of a single OS we care about which supports `mmap()` but not
the `MAP_ANON` flag.

Finally, there is no good reason to even use `mmap()` and implement our
own memory allocator. These days we should be using the OS provided libc
`malloc()` family of functions. And the value of the performance speedup
of using it in the SFIO code is dubious for a command shell. However, I
found that when I disabled it completely it results in more test failures
so this change is limited to the MAP_ANON related configuration.

Fixes #84