### PR TITLE
Implement config for clang-format and editors

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,22 @@
+# Use the Google style with these modifications and a couple of others:
+#
+# 1) Lines can be up to 100 chars long rather than 80.
+# 2) Use a four space indent rather than two spaces.
+#
+Language: Cpp
+BasedOnStyle: Google
+ColumnLimit: 100
+IndentWidth: 4
+
+# The following directives override defaults established above.
+
+# We don't want OCLint pragmas to be reformatted.
+CommentPragmas: '^!OCLINT'
+
+# Allow slightly overlong lines.
+PenaltyExcessCharacter: 10
+
+# Don't try to infer the most common alignment of `&` and `*` by analyzing the
+# source file. Use right alignment; i.e., bind to the symbol not the type.
+DerivePointerAlignment: false
+PointerAlignment: Right

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+indent_size = 4
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 100
+
+[{Makefile,*.in}]
+indent_style = tab

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_install:
     - docker pull ${OS_TYPE}
 
 script:
-    - find \( -name \*.c -o -name \*.h \) -exec sh -c '! grep --color "^[[:space:]]*//" $@' find {} \+ && echo No line comments found...
     - echo > build.sh "set -e;
         cd /source;
         export CCFLAGS='-fno-strict-aliasing -Wno-unknown-pragmas -Wno-missing-braces -Wno-unused-result -Wno-return-type -Wno-int-to-pointer-cast -Wno-parentheses -Wno-unused -Wno-unused-but-set-variable -Wno-cpp -P';

--- a/src/cmd/ksh93/bltins/cflow.c
+++ b/src/cmd/ksh93/bltins/cflow.c
@@ -1,118 +1,106 @@
-/***********************************************************************
-*                                                                      *
-*               This software is part of the ast package               *
-*          Copyright (c) 1982-2014 AT&T Intellectual Property          *
-*                      and is licensed under the                       *
-*                 Eclipse Public License, Version 1.0                  *
-*                    by AT&T Intellectual Property                     *
-*                                                                      *
-*                A copy of the License is available at                 *
-*          http://www.eclipse.org/org/documents/epl-v10.html           *
-*         (with md5 checksum b35adb5213ca9657e911e9befb180842)         *
-*                                                                      *
-*              Information and Software Systems Research               *
-*                            AT&T Research                             *
-*                           Florham Park NJ                            *
-*                                                                      *
-*                    David Korn <dgkorn@gmail.com>                     *
-*                                                                      *
-***********************************************************************/
+//
+//               This software is part of the ast package
+//          Copyright (c) 1982-2014 AT&T Intellectual Property
+//                      and is licensed under the
+//                 Eclipse Public License, Version 1.0
+//                    by AT&T Intellectual Property
+//
+//                A copy of the License is available at
+//          http://www.eclipse.org/org/documents/epl-v10.html
+//         (with md5 checksum b35adb5213ca9657e911e9befb180842)
+//
+//              Information and Software Systems Research
+//                            AT&T Research
+//                           Florham Park NJ
+//
+//                    David Korn <dgkorn@gmail.com>
+//
 #pragma prototyped
-/*
- * break [n]
- * continue [n]
- * return [n]
- * exit [n]
- *
- *   David Korn
- *   dgkorn@gmail.com
- *
- */
+//
+// break [n]
+// continue [n]
+// return [n]
+// exit [n]
+//
+//   David Korn
+//   dgkorn@gmail.com
+//
+#include "defs.h"
 
-#include	"defs.h"
-#include	<ast.h>
-#include	<error.h>
-#include	"shnodes.h"
-#include	"builtins.h"
+#include "ast.h"
+#include "builtins.h"
+#include "error.h"
+#include "shnodes.h"
 
