### PR TITLE
Remove SHOPT_PFSH and related code from sources

### DIFF
--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -1071,8 +1071,6 @@ int	b_builtin(int argc,char *argv[],Shbltin_t *context)
 	{
 		if(sh_isoption(tdata.sh,SH_RESTRICTED))
 			errormsg(SH_DICT,ERROR_exit(1),e_restricted,argv[-opt_info.index]);
-		if(sh_isoption(tdata.sh,SH_PFSH))
-			errormsg(SH_DICT,ERROR_exit(1),e_pfsh,argv[-opt_info.index]);
 		if(tdata.sh->subshell && !tdata.sh->subshare)
 			sh_subfork();
 	}

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -1468,9 +1468,6 @@ USAGE_LICENSE
 #endif
 	"\b${ENV-$HOME/.kshrc}\b, if it exists, as a profile. "
 	"On by default for interactive shells; use \b+E\b to disable.]"
-#if SHOPT_PFSH
-"[P?Invoke the shell as a profile shell.  See \bpfexec\b(1).]"
-#endif
 #if SHOPT_KIA
 "[R]:[file?Do not execute the script, but create a cross reference database "
 	"in \afile\a that can be used a separate shell script browser.  The "

--- a/src/cmd/ksh93/data/options.c
+++ b/src/cmd/ksh93/data/options.c
@@ -91,13 +91,6 @@ const Shtable_t shtab_options[] =
 	"privileged",			SH_PRIVILEGED,
 #if SHOPT_BASH
 	"profile",			SH_LOGIN_SHELL|SH_COMMANDLINE,
-#   if SHOPT_PFSH
-	"pfsh",				SH_PFSH|SH_COMMANDLINE,
-#   endif
-#else
-#   if SHOPT_PFSH
-	"profile",			SH_PFSH|SH_COMMANDLINE,
-#   endif
 #endif
 	bashopt("progcomp",		SH_PROGCOMP)
 	bashopt("promptvars",		SH_PROMPTVARS)

--- a/src/cmd/ksh93/include/defs.h
+++ b/src/cmd/ksh93/include/defs.h
@@ -391,10 +391,6 @@ struct shared
 #   define PIPE_BUF		512
 #endif
 
-#if SHOPT_PFSH && ( !_lib_getexecuser || !_lib_free_execattr )
-#   undef SHOPT_PFSH
-#endif
-
 #define MATCH_MAX		64
 
 #define SH_READEVAL		0x4000	/* for sh_eval */

--- a/src/cmd/ksh93/include/shell.h
+++ b/src/cmd/ksh93/include/shell.h
@@ -81,7 +81,6 @@ typedef union Shnode_u Shnode_t;
 #define SH_NOUNSET	9
 #define SH_NOGLOB	10
 #define SH_ALLEXPORT	11
-#define SH_PFSH		12
 #define SH_IGNOREEOF	13
 #define SH_NOCLOBBER	14
 #define SH_MARKDIRS	15

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -38,11 +38,6 @@
 #   include	"shlex.h"
 #   include	"io.h"
 #endif /* SHOPT_KIA */
-#if SHOPT_PFSH
-#   define PFSHOPT	"P"
-#else
-#   define PFSHOPT
-#endif
 #if SHOPT_BASH
 #   define BASHOPT	"\374"
 #else
@@ -57,12 +52,9 @@ static	char		*null;
 static  pid_t		*procsub;
 
 /* The following order is determined by sh_optset */
-static  const char optksh[] =  PFSHOPT BASHOPT "DircabefhkmnpstuvxBCGEl" HFLAG;
+static  const char optksh[] =  BASHOPT "DircabefhkmnpstuvxBCGEl" HFLAG;
 static const int flagval[]  =
 {
-#if SHOPT_PFSH
-	SH_PFSH,
-#endif
 #if SHOPT_BASH
 	SH_POSIX,
 #endif

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -78,10 +78,6 @@ char e_version[]	= "\n@(#)$Id: Version "
 #define ATTRS		1
 			"M"
 #endif
-#if SHOPT_PFSH && _hdr_exec_attr
-#define ATTRS		1
-			"P"
-#endif
 #if SHOPT_REGRESS
 #define ATTRS		1
 			"R"
@@ -1324,14 +1320,6 @@ int sh_type(const char *path)
 		}
 		if (!(t & (SH_TYPE_PROFILE|SH_TYPE_RESTRICTED)))
 		{
-#if SHOPT_PFSH
-			if (*s == 'p' && *(s+1) == 'f')
-			{
-				s += 2;
-				t |= SH_TYPE_PROFILE;
-				continue;
-			}
-#endif
 			if (*s == 'r')
 			{
 				s++;
@@ -1600,11 +1588,6 @@ Shell_t *sh_init(int argc,char *argv[], Shinit_f userinit)
 		/* check for restricted shell */
 		if(type&SH_TYPE_RESTRICTED)
 			sh_onoption(shp,SH_RESTRICTED);
-#if SHOPT_PFSH
-		/* check for profile shell */
-		else if(type&SH_TYPE_PROFILE)
-			sh_onoption(shp,SH_PFSH);
-#endif
 #if SHOPT_BASH
 		/* check for invocation as bash */
 		if(type&SH_TYPE_BASH)
@@ -1666,15 +1649,6 @@ Shell_t *sh_init(int argc,char *argv[], Shinit_f userinit)
 			beenhere = 2;
 		}
 	}
-#if SHOPT_PFSH
-	if (sh_isoption(shp,SH_PFSH))
-	{
-		struct passwd *pw = getpwuid(shp->gd->userid);
-		if(pw)
-			shp->gd->user = strdup(pw->pw_name);
-		
-	}
-#endif
 	/* set[ug]id scripts require the -p flag */
 	if(shp->gd->userid!=shp->gd->euserid || shp->gd->groupid!=shp->gd->egroupid)
 	{

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1072,19 +1072,6 @@ int sh_exec(Shell_t *shp,const Shnode_t *t, int flags)
 #endif /* SHOPT_NAMESPACE */
 					np = dtsearch(shp->fun_tree,np);
 				}
-#if SHOPT_PFSH
-				if(sh_isoption(shp,SH_PFSH) && nv_isattr(np,NV_BLTINOPT) && !nv_isattr(np,NV_BLTPFSH)) 
-				{
-					if(path_xattr(shp,np->nvname,(char*)0))
-					{
-						dtdelete(shp->bltin_tree,np);
-						np = 0;
-					}
-					else
-						nv_onattr(np,NV_BLTPFSH);
-					
-				}
-#endif /* SHOPT_PFSH */
 			}
 			if(com0)
 			{


### PR DESCRIPTION
SHOPT_PFSH makes use of execution profiles database (exec_attr) which
is only supported on Solaris. So it is decided to remove it from the
sources.

See github pull request #213