### PR TITLE
Pick an unused fd to capture subshell output

### DIFF
--- a/src/cmd/ksh93/include/io.h
+++ b/src/cmd/ksh93/include/io.h
@@ -82,6 +82,7 @@ extern void 	sh_vexsave(Shell_t*,int,int,Spawnvex_f,void*);
 extern Sfio_t 	*sh_iostream(Shell_t*,int,int);
 extern int	sh_redirect(Shell_t*,struct ionod*,int);
 extern void 	sh_iosave(Shell_t *, int,int,char*);
+extern int	sh_get_unused_fd(Shell_t* shp, int min_fd);
 extern bool 	sh_iovalidfd(Shell_t*, int);
 extern bool 	sh_inuse(Shell_t*, int);
 extern void 	sh_iounsave(Shell_t*);

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -1881,6 +1881,24 @@ void sh_vexsave(Shell_t *shp,int fn,int fd,Spawnvex_f vexfun, void *arg)
 	}
 }
 
+// Return the lowest numbered fd that is equal to or greater than the requested
+// `min_fd` and which is not currently in use.
+int sh_get_unused_fd(Shell_t* shp, int min_fd) {
+	int fd;
+
+	while (true) {
+	    if (fcntl(min_fd, F_GETFD) == -1) {
+		for(fd = 0; fd < shp->topfd; fd++) {
+		    if (filemap[fd].save_fd == min_fd || filemap[fd].orig_fd == min_fd) break;
+		}
+		if (fd == shp->topfd) break;
+	    }
+	    min_fd++;
+	}
+
+	return min_fd;
+}
+
 /*
  *  close all saved file descriptors
  */

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -697,7 +697,7 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 			}
 			if(iop && sffileno(iop)==1)
 			{
-				int fd=sfsetfd(iop,3);
+				int fd=sfsetfd(iop, sh_get_unused_fd(shp, 3));
 				if(fd<0)
 				{
 					shp->toomany = 1;


### PR DESCRIPTION
A subshell that manipulates file descriptors, such as redirecting fd 3
then closing it, interferes with capturing its output. Ensure we use a
file descriptor that is not in use.

Fix #198