### PR TITLE
Workaround feature test for using sockets for pipes

### DIFF
--- a/bin/ksh93_prereq.sh
+++ b/bin/ksh93_prereq.sh
@@ -18,10 +18,16 @@ iffe_tests_2=( nvapi shellapi )
 
 iffe_tests_3=( nfsd acct execargs pstat )
 
+function cc_fun {
+    cc -D_BLD_ast -I../../../lib/libast/include/ -I../../../lib/libast/features/  "$@"
+}
+
+export -f cc_fun
+
 pushd "$base_dir/src/cmd/ksh93/features"
 
 for iffe_test in ${iffe_tests[@]}; do
-    iffe -v -X ast -X std -c 'cc' run $iffe_test
+    iffe -v -X ast -X std -c cc_fun run $iffe_test
 done
 
 for iffe_test in ${iffe_tests_2[@]}; do

--- a/src/cmd/ksh93/features/poll
+++ b/src/cmd/ksh93/features/poll
@@ -4,7 +4,7 @@ lib	select,poll,socket
 lib	htons,htonl sys/types.h sys/socket.h netinet/in.h
 lib	getaddrinfo sys/types.h sys/socket.h netdb.h
 typ	fd_set sys/socket.h sys/select.h
-tst	pipe_socketpair note{ use socketpair() for peekable pipe() }end execute{
+tst	pipe_socketpair note{ use socketpair() for peekable pipe() }end compile{
 	#include <ast.h>
 	#include <signal.h>
 	#include <sys/types.h>
@@ -105,7 +105,6 @@ tst	socketpair_devfd -D_AST_INTERCEPT=0 note{ /proc/.../fd/N or /dev/fd/N handle
 	}
 }end
 tst	socketpair_shutdown_mode note{ fchmod() after socketpair() shutdown() }end execute{
-	#include <ast.h>
 	#include <sys/types.h>
 	#include <sys/stat.h>
 	#include <sys/socket.h>


### PR DESCRIPTION
While running feature tests under meson, libast.so is not available. It should be sufficient to check if feature test for using sockets instead of real pipes only compiles.
This fixes io tests.