### PR TITLE
Run more tests concurrently on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
     - docker pull ${OS_TYPE}
 
 script:
+    # TODO: Check how to set MESON_TESTTHREADS dynamically
     - echo > build.sh "set -e;
         export CFLAGS='-fno-strict-aliasing -Wno-unknown-pragmas -Wno-missing-braces -Wno-unused-result -Wno-return-type -Wno-int-to-pointer-cast -Wno-parentheses -Wno-unused -Wno-unused-but-set-variable -Wno-cpp -Wno-char-subscripts';
         cd /source;
@@ -27,6 +28,7 @@ script:
         ninja;
         echo ==== Running unit tests;
         ulimit -n 1024;
+        export MESON_TESTTHREADS=16;
         if ! ${MESON_TEST}; then cat meson-logs/testlog.txt; exit 1; fi;
         "
 

--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -122,7 +122,7 @@ all_tests = [
     ['io'], ['leaks'], ['locale'], ['math'], ['nameref'], ['namespace'],
     ['options'], ['path'], ['pointtype'], ['pty'], ['quoting'], ['quoting2'],
     ['readcsv'], ['recttype'], ['restricted'], ['return'], ['select'],
-    ['sh_match'], ['sigchld'], ['signal', 100], ['statics'], ['subshell', 60],
+    ['sh_match'], ['sigchld', 100], ['signal', 100], ['statics'], ['subshell', 60],
     ['substring'], ['tilde'], ['timetype'], ['treemove'], ['types'],
     ['variables'], ['vartree1'], ['vartree2'], ['wchar']
 ]


### PR DESCRIPTION
By default, meson runs as many tests concurrently as number of cores present on the system. We should be able to run more tests concurrently.