### PR TITLE
Enable some features from the legacy build system

### DIFF
--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -13,31 +13,39 @@ subdir('data')
 subdir('edit')
 subdir('sh')
 
+# These build time symbols are shared by ksh and shcomp.
+#
 # TODO: Add '-DSHOPT_DYNAMIC' when we have figured out how to get Meson to
 # build the libast libdll code.
-ksh93_c_args = ['-DERROR_CATALOG=0',
-                '-DERROR_CONTEXT_T=Error_context_t',
-                '-DKSHELL',
-                '-DSHOPT_BASH',
-                '-DSHOPT_COSHELL',
-                '-DSHOPT_FIXEDARRAY=0',
-                '-DUSAGE_LICENSE=""',
-                '-D_PACKAGE_ast',
-                '-D_BLD_shell',
-                '-D_API_ast=20130625']
+#
+# TODO: Figure out if '-DSHOPT_AUDIT' and '-DSHOPT_AUDITFILE="/etc/ksh_audit"'
+# should be added. They are defined in the legacy beta branch build.
+# See issue #240.
+shared_c_args = [
+    '-DUSAGE_LICENSE=""',
+    '-D_PACKAGE_ast',
+    '-D_BLD_shell',
+    '-D_API_ast=20130625',
+    '-DERROR_CONTEXT_T=Error_context_t',
+    '-DKSHELL',
+    '-DSHOPT_BASH',
+    '-DSHOPT_COSHELL',
+    '-DSHOPT_EDPREDICT',
+    '-DSHOPT_FILESCAN',
+    '-DSHOPT_FIXEDARRAY=0',
+    '-DSHOPT_POLL',
+]
 
-# TODO: -DSHOPT_DYNAMIC
-shcomp_c_args = ['-DERROR_CATALOG="libshell"',
-                 '-DERROR_CONTEXT_T=Error_context_t',
-                 '-DKSHELL',
-                 '-DSHOPT_BASH',
-                 '-DSHOPT_COSHELL',
-                 '-DSHOPT_FIXEDARRAY=0',
-                 '-DSHOPT_POLL',
-                 '-DUSAGE_LICENSE=""',
-                 '-D_PACKAGE_ast',
-                 '-D_BLD_shell',
-                 '-D_API_ast=20130625']
+# TODO: Figure out why there is a different definition of these symbols for
+# ksh93 versus shcomp and if there is a good reason add a comment why they are
+# defined differently.
+ksh93_c_args = shared_c_args + [
+    '-DERROR_CATALOG=0',
+]
+
+shcomp_c_args = shared_c_args + [
+    '-DERROR_CATALOG="libshell"',
+]
 
 cpu = host_machine.cpu()
 system = host_machine.system()


### PR DESCRIPTION
While working on issue #210 I noticed there were some features enabled
by the legacy Nmake based build system that were not enabled in the new
Meson based build system. Since that appears to be an oversight enable
those features so that we have parity with the legacy ksh93u+ build.
These symbols include SHOPT_POLL, SHOPT_FILESCAN, and SHOPT_EDPREDICT.

Whether or not the features controlled by those symbols should be in the
next stable release is TBD.

This also refactors the Meson build config to make it more obvious which
features are shared between the ksh and shcomp build targets.