### PR TITLE
Fix a crash when ksh is used as login shell

### DIFF
--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1202,7 +1202,7 @@ tryagain:
 			if((io||argn))
 			{
 				Shbltin_t *bp=0;
-				static char *argv[1];
+				static char *argv[2];
 				int tflags = 1;
 				if(np &&  nv_isattr(np,BLT_DCL))
 					tflags |= 2;


### PR DESCRIPTION
Resolves: rhbz#1200534