### PR TITLE
Correct $INSTALLROOT when runing bin/package clean

### DIFF
--- a/bin/package
+++ b/bin/package
@@ -4996,6 +4996,11 @@ admin)	while	test ! -f $admin_db
 	;;
 
 clean|clobber)
+	case $INSTALLROOT in
+	$PACKAGEROOT)
+		INSTALLROOT=$INSTALLROOT/arch/$HOSTTYPE
+		;;
+	esac
 	cd $PACKAGEROOT
 	$exec rm -rf $INSTALLROOT
 	exit


### PR DESCRIPTION
There was a bug that caused running "bin/package clean" twice to
remove the entire repo.