### PR TITLE
Fix exporting vars in subshells

### DIFF
--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -271,9 +271,7 @@ Namval_t *sh_assignok(register Namval_t *np,int add)
 		return(np);
 	shp = sp->shp;
 	dp = shp->var_tree;
-	/* don't bother to save if in newer scope */
-	if(sp->var!=shp->var_tree && sp->var!=shp->var_base && shp->last_root==shp->var_tree)
-		return(np);
+
 	if((ap=nv_arrayptr(np)) && (mp=nv_opensub(np)))
 	{
 		shp->last_root = ap->table;

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -720,4 +720,34 @@ then	(( size = 117*1024 ))
 	fi
 fi
 
+# ========================================
+# Test that variables exported in subshells don't affect the outer shell.
+# Regression test for issue #7.
+function proxy {
+    export MYVAR="blah"
+    child
+    unset MYVAR
+}
+
+function child {
+    echo "MYVAR=$MYVAR"
+}
+
+function test {
+        child
+        proxy
+        child
+}
+
+actual="$(test)"
+expected="\
+MYVAR=
+MYVAR=blah
+MYVAR="
+if [[ $actual != $expected ]]
+then
+    err_exit -u2 "exported vars in subshells not confined to the subshell: $actual"
+fi
+
+# ========================================
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
This change applies the fix from here:

https://github.com/oracle/solaris-userland/blob/master/components/ksh93/patches/250-22561374.patch

It also adds a regression test.

Fixes #7