### PR TITLE
Fix memory leak in associative array

### DIFF
--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -1395,7 +1395,16 @@ void nv_delete(Namval_t* np, Dt_t *root, int flags)
 		if(dtdelete(root,np))
 		{
 			if(!(flags&NV_NOFREE) && ((flags&NV_FUNCTION) || !nv_subsaved(np,flags&NV_TABLE)))
+			{
+				Namarr_t	*ap;
+				if(nv_isarray(np) && np->nvfun && (ap=nv_arrayptr(np)) && array_assoc(ap)) {
+					while(nv_associative(np,0,NV_ANEXT))
+						nv_associative(np, 0, NV_ADELETE);
+					nv_associative(np, 0, NV_AFREE);
+					free((void*)np->nvfun);
+				}
 				free((void*)np);
+			}
 		}
 #if 0
 		else

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -67,7 +67,7 @@ curr_vsz=$(ps -o vsz $$ | tail -n 1 | tr -d '\n')
 
 if [[ $init_vsz -lt $curr_vsz ]];
 then
-    err_exit "Memory leak on associate arrary"
+    err_exit "Memory leak on associative array"
 fi
 
 #TODO: Enable these tests when vmstate is a builtin


### PR DESCRIPTION
Fix memory leak while unsetting element of an associative array
Resolves: rhbz#1189294
