### PR TITLE
Fix a crash in print builtin

### DIFF
--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -174,6 +174,7 @@ int    b_print(int argc, char *argv[], Shbltin_t *context)
 	int sflag = 0, nflag=0, rflag=0, vflag=0;
 	Namval_t *vname=0;
 	Optdisc_t disc;
+	memset(&disc, 0, sizeof(disc));
 	disc.version = OPT_VERSION;
 	disc.infof = infof;
 	opt_info.disc = &disc;


### PR DESCRIPTION
There are some tests crashing due to use of uninitialized value in print builtin while parsing arguments. This should fix it.