### PR TITLE
Remove feature test for some headers

### DIFF
--- a/bin/ksh93_prereq.sh
+++ b/bin/ksh93_prereq.sh
@@ -16,8 +16,6 @@ iffe_tests=( options )
 
 iffe_tests_2=( nvapi shellapi )
 
-iffe_tests_3=( nfsd acct execargs pstat )
-
 function cc_fun {
     cc -D_BLD_ast -I../../../lib/libast/include/ -I../../../lib/libast/features/  "$@"
 }
@@ -33,10 +31,6 @@ done
 for iffe_test in ${iffe_tests_2[@]}; do
     iffe -v -X ast -X std -c 'cc' run $iffe_test
     cp "$base_dir/src/cmd/ksh93/features/FEATURE/$iffe_test" "$base_dir/src/cmd/ksh93/features/$iffe_test.h"
-done
-
-for iffe_test in ${iffe_tests_3[@]}; do
-    iffe -v -c 'cc' : def $iffe_test
 done
 
 # Generate a c source file for ksh93 bash compatiblity

--- a/src/cmd/ksh93/include/path.h
+++ b/src/cmd/ksh93/include/path.h
@@ -138,15 +138,10 @@ extern const char is_ufunction[];
 #endif /* SHELLMAGIC */
 
 #if SHOPT_ACCT
-#   include	"FEATURE/acct"
-#   ifdef	_sys_acct
 	extern void sh_accinit(void);
 	extern void sh_accbegin(const char*);
 	extern void sh_accend(void);
 	extern void sh_accsusp(void);
-#   else
-#	undef	SHOPT_ACCT
-#   endif	/* _sys_acct */
 #endif /* SHOPT_ACCT */
 
 #endif /*! PATH_OFFSET */

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -41,8 +41,6 @@
 #include	"shnodes.h"
 #include	"history.h"
 #include	"timeout.h"
-#include	"FEATURE/pstat"
-#include	"FEATURE/execargs"
 #ifdef	_hdr_nc
 #   include	<nc.h>
 #endif	/* _hdr_nc */

--- a/src/lib/libcoshell/cosync.c
+++ b/src/lib/libcoshell/cosync.c
@@ -34,8 +34,6 @@
 
 #include <ls.h>
 
-#include "FEATURE/nfsd"
-
 int
 cosync(Coshell_t* co, const char* file, int fd, int mode)
 {


### PR DESCRIPTION
It either checks for standard headers or headers for systems that we do not want to support.