### PR TITLE
Fix some logical typos in src/lib/libast/comp/iconv.c

### DIFF
--- a/src/lib/libast/comp/iconv.c
+++ b/src/lib/libast/comp/iconv.c
@@ -523,20 +523,21 @@ if (error_info.trace < DEBUG_TRACE) sfprintf(sfstderr, "%s: debug%d: AHA#%d _ast
 		else if (!(cp = (const _ast_iconv_list_t*)ccmaplist((_ast_iconv_list_t*)cp)))
 			cp = codes;
 	}
-	if (bp != 0)
+	cp = bp;
+	if (cp != 0)
 	{
-		cc = bp->ccode;
-		if (bp->canon)
+		cc = cp->ccode;
+		if (cp->canon)
 		{
-			if (bp->index)
+			if (cp->index)
 			{
 				for (m += sub[1]; *m && !isalnum(*m); m++);
 				if (!isdigit(*m))
-					m = bp->index;
+					m = cp->index;
 			}
 			else
 				m = "1";
-			b += sfsprintf(b, e - b, bp->canon, m);
+			b += sfsprintf(b, e - b, cp->canon, m);
 			if (cc == CC_UTF && *m != '8')
 				cc = CC_ICONV;
 		}

--- a/src/lib/libast/comp/iconv.c
+++ b/src/lib/libast/comp/iconv.c
@@ -523,7 +523,7 @@ if (error_info.trace < DEBUG_TRACE) sfprintf(sfstderr, "%s: debug%d: AHA#%d _ast
 		else if (!(cp = (const _ast_iconv_list_t*)ccmaplist((_ast_iconv_list_t*)cp)))
 			cp = codes;
 	}
-	if (cp = bp)
+	if (cp == bp)
 	{
 		cc = cp->ccode;
 		if (cp->canon)
@@ -759,11 +759,11 @@ umeinit(void)
 
 	if (!ume_d[ume_D[0]])
 	{
-		s = ume_D; 
-		while (c = *s++)
+		s = ume_D;
+		while ((c = *s++) != 0)
 			ume_d[c] = 1;
 		memset(ume_m, NOE, sizeof(ume_m));
-		for (i = 0; c = ume_M[i]; i++)
+		for (i = 0; (c = ume_M[i]) != 0; i++)
 			ume_m[c] = i;
 	}
 	return 0;
@@ -1165,9 +1165,11 @@ _ast_iconv_open(const char* t, const char* f)
 #if DEBUG_TRACE
 if (error_info.trace < DEBUG_TRACE) sfprintf(sfstderr, "%s: debug%d: AHA#%d _ast_iconv_open f=%s t=%s\n", error_info.id, error_info.trace, __LINE__, f, t);
 #endif
-	if (!t || !*t || *t == '-' && !*(t + 1) || !strcasecmp(t, name_local) || !strcasecmp(t, name_native))
+	/* accept only name_Local or name_native, default to name_native in all other cases */
+	if (!t || (!strcasecmp(t, name_local) && !strcasecmp(t, name_native)))
 		t = name_native;
-	if (!f || !*f || *f == '-' && !*(f + 1) || !strcasecmp(t, name_local) || !strcasecmp(f, name_native))
+	/* accept only name_Local or name_native, default to name_native in all other cases */
+	if (!f || (!strcasecmp(f, name_local) && !strcasecmp(f, name_native)))
 		f = name_native;
 
 	/*
@@ -1185,7 +1187,7 @@ if (error_info.trace < DEBUG_TRACE) sfprintf(sfstderr, "%s: debug%d: AHA#%d _ast
 #if DEBUG_TRACE
 if (error_info.trace <= DEBUG_TRACE) sfprintf(sfstderr, "%s: debug%d: AHA#%d _ast_iconv_open f=%s:%s:%d t=%s:%s:%d\n", error_info.id, error_info.trace, __LINE__, f, fr, fc, t, to, tc);
 #endif
-	if (fc != CC_ICONV && fc == tc || streq(fr, to))
+	if ((fc != CC_ICONV && fc == tc) || streq(fr, to))
 		return (iconv_t)(0);
 
 	/*
@@ -1389,7 +1391,7 @@ _ast_iconv_close(_ast_iconv_t cd)
 			 * close the oldest
 			 */
 
-			if (oc = freelist[i])
+			if (0 != (oc = freelist[i]))
 			{
 #if _lib_iconv_open
 				if (oc->cvt != (iconv_t)(-1))
@@ -1462,7 +1464,7 @@ _ast_iconv(_ast_iconv_t cd, char** fb, size_t* fn, char** tb, size_t* tn)
 			if ((*cc->from.fun)(cc->cvt, fb, fn, tb, tn) == (size_t)(-1))
 				return -1;
 			n -= *tn;
-			if (m = cc->to.map)
+			if (0 != (m = cc->to.map))
 			{
 				e = (unsigned char*)(*tb);
 				for (t = e - n; t < e; t++)
@@ -1790,7 +1792,8 @@ if (error_info.trace < DEBUG_TRACE) sfprintf(sfstderr, "%s: debug%d: AHA#%d icon
 				fn--;
 			}
 		}
-		if (i = fs - fb)
+		i = fs - fb;
+		if (i != 0)
 		{
 			if (n != SF_UNBOUND)
 			{

--- a/src/lib/libast/comp/iconv.c
+++ b/src/lib/libast/comp/iconv.c
@@ -523,20 +523,20 @@ if (error_info.trace < DEBUG_TRACE) sfprintf(sfstderr, "%s: debug%d: AHA#%d _ast
 		else if (!(cp = (const _ast_iconv_list_t*)ccmaplist((_ast_iconv_list_t*)cp)))
 			cp = codes;
 	}
-	if (cp == bp)
+	if (bp != 0)
 	{
-		cc = cp->ccode;
-		if (cp->canon)
+		cc = bp->ccode;
+		if (bp->canon)
 		{
-			if (cp->index)
+			if (bp->index)
 			{
 				for (m += sub[1]; *m && !isalnum(*m); m++);
 				if (!isdigit(*m))
-					m = cp->index;
+					m = bp->index;
 			}
 			else
 				m = "1";
-			b += sfsprintf(b, e - b, cp->canon, m);
+			b += sfsprintf(b, e - b, bp->canon, m);
 			if (cc == CC_UTF && *m != '8')
 				cc = CC_ICONV;
 		}


### PR DESCRIPTION
Some typos involving assigment in if clause that evaluates to being non-zero used for boolean value.

Line 1170 actually may have had a hidden bug.
It is slightly different from line 1168.
```c
if (!t || !*t || *t == '-' && !*(t + 1) || !strcasecmp(t, name_local) || !strcasecmp(t, name_native))
if (!f || !*f || *f == '-' && !*(f + 1) || !strcasecmp(t, name_local) || !strcasecmp(f, name_native))
//                                                     ^
```
I believe the character pointed to should actually be an 'f', not a 't'.
