### PR TITLE
Remove dependency over common libast feature test

### DIFF
--- a/src/lib/libast/astsa/ast_common.h
+++ b/src/lib/libast/astsa/ast_common.h
@@ -31,15 +31,9 @@
 #define _END_EXTERNS_
 #define __STD_C		1
 
-#if _hdr_stdint
 #include <stdint.h>
-#else
-#include <inttypes.h>
-#endif
 
-#if _hdr_unistd
 #include <unistd.h>
-#endif
 
 #define _typ_int32_t	1
 #ifdef _ast_int8_t

--- a/src/lib/libast/features/fcntl.c
+++ b/src/lib/libast/features/fcntl.c
@@ -46,12 +46,8 @@
 #if _hdr_fcntl
 #include <fcntl.h>
 #endif
-#if _hdr_unistd
 #include <unistd.h>
-#endif
-#if _sys_socket
 #include <sys/socket.h>
-#endif
 
 #include <sys/stat.h>
 

--- a/src/lib/libast/include/fnv.h
+++ b/src/lib/libast/include/fnv.h
@@ -47,17 +47,8 @@
 
 #if _typ_int64_t
 
-#ifdef _ast_LL
-
 #define FNV_INIT64	0xcbf29ce484222325LL
 #define FNV_MULT64	0x00000100000001b3LL
-
-#else
-
-#define FNV_INIT64	((int64_t)0xcbf29ce484222325)
-#define FNV_MULT64	((int64_t)0x00000100000001b3)
-
-#endif
 
 #define FNVINIT64(h)	(h = FNV_INIT64)
 #define FNVPART64(h,c)	(h = (h) * FNV_MULT64 ^ (c))

--- a/src/lib/libast/misc/debug.c
+++ b/src/lib/libast/misc/debug.c
@@ -459,8 +459,6 @@ debug_indent(int n)
 		indent = 0;
 }
 
-#if _sys_times
-
 #include <times.h>
 #include <sys/resource.h>
 
@@ -478,13 +476,3 @@ debug_elapsed(int set)
 		return prev = tm;
 	return tm - prev;
 }
-
-#else
-
-double
-debug_elapsed(int set)
-{
-	return 0;
-}
-
-#endif

--- a/src/lib/libast/misc/procopen.c
+++ b/src/lib/libast/misc/procopen.c
@@ -55,12 +55,8 @@
 #endif
 
 #if _lib_socketpair
-#if _sys_socket
 #include <sys/types.h>
 #include <sys/socket.h>
-#else
-#undef	_lib_socketpair
-#endif
 #endif
 
 Proc_t			proc_default = { -1 };

--- a/src/lib/libast/path/pathopen.c
+++ b/src/lib/libast/path/pathopen.c
@@ -30,9 +30,7 @@
 
 #include <ast.h>
 #include <error.h>
-#if _sys_socket
 #include <sys/socket.h>
-#endif
 #if _hdr_netdb
 #include <netdb.h>
 #endif

--- a/src/lib/libast/sfio/sfhdr.h
+++ b/src/lib/libast/sfio/sfhdr.h
@@ -62,12 +62,8 @@
 #define _LARGEFILE_SOURCE	1	
 #endif
 
-#if _hdr_stdarg
 #include	<stdarg.h>
-#else
-#include	<varargs.h>
-#endif
-#include	"FEATURE/common"
+#include	<stdbool.h>
 #if !__STD_C
 #define const	
 #endif
@@ -127,8 +123,6 @@
    are not needed and they may get in the way so we remove them here.
 */
 #if _SFBINARY_H
-#undef  _sys_time
-#undef  _sys_stat
 #undef  _hdr_stat
 #undef  _hdr_filio
 #undef  _sys_filio
@@ -145,33 +139,15 @@
 #undef  _sys_ioctl
 #endif
 
-#if _hdr_stdlib
 #include	<stdlib.h>
-#endif
 
 #if _hdr_string
 #include	<string.h>
 #endif
 
 #include	<time.h>
-#if _sys_time
-#include	<sys/time.h>
-#endif
 
-#if _sys_stat
 #include	<sys/stat.h>
-#else
-#if _hdr_stat
-#include	<stat.h>
-#ifndef _sys_stat
-#define	_sys_stat	1
-#endif
-#endif
-#endif /*_sys_stat*/
-
-#ifndef _sys_stat
-#define _sys_stat	0
-#endif
 
 #include	<fcntl.h>
 
@@ -187,9 +163,7 @@
 #endif /*_FIOCLEX*/
 #endif /*F_SETFD*/
 
-#if _hdr_unistd
 #include	<unistd.h>
