### PR TITLE
Fix a double fork when ksh is used as login shell

### DIFF
--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -2091,6 +2091,7 @@ shp,SH_BASH) && !sh_isoption(shp,SH_LASTPIPE))
 				{
 					sh_exec(shp,t->par.partre,flags);
 					shp->st.trapcom[0]=0;
+					sh_offoption(SH_INTERACTIVE);
 					sh_done(shp,0);
 				}
 			}


### PR DESCRIPTION
Resolves: rhbz#1217236