-/*
- * return and exit
- */
-#if 0
-    /* for the dictionary generator */
-    int	b_exit(int n, register char *argv[],Shbltin_t *context){}
-#endif
-int	b_return(register int n, register char *argv[],Shbltin_t *context)
-{
-	register char *arg;
-	register Shell_t *shp = context->shp;
-	struct checkpt *pp = (struct checkpt*)shp->jmplist;
-	const char *options = (**argv=='r'?sh_optreturn:sh_optexit);
-	while((n = optget(argv,options))) switch(n)
-	{
-	    case ':':
-		if(!strmatch(argv[opt_info.index],"[+-]+([0-9])"))
-			errormsg(SH_DICT,2, "%s", opt_info.arg);
-		goto done;
-	    case '?':
-		errormsg(SH_DICT,ERROR_usage(0), "%s", opt_info.arg);
-		return(2);
-	}
+//
+// Implement `return` and `exit`.
+//
+int b_return(int n, char *argv[], Shbltin_t *context) {
+    char *arg;
+    Shell_t *shp = context->shp;
+    struct checkpt *pp = (struct checkpt *)shp->jmplist;
+    const char *options = (**argv == 'r') ? sh_optreturn : sh_optexit;
+    while ((n = optget(argv, options))) {
+        switch (n) {
+            case ':': {
+                if (!strmatch(argv[opt_info.index], "[+-]+([0-9])"))
+                    errormsg(SH_DICT, 2, "%s", opt_info.arg);
+                goto done;
+            }
+            case '?': {
+                errormsg(SH_DICT, ERROR_usage(0), "%s", opt_info.arg);
+                return 2;
+            }
+        }
+    }
+
 done:
-	if(error_info.errors)
-		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
-	pp->mode = (**argv=='e'?SH_JMPEXIT:SH_JMPFUN);
-	argv += opt_info.index;
-	n = (((arg= *argv)?(int)strtol(arg, (char**)0, 10):shp->oldexit));
-	if(n<0 || n==256 || n > SH_EXITMASK+shp->gd->sigmax)
-			n &= ((unsigned int)n)&SH_EXITMASK;
-	/* return outside of function, dotscript and profile is exit */
-	if(shp->fn_depth==0 && shp->dot_depth==0 && !sh_isstate(shp,SH_PROFILE))
-		pp->mode = SH_JMPEXIT;
-	sh_exit(shp,shp->savexit=n);
-	return(1);
+    if (error_info.errors) errormsg(SH_DICT, ERROR_usage(2), "%s", optusage(NULL));
+    pp->mode = (**argv == 'e') ? SH_JMPEXIT : SH_JMPFUN;
+    argv += opt_info.index;
+    n = (arg = *argv) ? (int)strtol(arg, NULL, 10) : shp->oldexit;
+    if (n < 0 || n == 256 || n > SH_EXITMASK + shp->gd->sigmax) {
+        n &= (unsigned int)n & SH_EXITMASK;
+    }
+    // Return outside of function, dotscript and profile is exit.
+    if (shp->fn_depth == 0 && shp->dot_depth == 0 && !sh_isstate(shp, SH_PROFILE)) {
+        pp->mode = SH_JMPEXIT;
+    }
+    sh_exit(shp, shp->savexit = n);
+    return 1;
 }
 
+//
+// Implement `break` and `continue`.
+//
+int b_break(int n, char *argv[], Shbltin_t *context) {
+    char *arg;
+    int cont = **argv == 'c';
+    Shell_t *shp = context->shp;
+    while ((n = optget(argv, cont ? sh_optcont : sh_optbreak))) {
+        switch (n) {
+            case ':': {
+                errormsg(SH_DICT, 2, "%s", opt_info.arg);
+                break;
+            }
+            case '?': {
+                errormsg(SH_DICT, ERROR_usage(0), "%s", opt_info.arg);
+                return 2;
+            }
+        }
+    }
 
-/*
- * break and continue
- */
-#if 0
-    /* for the dictionary generator */
-    int	b_continue(int n, register char *argv[],Shbltin_t *context){}
-#endif
-int	b_break(register int n, register char *argv[],Shbltin_t *context)
-{
-	char *arg;
-	register int cont= **argv=='c';
-	register Shell_t *shp = context->shp;
-	while((n = optget(argv,cont?sh_optcont:sh_optbreak))) switch(n)
-	{
-	    case ':':
-		errormsg(SH_DICT,2, "%s", opt_info.arg);
-		break;
-	    case '?':
-		errormsg(SH_DICT,ERROR_usage(0), "%s", opt_info.arg);
-		return(2);
-	}
-	if(error_info.errors)
-		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
-	argv += opt_info.index;
-	n=1;
-	if(arg= *argv)
-	{
-		n = (int)strtol(arg,&arg,10);
-		if(n<=0 || *arg)
-			errormsg(SH_DICT,ERROR_exit(1),e_nolabels,*argv);
-	}
-	if(shp->st.loopcnt)
-	{
-		shp->st.execbrk = shp->st.breakcnt = n;
-		if(shp->st.breakcnt > shp->st.loopcnt)
-			shp->st.breakcnt = shp->st.loopcnt;
-		if(cont)
-			shp->st.breakcnt = -shp->st.breakcnt;
-	}
-	return(0);
+    if (error_info.errors) errormsg(SH_DICT, ERROR_usage(2), "%s", optusage(NULL));
+    argv += opt_info.index;
+    n = 1;
+    if ((arg = *argv)) {
+        n = (int)strtol(arg, &arg, 10);
+        if (n <= 0 || *arg) errormsg(SH_DICT, ERROR_exit(1), e_nolabels, *argv);
+    }
+    if (shp->st.loopcnt) {
+        shp->st.execbrk = shp->st.breakcnt = n;
+        if (shp->st.breakcnt > shp->st.loopcnt) shp->st.breakcnt = shp->st.loopcnt;
+        if (cont) shp->st.breakcnt = -shp->st.breakcnt;
+    }
+    return 0;
 }
-


### PR DESCRIPTION
This creates a config file for the clang-format tool. It also establishes
a `.editorconfig` file to help establish the proper settings for editing
code in this project.

Finally, it includes one module that was reformatted with clang-format
followed by some manual cleanups to illustrate how this affects the
code. The latter being necessary because clang-format won't do things like
add missing braces. I verified the resulting object file is unchanged
using the `objdump -d` technique.

First step to fixing #125