-#endif
 
 #if !_LARGEFILE64_SOURCE	/* turn off the *64 stuff */
 #undef	_typ_off64_t
@@ -1232,60 +1206,6 @@ extern Sfdouble_t	ldexpl _ARG_((Sfdouble_t, int));
 #endif
 
 #if !_PACKAGE_ast
-
-#if !__STDC__ && !_hdr_stdlib
-extern void	abort _ARG_((void));
-extern int	atexit _ARG_((void(*)(void)));
-extern char*	getenv _ARG_((const char*));
-extern void*	malloc _ARG_((size_t));
-extern void*	realloc _ARG_((void*, size_t));
-extern void	free _ARG_((void*));
-extern size_t	strlen _ARG_((const char*));
-extern char*	strcpy _ARG_((char*, const char*));
-
-extern Void_t*	memset _ARG_((void*, int, size_t));
-extern Void_t*	memchr _ARG_((const void*, int, size_t));
-extern Void_t*	memccpy _ARG_((void*, const void*, int, size_t));
-#ifndef memcpy
-extern Void_t*	memcpy _ARG_((void*, const void*, size_t));
-#endif
-#if !defined(strtod)
-extern double	strtod _ARG_((const char*, char**));
-#endif
-#if !defined(remove)
-extern int	sysremovef _ARG_((const char*));
-#endif
-#endif /* !__STDC__ && !_hdr_stdlib */
-
-#if !_hdr_unistd
-#if _proto_open && __cplusplus
-extern int	sysopenf _ARG_((const char*, int, ...));
-#endif
-extern int	sysclosef _ARG_((int));
-extern ssize_t	sysreadf _ARG_((int, void*, size_t));
-extern ssize_t	syswritef _ARG_((int, const void*, size_t));
-extern sfoff_t	syslseekf _ARG_((int, sfoff_t, int));
-extern int	sysdupf _ARG_((int));
-extern int	syspipef _ARG_((int*));
-extern int	sysaccessf _ARG_((const char*, int));
-extern int	sysremovef _ARG_((const char*));
-extern int	sysfstatf _ARG_((int, sfstat_t*));
-extern int	sysstatf _ARG_((const char*, sfstat_t*));
-
-extern int	isatty _ARG_((int));
-
-extern int	wait _ARG_((int*));
-extern uint	sleep _ARG_((uint));
-extern int	execl _ARG_((const char*, const char*,...));
-extern int	execv _ARG_((const char*, char**));
-#if !defined(fork)
-extern int	fork _ARG_((void));
-#endif
-#if _lib_unlink
-extern int	unlink _ARG_((const char*));
-#endif
-
-#endif /*_hdr_unistd*/
 
 #if _lib_bcopy && !_proto_bcopy
 extern void	bcopy _ARG_((const void*, void*, size_t));

--- a/src/lib/libast/sfio/sfsetbuf.c
+++ b/src/lib/libast/sfio/sfsetbuf.c
@@ -47,15 +47,6 @@ _END_EXTERNS_
 **	Written by Kiem-Phong Vo.
 */
 
-#if !_sys_stat
-struct stat
-{	int	st_mode;
-	int	st_size;
-};
-#undef sysfstatf
-#define sysfstatf(fd,st)	(-1)
-#endif /*_sys_stat*/
-
 #if _PACKAGE_ast && !defined(SFSETLINEMODE)
 #define SFSETLINEMODE		1
 #endif
@@ -337,7 +328,7 @@ size_t	size;	/* buffer size, -1 for default size */
 		st.st_mode = 0;
 
 		/* if has discipline, set size by discipline if possible */
