### PR TITLE
Align CFLAGS with definition in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ before_install:
 script:
     # TODO: Check how to set MESON_TESTTHREADS dynamically
     - echo > build.sh "set -e;
-        hostType=`bin/package`;
-        export CFLAGS="-D_PACKAGE_ast -DMESON_BUILD=1 -DHOSTTYPE=$hostType -fno-strict-aliasing -Wno-unknown-pragmas -Wno-missing-braces -Wno-unused-result -Wno-return-type -Wno-int-to-pointer-cast -Wno-parentheses -Wno-unused -Wno-unused-but-set-variable -Wno-cpp -Wno-char-subscripts";
+        export CFLAGS='-D_PACKAGE_ast -DMESON_BUILD=1 -fno-strict-aliasing -Wno-unknown-pragmas -Wno-missing-braces -Wno-unused-result -Wno-return-type -Wno-int-to-pointer-cast -Wno-parentheses -Wno-unused -Wno-unused-but-set-variable -Wno-cpp -Wno-char-subscripts';
         cd /source;
         mkdir build;
         cd build;

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ before_install:
 script:
     # TODO: Check how to set MESON_TESTTHREADS dynamically
     - echo > build.sh "set -e;
-        export CFLAGS='-fno-strict-aliasing -Wno-unknown-pragmas -Wno-missing-braces -Wno-unused-result -Wno-return-type -Wno-int-to-pointer-cast -Wno-parentheses -Wno-unused -Wno-unused-but-set-variable -Wno-cpp -Wno-char-subscripts';
+        hostType=`bin/package`;
+        export CFLAGS="-D_PACKAGE_ast -DMESON_BUILD=1 -DHOSTTYPE=$hostType -fno-strict-aliasing -Wno-unknown-pragmas -Wno-missing-braces -Wno-unused-result -Wno-return-type -Wno-int-to-pointer-cast -Wno-parentheses -Wno-unused -Wno-unused-but-set-variable -Wno-cpp -Wno-char-subscripts";
         cd /source;
         mkdir build;
         cd build;

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,18 @@ add_project_arguments('-D_PACKAGE_ast', language: 'c')
 add_project_arguments('-DMESON_BUILD=1', language: 'c')
 
 # We should remove all #prototyped pragmas from headers
+add_project_arguments('-fno-strict-aliasing', language: 'c')
 add_project_arguments('-Wno-unknown-pragmas', language: 'c')
+add_project_arguments('-Wno-missing-braces', language: 'c')
+add_project_arguments('-Wno-unused-result', language: 'c')
+add_project_arguments('-Wno-return-type', language: 'c')
+add_project_arguments('-Wno-int-to-pointer-cast', language: 'c')
+add_project_arguments('-Wno-parentheses', language: 'c')
+add_project_arguments('-Wno-unused', language: 'c')
+add_project_arguments('-Wno-unused-but-set-variable', language: 'c')
+add_project_arguments('-Wno-cpp', language: 'c')
+add_project_arguments('-Wno-char-subscripts', language: 'c')
+
 # We sure we have symbolic debug info in the compiled binaries so that our
 # `dump_backtrace()` function can provide some minimally useful information.
 add_project_arguments('-g', language: 'c')


### PR DESCRIPTION
In development we need to have the same compiler flags defined as in Continous Integration.
This PR fixes #258.