### PR TITLE
Remove a 'hack' generated by feature test

### DIFF
--- a/src/lib/libast/Mamfile
+++ b/src/lib/libast/Mamfile
@@ -3224,12 +3224,6 @@ make comp/gross_sgi.h implicit
 make locale_attr.h implicit
 done locale_attr.h dontcare virtual
 done comp/gross_sgi.h dontcare
-make FEATURE/hack implicit
-meta FEATURE/hack features/%>FEATURE/% features/hack hack
-make features/hack
-done features/hack
-exec - iffe -v -X ast -X std -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} ' run features/hack
-done FEATURE/hack generated
 prev include/ls.h implicit
 prev include/ast.h implicit
 done comp/gross.c

--- a/src/lib/libast/comp/gross.c
+++ b/src/lib/libast/comp/gross.c
@@ -26,8 +26,6 @@
 #include <ast.h>
 #include <ls.h>
 
-#include "FEATURE/hack"
-
 void _STUB_gross(){}
 
 #if _lcl_xstat

--- a/src/lib/libast/features/hack
+++ b/src/lib/libast/features/hack
@@ -1,1 +1,0 @@
-hdr	locale_attr


### PR DESCRIPTION
It looks like it is generated to hijack standard functions, so it should be safe to remove.