### PR TITLE
Avoid buffer overrun after duplicating fd in iousepipe()

### DIFF
--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -134,6 +134,8 @@ static bool iousepipe(Shell_t *shp)
 		return(true);
 	}
 	subpipe[2] = sh_fcntl(fd,F_dupfd_cloexec,10);
+	if(subpipe[2] >= shp->gd->lim.open_max)
+		sh_iovalidfd(shp,subpipe[2]);
 	shp->fdstatus[subpipe[2]] = shp->fdstatus[1];
 	while(close(fd)<0 && errno==EINTR)
 		errno = err;


### PR DESCRIPTION
Duplicating a fd may return a descriptor that is greater than shp->gd->lim.open_max, this can cause a buffer overrun while assigning a value to shp->fdstatus[subpipe[2]]. This patch fixes it. Thanks to Paulo Andrade <pandrade@redhat.com> for the patch.
Resolves: rhbz#1506344