### PR TITLE
Clarify handling of INT and QUIT signals

### DIFF
--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -4379,7 +4379,7 @@ command are ignored if the command is followed by
 .B &
 and the
 .B monitor
-option is not active.
+option is active.
 Otherwise, signals have the values
 inherited by the shell from its parent
 (but see also


### PR DESCRIPTION
The INT and QUIT signals for an invoked command are ignored if the
command is followed by & and the monitor option is active.

Resolves: rhbz#1019334