### PR TITLE
All 3 tests named `builtins*` crash

### DIFF
--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -175,8 +175,12 @@ libast_build_dir = join_paths(build_dir, 'src', 'lib', 'libast')
 libcmd_build_dir = join_paths(build_dir, 'src', 'lib', 'libcmd')
 libcoshell_build_dir = join_paths(build_dir, 'src', 'lib', 'libcoshell')
 
-ld_library_path = 'LD_LIBRARY_PATH=' + ':'.join(
-    [libast_build_dir, libcmd_build_dir, libcoshell_build_dir])
+if system == 'darwin'
+    ld_library_path = 'DYLD_FALLBACK_LIBRARY_PATH=src/lib'
+else
+    ld_library_path = 'LD_LIBRARY_PATH=' + ':'.join(
+        [libast_build_dir, libcmd_build_dir, libcoshell_build_dir])
+endif
 
 # These are the default locales used by legacy test script.
 # The emptry string is POSIX locale.


### PR DESCRIPTION
The problem is that the tests dynamically need to load libast.dylib.
The provided environment variable LD_LIBRARY_PATH does not help.

Instead, use DYLD_FALLBACK_LIBRARY_PATH=src/lib and the test not only does not crash anymore, but actually succeeds.

This PR fixes issue #262.