### PR TITLE
Add support for additionally installed GNU libiconv.

### DIFF
--- a/src/lib/libast/include/ast_iconv.h
+++ b/src/lib/libast/include/ast_iconv.h
@@ -9,6 +9,7 @@
 #define _lib_iconv	1	/* iconv() in default lib(s) */
 #include <ast_common.h>
 #include <ccode.h>
+#define LIBICONV_PLUG 1 /* prefer more recent GNU libiconv */
 #include <iconv.h>	/* the native iconv.h */
 
 #define ICONV_VERSION		20121001L


### PR DESCRIPTION
It defines an extra compiler constant, LIBICONV_PLUG, in order to use the GNU libiconv function iconv_open and iconv_close.
As far as I can tell, there is no impact for Linux, or for people who only have libiconv which comes with the system.