### PR TITLE
Add checks for utimensat() and utimets()

### DIFF
--- a/src/lib/libast/meson.build
+++ b/src/lib/libast/meson.build
@@ -164,8 +164,14 @@ if align_bound_result.returncode() == 0
     endforeach
 endif
 
-if not cc.has_function('isnanl', prefix : '#include<math.h>')
+if not cc.has_function('isnanl', prefix: '#include <math.h>')
     libast_c_args += [ '-Disnanl=isnan' ]
+endif
+
+if cc.has_function('utimensat', prefix: '#include <sys/time.h>')
+    libast_c_args += [ '-D_lib_utimensat' ]
+elif cc.has_function('utimets', prefix: '#include <sys/time.h>')
+    libast_c_args += [ '-D_lib_utime' ]
 endif
 
 if cc.has_function('sysinfo', prefix : '#include <sys/sysinfo.h>')

--- a/src/lib/libast/tm/tvtouch.c
+++ b/src/lib/libast/tm/tvtouch.c
@@ -85,6 +85,8 @@ tvtouch(const char* path, const Tv_t* av, const Tv_t* mv, const Tv_t* cv, int fl
 	struct timeval	am[2];
 
 	oerrno = errno;
+
+#if _lib_utimensat
 	if (!av)
 	{
 		ts[0].tv_sec = 0;
@@ -149,7 +151,7 @@ tvtouch(const char* path, const Tv_t* av, const Tv_t* mv, const Tv_t* cv, int fl
 		if (!mv)
 			mv = (const Tv_t*)&now;
 	}
-#if _lib_utimets
+#elif _lib_utimets
 	if (av == TV_TOUCH_RETAIN)
 	{
 		ts[0].tv_sec = st.st_atime;


### PR DESCRIPTION
Commit a2bc8be5 removed the feature test for those functions under the
not unreasonable assumption that modern platforms provide `utimensat()`.
Unfortunately even some relatively recent platforms, such as macOS 10.12
(Sierra) which was the latest version just a few months ago, don't have
`utimensat()` or `utimets()`. So reinstate feature tests for those
functions.

Fixes #236