### PR TITLE
Make types and friends fail on SIGABRT

### DIFF
--- a/src/cmd/ksh93/tests/types.sh
+++ b/src/cmd/ksh93/tests/types.sh
@@ -29,7 +29,8 @@ Command=${0##*/}
 integer Errors=0
 
 tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
-trap "cd /; rm -rf $tmp" EXIT
+trap 'rm -fr $tmp' EXIT
+trap 'rm -fr $tmp; exit 1' 0 1 2 3 5 7 8 9 10 15
 
 integer n=2
 


### PR DESCRIPTION
This PR prevents one test to fail as soon as it SIGSEVs.
It addresses a concern in issue #267.

Apologies for the extra lines that have their final white-space removed at the end.
