### PR TITLE
Don't use SOCK_CLOEXEC

### DIFF
--- a/src/lib/libast/features/fcntl.c
+++ b/src/lib/libast/features/fcntl.c
@@ -511,21 +511,6 @@ main(int argc, char** argv)
 #ifndef	O_TEXT
 	printf("#define O_TEXT			0		/* %s */\n", ORIGIN_IGNORE);
 #endif
-#if !defined(SOCK_CLOEXEC) || !defined(SOCK_NONBLOCK)
-	printf("\n");
-#ifndef SOCK_CLOEXEC
-	printf("#ifndef SOCK_CLOEXEC\n");
-	printf("#define _ast_SOCK_CLOEXEC	1\n");
-	printf("#define SOCK_CLOEXEC		02000000 /* %s */\n", ORIGIN_EXTENSION);
-	printf("#endif\n");
-#endif
-#ifndef SOCK_NONBLOCK
-	printf("#ifndef SOCK_NONBLOCK\n");
-	printf("#define _ast_SOCK_NONBLOCK	1\n");
-	printf("#define SOCK_NONBLOCK		04000	/* %s */\n", ORIGIN_EXTENSION);
-	printf("#endif\n");
-#endif
-#endif
 
 	printf("\n");
 	printf("#define F_dupfd_cloexec		F_DUPFD_CLOEXEC /* OBSOLETE */\n");

--- a/src/lib/libast/path/pathopen.c
+++ b/src/lib/libast/path/pathopen.c
@@ -339,12 +339,11 @@ pathopen(int dfd, const char* path, char* canon, size_t size, int flags, int ofl
 		
 				if (!(type = a->ai_socktype))
 					type = hint.ai_socktype;
-				if (oflags & O_CLOEXEC)
-					type |= SOCK_CLOEXEC;
 				if (!(prot = a->ai_protocol))
 					prot = hint.ai_protocol;
 				if ((fd = socket(a->ai_family, type, prot)) >= 0)
 				{
+					if (oflags & O_CLOEXEC) fcntl(fd,F_SETFD,FD_CLOEXEC);
 					if (server && !bind(fd, a->ai_addr, a->ai_addrlen) && !listen(fd, 5) || !server && !connect(fd, a->ai_addr, a->ai_addrlen))
 						goto done;
 					close(fd);


### PR DESCRIPTION
The `SOCK_CLOEXEC` symbol is not available on some of the platforms
we want to support such as macOS. It's also wrong if it's missing to
define it with a specific value. Instead just use `fcntl()` to set the
close-on-exec attribute.

Also, remove `SOCK_NONBLOCK` because it too is nonstandard and isn't
actually needed to build ksh.

Fixes #110