-		if(!_sys_stat || disc)
+		if(disc)
 		{	if((f->here = SFSK(f,(Sfoff_t)0,SEEK_CUR,disc)) < 0)
 				goto unseekable;
 			else
@@ -354,7 +345,7 @@ size_t	size;	/* buffer size, -1 for default size */
 			f->here = -1;
 		else
 		{
-#if _sys_stat && _stat_blksize	/* preferred io block size */
+#if _stat_blksize	/* preferred io block size */
 			f->blksz = (size_t)st.st_blksize;
 #endif
 			bufsize = 64 * 1024;
@@ -407,7 +398,6 @@ size_t	size;	/* buffer size, -1 for default size */
 					/* set line mode for terminals */
 					if(!(f->flags&(SF_LINE|SF_WCWIDTH)) && isatty(f->file))
 						f->flags |= SF_LINE|SF_WCWIDTH;
-#if _sys_stat
 					else	/* special case /dev/null */
 					{	reg int	dev, ino;
 						static int null_checked, null_dev, null_ino;
@@ -425,7 +415,6 @@ size_t	size;	/* buffer size, -1 for default size */
 						if(null_checked >= 0 && dev == null_dev && ino == null_ino)
 							SFSETNULL(f);
 					}
-#endif
 					errno = oerrno;
 				}
 

--- a/src/lib/libast/sfio/sfsize.c
+++ b/src/lib/libast/sfio/sfsize.c
@@ -56,14 +56,13 @@ Sfio_t*	f;
 		{	for(disc = f->disc; disc; disc = disc->disc)
 				if(disc->seekf)
 					break;
-			if(!_sys_stat || disc)
+			if(disc)
 			{	Sfoff_t	e;
 				if((e = SFSK(f,0,SEEK_END,disc)) >= 0)
 					f->extent = e;
 				if(SFSK(f,f->here,SEEK_SET,disc) != f->here)
 					f->here = SFSK(f,(Sfoff_t)0,SEEK_CUR,disc);
 			}
-#if _sys_stat
 			else
 			{	sfstat_t	st;
 				if(sysfstatf(f->file,&st) < 0)
@@ -71,7 +70,6 @@ Sfio_t*	f;
 				else if((f->extent = st.st_size) < f->here)
 					f->here = SFSK(f,(Sfoff_t)0,SEEK_CUR,disc);
 			}
-#endif
 		}
 
 		if((f->flags&(SF_SHARE|SF_PUBLIC)) == (SF_SHARE|SF_PUBLIC))

--- a/src/lib/libast/sfio/vthread.h
+++ b/src/lib/libast/sfio/vthread.h
@@ -46,7 +46,7 @@
 #endif
 #undef vt_threaded
 
-#if _may_use_threads && !defined(vt_threaded) && _hdr_pthread
+#if _may_use_threads && !defined(vt_threaded)
 #define vt_threaded		1
 #include			<pthread.h>
 typedef pthread_mutex_t		_vtmtx_t;

--- a/src/lib/libast/vmalloc/malloc.c
+++ b/src/lib/libast/vmalloc/malloc.c
@@ -142,9 +142,7 @@ typedef struct ______mstats Mstats_t;
 **	Written by Kiem-Phong Vo, phongvo@gmail.com, 01/16/94.
 */
 
-#if _sys_stat
 #include	<sys/stat.h>
-#endif
 #include	<fcntl.h>
 
 #ifdef S_IRUSR

--- a/src/lib/libast/vmalloc/vmdcshare.c
+++ b/src/lib/libast/vmalloc/vmdcshare.c
@@ -28,9 +28,7 @@ void _STUB_vmdcshare(){}
 #include	"vmhdr.h"
 #include	<sys/types.h>
 #include	<string.h>
-#if _hdr_unistd
 #include	<unistd.h>
-#endif
 
 #include	<sys/mman.h>	/* mmap() headers	*/
 #include	<sys/file.h>

--- a/src/lib/libast/vmalloc/vmhdr.h
+++ b/src/lib/libast/vmalloc/vmhdr.h
@@ -440,27 +440,10 @@ extern int		getpagesize _ARG_((void));
 
 #else
 
-#if _hdr_unistd
 #include	<unistd.h>
-#else
-extern void		abort _ARG_(( void ));
-extern ssize_t		write _ARG_(( int, const void*, size_t ));
-extern int		getpagesize _ARG_((void));
-extern Void_t*		sbrk _ARG_((ssize_t));
-#endif
 
-#if !__STDC__ && !_hdr_stdlib
-extern size_t		strlen _ARG_(( const char* ));
-extern char*		strcpy _ARG_(( char*, const char* ));
-extern int		strcmp _ARG_(( const char*, const char* ));
-extern int		atexit _ARG_(( void(*)(void) ));
-extern char*		getenv _ARG_(( const char* ));
-extern Void_t*		memcpy _ARG_(( Void_t*, const Void_t*, size_t ));
-extern Void_t*		memset _ARG_(( Void_t*, int, size_t ));
-#else
 #include	<stdlib.h>
 #include	<string.h>
-#endif
 
 /* for vmexit.c */
 extern int		onexit _ARG_(( void(*)(void) ));
@@ -468,11 +451,6 @@ extern void		_exit _ARG_(( int ));
 extern void		_cleanup _ARG_(( void ));
 
 #endif /*_PACKAGE_ast*/
-
-/* for vmdcsbrk.c */
-#if !_typ_ssize_t
-typedef int		ssize_t;
-#endif
 
 _END_EXTERNS_
 


### PR DESCRIPTION
There are other feature tests that still depend on it, but the
dependency in the source code over symbols that it generates
has been removed.