### PR TITLE
Fix 36 warning regarding proper use of asointegralof

### DIFF
--- a/src/lib/libast/include/ast_aso.h
+++ b/src/lib/libast/include/ast_aso.h
@@ -4,7 +4,7 @@
 #define _def_aso_features	1
 #define _sys_types	1	/* #include <sys/types.h> ok */
 #include <ast_common.h>
-#define asointegralof(x)	(((char*)(x))-((char*)0))
+#define asointegralof(x)	(void *)(((char *) (x)) - ((char *) 0))
 
 #if GCC_4_1PLUS_64_BIT_MEMORY_ATOMIC_OPERATIONS_MODEL
 /* gcc 4.1+ 64 bit memory atomic operations model */


### PR DESCRIPTION
This PR fixes the warning like this:

```log
../src/lib/libast/cdt/dtuser.c:48:6: warning: incompatible integer to pointer conversion passing 'long' to parameter of type 'void *' [-Wint-conversion]
                if(asocasptr(&dt->data->user.data, current, data) == current)
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/lib/libast/features/ast_aso.h:33:64: note: expanded from macro 'asocasptr'
#define asocasptr(p,o,n)        ((void*)__sync_val_compare_and_swap(p,asointegralof(o),asointegralof(n)))
                                                                      ^~~~~~~~~~~~~~~~
../src/lib/libast/features/ast_aso.h:7:26: note: expanded from macro 'asointegralof'
#define asointegralof(x)        (((char*)(x))-((char*)0))
                                ^~~~~~~~~~~~~~~~~~~~~~~~~
../src/lib/libast/cdt/dtuser.c:48:6: warning: incompatible integer to pointer conversion passing 'long' to parameter of type 'void *' [-Wint-conversion]
                if(asocasptr(&dt->data->user.data, current, data) == current)
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/lib/libast/features/ast_aso.h:33:81: note: expanded from macro 'asocasptr'
#define asocasptr(p,o,n)        ((void*)__sync_val_compare_and_swap(p,asointegralof(o),asointegralof(n)))
                                                                                       ^~~~~~~~~~~~~~~~
../src/lib/libast/features/ast_aso.h:7:26: note: expanded from macro 'asointegralof'
#define asointegralof(x)        (((char*)(x))-((char*)0))
                                ^~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
```

Quite a long way to report 2 warning, eh ?
