### PR TITLE
Save iffe generated api headers for ksh93

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,3 @@ src/lib/libast/include/lc.h
 src/lib/libast/port/lctab.c
 src/cmd/ksh93/data/bash_pre_rc.c
 src/cmd/ksh93/features/FEATURE/
-src/cmd/ksh93/features/nvapi.h
-src/cmd/ksh93/features/shellapi.h

--- a/bin/ksh93_prereq.sh
+++ b/bin/ksh93_prereq.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script is used for feature detections that are required to build ksh93
+# This script is used for generating bash compatibility source file that is required to build ksh93
 set -x
 set -e
 
@@ -10,28 +10,7 @@ script_path=`realpath "$0"`
 bin_dir=`dirname "$script_path"`
 base_dir=`dirname "$bin_dir"`
 
-PATH=$bin_dir:$PATH
-
-iffe_tests=( )
-
-iffe_tests_2=( nvapi shellapi )
-
-function cc_fun {
-    cc -D_BLD_ast -I../../../lib/libast/include/ -I../../../lib/libast/features/  "$@"
-}
-
-export -f cc_fun
-
 pushd "$base_dir/src/cmd/ksh93/features"
-
-for iffe_test in ${iffe_tests[@]}; do
-    iffe -v -X ast -X std -c cc_fun run $iffe_test
-done
-
-for iffe_test in ${iffe_tests_2[@]}; do
-    iffe -v -X ast -X std -c 'cc' run $iffe_test
-    cp "$base_dir/src/cmd/ksh93/features/FEATURE/$iffe_test" "$base_dir/src/cmd/ksh93/features/$iffe_test.h"
-done
 
 # Generate a c source file for ksh93 bash compatiblity
 echo "const char bash_pre_rc[] = " > "$base_dir/src/cmd/ksh93/data/bash_pre_rc.c"

--- a/src/cmd/ksh93/features/nvapi.h
+++ b/src/cmd/ksh93/features/nvapi.h
@@ -1,0 +1,32 @@
+/* : : generated from nvapi by iffe version 2013-11-14 : : */
+#ifndef _NV_API_H
+#define _NV_API_H	1
+#define _sys_types	1	/* #include <sys/types.h> ok */
+#ifndef _API_nv
+#define _API_nv	_API_shell
+#endif
+#define NVAPI(rel)	( _BLD_nv || !_API_nv || _API_nv >= rel )
+
+#ifndef _NV_API_IMPLEMENT
+#define _NV_API_IMPLEMENT	1
+
+
+#if !defined(_API_nv) && defined(_API_DEFAULT)
+#define _API_nv	_API_DEFAULT
+#endif
+
+#if NVAPI(20120720)
+#undef	nv_lastdict
+#define nv_lastdict	nv_lastdict_20120720
+#endif
+
+#if NVAPI(20120720)
+#undef	nv_putsub
+#define nv_putsub	nv_putsub_20120720
+#endif
+
+#define _API_nv_MAP	"nv_lastdict_20120720 nv_putsub_20120720"
+
+#endif
+
+#endif

--- a/src/cmd/ksh93/features/shellapi.h
+++ b/src/cmd/ksh93/features/shellapi.h
@@ -1,0 +1,109 @@
+/* : : generated from shellapi by iffe version 2013-11-14 : : */
+#ifndef _SHELL_API_H
+#define _SHELL_API_H	1
+#define _sys_types	1	/* #include <sys/types.h> ok */
+#define SHELLAPI(rel)	( _BLD_shell || !_API_shell || _API_shell >= rel )
+
+#ifndef _SHELL_API_IMPLEMENT
+#define _SHELL_API_IMPLEMENT	1
+
+
+#if !defined(_API_shell) && defined(_API_DEFAULT)
+#define _API_shell	_API_DEFAULT
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_addbuiltin
+#define sh_addbuiltin	sh_addbuiltin_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_bltin_tree
+#define sh_bltin_tree	sh_bltin_tree_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_eval
+#define sh_eval	sh_eval_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_exit
+#define sh_exit	sh_exit_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_fd2sfio
+#define sh_fd2sfio	sh_fd2sfio_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_fun
+#define sh_fun	sh_fun_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_funscope
+#define sh_funscope	sh_funscope_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_getscope
+#define sh_getscope	sh_getscope_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_isoption
+#define sh_isoption	sh_isoption_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_menu
+#define sh_menu	sh_menu_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_offoption
+#define sh_offoption	sh_offoption_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_onoption
+#define sh_onoption	sh_onoption_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_pathopen
+#define sh_pathopen	sh_pathopen_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_reinit
+#define sh_reinit	sh_reinit_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_run
+#define sh_run	sh_run_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_setscope
+#define sh_setscope	sh_setscope_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_strnum
+#define sh_strnum	sh_strnum_20120720
+#endif
+
+#if SHELLAPI(20120720)
+#undef	sh_trap
+#define sh_trap	sh_trap_20120720
+#endif
+
+#define _API_shell_MAP	"sh_addbuiltin_20120720 sh_bltin_tree_20120720 sh_eval_20120720 sh_exit_20120720 sh_fd2sfio_20120720 sh_fun_20120720 sh_funscope_20120720 sh_getscope_20120720 sh_isoption_20120720 sh_menu_20120720 sh_offoption_20120720 sh_onoption_20120720 sh_pathopen_20120720 sh_reinit_20120720 sh_run_20120720 sh_setscope_20120720 sh_strnum_20120720 sh_trap_20120720"
+
+#endif
+
+#endif


### PR DESCRIPTION
These api headers are generated with each build by iffe. Macros
in the generated header are based on api version. We should save
the generated headers and find a better scheme later for using
different versions of same function.