### PR TITLE
Fix reading file through command substituion

### DIFF
--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -1319,6 +1319,7 @@ int	sh_redirect(Shell_t *shp,struct ionod *iop, int flag)
 				if(flag==SH_SHOWME)
 					goto traceit;
 				fd=sh_chkopen(fname);
+				fd=sh_iomovefd(shp, fd);
 			}
 			else if(sh_isoption(shp,SH_RESTRICTED))
 				errormsg(SH_DICT,ERROR_exit(1),e_restricted,fname);

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -749,5 +749,18 @@ then
     err_exit -u2 "exported vars in subshells not confined to the subshell: $actual"
 fi
 
+TMPF=$(mktemp)
+echo ok >$TMPF
+errmsg=""
+export TMPF
+
+[ -n "$($SHELL -c 'echo $(<$TMPF)' <&-)" ] || errmsg="stdin $errmsg"
+[ -n "$($SHELL -c "$SHELL -c 'echo \$(<$TMPF) >&2' >&-" 2>&1)" ] || errmsg="stdout $errmsg"
+[ -n "$($SHELL -c 'echo $(<$TMPF)' 2>&-)" ] || errmsg="stderr $errmsg"
+
+rm -f $TMPF
+
+[[ -n "$errmsg" ]] && err_exit "\$(<file) empty when any of ${errmsg}is closed"
+
 # ========================================
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
* Fix for reading a file through command substituion when any of stdin, stdout or stderr is closed.
* Add test case for reading file in command substitution when any of stdin, stdout or stderr is closed.
 
Resolves: rhbz#1066589