### PR TITLE
Fix unused variables.

### DIFF
--- a/src/cmd/ksh93/bltins/alarm.c
+++ b/src/cmd/ksh93/bltins/alarm.c
@@ -211,7 +211,7 @@ static void putval(Namval_t* np, const char* val, int flag, Namfun_t* fp)
 	struct tevent	*tp = (struct tevent*)fp;
 	double		d,x;
 	Shell_t		*shp = tp->sh;
-	char		*cp, *pp;
+	char		*pp;
 	if(val)
 	{
 		Time_t now = getnow();

--- a/src/cmd/ksh93/bltins/cd_pwd.c
+++ b/src/cmd/ksh93/bltins/cd_pwd.c
@@ -112,8 +112,8 @@ int	b_cd(int argc, char *argv[],Shbltin_t *context)
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
 	shp->pwd = path_pwd(shp,0);
 	oldpwd = (char*)shp->pwd;
-	opwdnod = (shp->subshell?sh_assignok(OLDPWDNOD,1):OLDPWDNOD); 
-	pwdnod = (shp->subshell?sh_assignok(PWDNOD,1):PWDNOD); 
+	opwdnod = (shp->subshell?sh_assignok(OLDPWDNOD,1):OLDPWDNOD);
+	pwdnod = (shp->subshell?sh_assignok(PWDNOD,1):PWDNOD);
 	if(dirfd!=shp->pwdfd && dir==0)
 		dir = (char*)e_dot;
 	if(argc==2)
@@ -311,10 +311,10 @@ success:
 
 int	b_pwd(int argc, char *argv[],Shbltin_t *context)
 {
-	char *cp, *dir;
+	char *cp;
 	Shell_t *shp = context->shp;
 	bool pflag = false;
-	int n,fd,ffd=-1;
+	int n, ffd = -1;
 	NOT_USED(argc);
 	while((n=optget(argv,sh_optpwd))) switch(n)
 	{

--- a/src/cmd/ksh93/bltins/mkservice.c
+++ b/src/cmd/ksh93/bltins/mkservice.c
@@ -49,7 +49,7 @@ USAGE_LICENSE
 		"to be read from one of the active connections.  It is "
 		"called with the file descriptor number that has data "
 		"to be read.  If the function returns a non-zero "
-		"value, this connection will be closed.]" 
+		"value, this connection will be closed.]"
 	"[+close?This function is invoked when the connection is closed.]"
 	"}"
 "[+?If \avarname\a is unset, then all active connection, and the service "
@@ -208,7 +208,7 @@ static void process_stream(Sfio_t* iop)
 			close(fd);
 	}
 }
-				
+
 static int waitnotify(int fd, long timeout, int rw)
 {
 	Shell_t	*shp = sh_getinterp();
@@ -458,7 +458,7 @@ int	b_mkservice(int argc, char** argv, Shbltin_t *context)
 		sp->fd = fd;
 	np = nv_open(var,shp->var_tree,NV_ARRAY|NV_VARNAME|NV_NOASSIGN);
 	sp->node = np;
-	nv_putval(np, path, 0); 
+	nv_putval(np, path, 0);
 	nv_stack(np, (Namfun_t*)sp);
 	service_add(sp);
 	return(0);
@@ -466,7 +466,6 @@ int	b_mkservice(int argc, char** argv, Shbltin_t *context)
 
 int	b_eloop(int argc, char** argv, Shbltin_t *context)
 {
-	Shell_t	*shp = context->shp;
 	long	timeout = -1;
 	NOT_USED(argc);
 	for (;;)

--- a/src/cmd/ksh93/bltins/poll.c
+++ b/src/cmd/ksh93/bltins/poll.c
@@ -155,7 +155,7 @@ const char sh_optpoll[] =
 	"are available. A file descriptor for a socket that "
 	"is connecting asynchronously will indicate that it is ready "
 	"for writing, once a connection has been established.]"
- 
+
 "[+?Regular files always poll TRUE for reading and writing.]"
 
 "[e:eventarray]:[fdcount?Upon successful completion, an indexed array "
@@ -230,7 +230,7 @@ Namval_t *nv_open_fmt(Dt_t *dict, int flags, const char *namefmt, ...)
 	va_start(ap, namefmt);
 	vsnprintf(varnamebuff, sizeof(varnamebuff), namefmt, ap);
 	va_end(ap);
-	
+
 	return nv_open(varnamebuff, dict, flags);
 }
 
@@ -450,8 +450,7 @@ int b_poll(int argc, char *argv[], Shbltin_t* context)
 	Sfio_t		*strstk		= NULL; /* stk object for memory allocations */
 	const char	*parrayname,		/* name of array with poll data */
 			*eventarrayname = NULL, /* name of array with indexes to results */
-			*subname,		/* current subscript */
-			*s;
+			*subname;		/* current subscript */
 	int		n;
 	nfds_t		numpollfd = 0;		/* number of entries to poll */
 	int		i,
@@ -460,9 +459,7 @@ int b_poll(int argc, char *argv[], Shbltin_t* context)
 	char		buff[PATH_MAX*2+1];	/* fixme: theoretically enough to hold two variable names */
 	bool		ttyraw		= false;/* put ttys into raw more when polling */
 	bool		pollsfio	= true; /* should we ask sfio layer if it has data cached ? */
-	int		pi;			/* index for |pfnm| */
-	struct pollfd   *pollfd		= NULL,	/* data for poll(2) */
-			*currpollfd;		/* current |pollfd| we are working on */
+	struct pollfd   *pollfd		= NULL;	/* data for poll(2) */
 	struct pollstat *pollstat	= NULL,	/* context data from shell array */
 			*currps;		/* current |pollstat| we are working on */
 	int		retval		= 0;	/* return value of builtin */
@@ -471,7 +468,7 @@ int b_poll(int argc, char *argv[], Shbltin_t* context)
 	{
 		case 't':
 			errno = 0;
-			timeout = strtod(opt_info.arg, (char **)NULL);	
+			timeout = strtod(opt_info.arg, (char **)NULL);
 			if (errno != 0)
 				errormsg(SH_DICT, ERROR_system(1), "%s: invalid timeout", opt_info.arg);
 
@@ -594,7 +591,7 @@ int b_poll(int argc, char *argv[], Shbltin_t* context)
 		{
 			currps=&pollstat[i];
 			fd=pollfd[i].fd;
-			
+
 			currps->sfio.sfd=(fd>=0)?sh_fd2sfio(shp, fd):NULL;
 			currps->sfio.flags=0;
 			if (currps->sfio.sfd!=NULL)
@@ -681,7 +678,7 @@ int b_poll(int argc, char *argv[], Shbltin_t* context)
 	 */
 	n = poll_loop(context, pollfd, numpollfd, timeout);
 
-	/* 
+	/*
 	 * ... and restore the tty's to "cooked" mode
 	 */
 	if (ttyraw)
@@ -726,7 +723,7 @@ int b_poll(int argc, char *argv[], Shbltin_t* context)
 			sh_trap(shp, buff, 0);
 		}
 	}
-	
+
 	goto done;
 
 done_error:
@@ -736,6 +733,6 @@ done:
 		nv_close(array_np);
 	if (strstk)
 		stkclose(strstk);
-	
+
 	return(retval);
 }

--- a/src/cmd/ksh93/bltins/read.c
+++ b/src/cmd/ksh93/bltins/read.c
@@ -114,7 +114,6 @@ static int json2sh(Shell_t *shp, Sfio_t *in, Sfio_t *out)
 		}
 		else if(state==2)
 		{
-			char *last;
 			if(c==' ' || c == '\t')
 				continue;
 			if(c==':')

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -601,7 +601,7 @@ static int     setall(char **argv,int flag,Dt_t *troot,struct tdata *tp)
 					else
 					np = nv_open(name,sh_subfuntree(shp,1),NV_NOARRAY|NV_IDENT|NV_NOSCOPE);
 				}
-				else 
+				else
 				{
 					if(shp->prefix)
 					{
@@ -646,7 +646,7 @@ static int     setall(char **argv,int flag,Dt_t *troot,struct tdata *tp)
 						np = nv_search(stkptr(shp->stk,offset),troot,0);
 						stkseek(shp->stk,offset);
 					}
-					if(np && np->nvalue.cp) 
+					if(np && np->nvalue.cp)
 						np->nvalue.rp->help = tp->help;
 				}
 				continue;
@@ -674,7 +674,7 @@ static int     setall(char **argv,int flag,Dt_t *troot,struct tdata *tp)
 				_nv_unset(np,0);
 				ap->nelem--;
 			}
-			else if(iarray && ap && ap->fun) 
+			else if(iarray && ap && ap->fun)
 				errormsg(SH_DICT,ERROR_exit(1),"cannot change associative array %s to index array",nv_name(np));
 			else if( (iarray||(flag&NV_ARRAY)) && nv_isvtree(np) && !nv_type(np))
 				_nv_unset(np,NV_EXPORT);
@@ -704,7 +704,7 @@ static int     setall(char **argv,int flag,Dt_t *troot,struct tdata *tp)
 				if(comvar || (shp->last_root==shp->var_tree && ((tp->tp && tp->tp!=nv_type(np)) || (!shp->st.real_fun && (nvflags&NV_STATIC)) || (!(flag&(NV_EXPORT|NV_RDONLY)) && nv_isattr(np,(NV_EXPORT|NV_IMPORT))==(NV_EXPORT|NV_IMPORT)))))
 {
 				{
-					if((flag&(NV_HOST|NV_INTEGER))!=NV_HOST) 
+					if((flag&(NV_HOST|NV_INTEGER))!=NV_HOST)
 						_nv_unset(np,NV_EXPORT);
 				}
 }
@@ -805,7 +805,7 @@ static int     setall(char **argv,int flag,Dt_t *troot,struct tdata *tp)
 				{
 					if(!(flag&NV_RJUST))
 						newflag &= ~NV_RJUST;
-					
+
 					else if(!(flag&NV_LJUST))
 						newflag &= ~NV_LJUST;
 				}
@@ -1008,12 +1008,9 @@ int	b_builtin(int argc,char *argv[],Shbltin_t *context)
 	struct tdata tdata;
 	Shbltin_f addr;
 	Stk_t	*stkp;
-	void *library=0;
 	char *errmsg;
 #ifdef SH_PLUGIN_VERSION
-	unsigned long ver;
 	int list = 0;
-	char path[1024];
 #endif
 	NOT_USED(argc);
 	memset(&tdata,0,sizeof(tdata));
@@ -1295,7 +1292,6 @@ static int unall(int argc, char **argv, Dt_t *troot, Shell_t* shp)
 			isfun = is_afunction(np);
 			if(troot==shp->var_tree)
 			{
-				Namarr_t *ap;
 #if SHOPT_FIXEDARRAY
 				if((ap=nv_arrayptr(np)) && !ap->fixed  && name[strlen(name)-1]==']' && !nv_getsub(np))
 #else
@@ -1305,7 +1301,7 @@ static int unall(int argc, char **argv, Dt_t *troot, Shell_t* shp)
 					r=1;
 					continue;
 				}
-					
+
 				if(shp->subshell)
 					np=sh_assignok(np,0);
 			}
@@ -1532,7 +1528,7 @@ static void print_scan(Sfio_t *file, int flag, Dt_t *root, int option,struct tda
 				}
 				else if((flag&NV_IARRAY))
 					continue;
-				
+
 			}
 			tp->scanmask = flag&~NV_NOSCOPE;
 			tp->scanroot = root;

--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -52,9 +52,9 @@
 #if SHOPT_AUDIT
 #   define _HIST_AUDIT	Sfio_t	*auditfp; \
 			char	*tty; \
-			int	auditmask; 
+			int	auditmask;
 #else
-#   define _HIST_AUDIT 
+#   define _HIST_AUDIT
 #endif
 
 #define _HIST_PRIVATE \
@@ -118,17 +118,15 @@ static int	hist_clean(int);
     static int	hist_exceptf(Sfio_t*, int, Sfdisc_t*);
 #endif
 
-
 static int	histinit;
 static mode_t	histmode;
-static History_t *wasopen;
 static History_t *hist_ptr;
 
 #if SHOPT_ACCTFILE
     static int	acctfd;
     static char *logname;
 #   include <pwd.h>
-    
+
     static int  acctinit(History_t *hp)
     {
 	char *cp, *acctfile;
@@ -204,7 +202,7 @@ static int sh_checkaudit(History_t *hp, const char *name, char *logbuf, size_t l
 done:
 	sh_close(fd);
 	return(r);
-	
+
 }
 #endif /*SHOPT_AUDIT*/
 
@@ -551,7 +549,7 @@ static History_t* hist_trim(History_t *hp, int n)
 }
 
 /*
- * position history file at size and find next command number 
+ * position history file at size and find next command number
  */
 static int hist_nearend(History_t *hp, Sfio_t *iop, off_t size)
 {
@@ -801,7 +799,6 @@ static int hist_write(Sfio_t *iop,const void *buff,int insize,Sfdisc_t* handle)
 	char *bufptr = ((char*)buff)+insize;
 	int c,size = insize;
 	off_t cur;
-	Shell_t *shp = hp->histshell;
 	int saved=0;
 	char saveptr[HIST_MARKSZ];
 	if(!hp->histflush)
@@ -941,7 +938,7 @@ void hist_list(History_t *hp,Sfio_t *outfile, off_t offset,int last, char *nl)
 	}
 	return;
 }
-		 
+
 /*
  * find index for last line with given string
  * If flag==0 then line must begin with string
@@ -1063,7 +1060,7 @@ int hist_copy(char *s1,int size,int command,int line)
 		{
 			if(count++ ==line)
 				break;
-			else if(line >= 0)	
+			else if(line >= 0)
 				continue;
 		}
 		if(s1 && (line<0 || line==count))
@@ -1075,7 +1072,7 @@ int hist_copy(char *s1,int size,int command,int line)
 			}
 			*s1++ = c;
 		}
-			
+
 	}
 	sfseek(hp->histfp,(off_t)0,SEEK_END);
 	if(s1==0)

--- a/src/cmd/ksh93/edit/pcomplete.c
+++ b/src/cmd/ksh93/edit/pcomplete.c
@@ -86,7 +86,7 @@ static const char *Action_eval[] =  {
 	"x'builtin'",
 	"xtypeset +x",
 	"xtypeset +f | sed -e 's/()//'",
-	"xsed -e 's/:.*//' /etc/group", 
+	"xsed -e 's/:.*//' /etc/group",
 	"",
 	"ygrep -v '^#' ${HOSTFILE:-/etc/hosts} | tr '\t ' '\n\n' | tr -s '\n' | cat",
 	"xjobs -l",
@@ -96,7 +96,7 @@ static const char *Action_eval[] =  {
 	"pprint interactive\nrestricted\nlogin_shell\n",
 	"xkill -l",
 	"xjobs -l | grep Stopped",
-	"xsed -e 's/:.*//' /etc/passwd", 
+	"xsed -e 's/:.*//' /etc/passwd",
 	"xtypeset + | grep -v '^[ {}]' | grep -v namespace",
 	0
 };
@@ -217,7 +217,7 @@ static char action(const char *list[],const char *str)
 {
 	const char *cp;
 	int n=0;
-	for(cp=list[0]; cp; cp=list[++n]) 
+	for(cp=list[0]; cp; cp=list[++n])
 	{
 		if(strcmp(cp+1,str)==0)
 			return(*cp);
@@ -280,14 +280,14 @@ static gen_wordlist(Sfio_t *iop, const char *word)
 	}
 	if(n==0)
 		sfputc(iop,'\n');
-	
+
 }
 
 char **ed_pcomplete(struct Complete *comp, const char *line, const char *prefix, int index)
 {
 	Sfio_t		*tmp=sftmp(0), *saveout;
 	int		i=0,c,complete=(index!=0);
-	bool		negate=false, wordlist;
+	bool		negate = false;
 	size_t		len,tlen=0,plen=0,slen=0, wlen;
 	char		**av, *cp, *str, *lastword;
 	const char	*filter;
@@ -415,7 +415,7 @@ char **ed_pcomplete(struct Complete *comp, const char *line, const char *prefix,
 			nv_setvec(COMP_WORDS,0,n,av);
 			stkseek(shp->stk,0);
 			*cpsave = 0;
-			sfprintf(shp->stk,"%s \"%s\" \"%s\" \"%s\"\n\0",nv_name(comp->fun),comp->name,prefix,lastword); 
+			sfprintf(shp->stk,"%s \"%s\" \"%s\" \"%s\"\n\0",nv_name(comp->fun),comp->name,prefix,lastword);
 			*cpsave = csave;
 			sfputc(shp->stk,0);
 			str = stkptr(shp->stk,0);
@@ -535,7 +535,7 @@ again:
 	{
 		/* reserved space on stack and try again */
 		len = 3;
-		tlen = (c+1)*sizeof(char*)+len*c +1024; 
+		tlen = (c+1)*sizeof(char*)+len*c +1024;
 		stkseek(shp->stk,tlen);
 		complete = 2;
 		av = (char**)stkptr(shp->stk,0);
@@ -620,7 +620,7 @@ static const char *lquote(struct Complete *cp, const char *str)
 	sfputc(stakp,'$');
 	if(sp-str)
 		sfwrite(stakp,str,sp-str);
-	while(c = *sp++) 
+	while(c = *sp++)
 	{
 		if(c=='\'')
 			sfputc(stakp,'\\');

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -470,7 +470,6 @@ int sh_open(const char *path, int flags, ...) {
     Sfio_t *sp;
     int fd;
     mode_t mode;
-    char *e;
     va_list ap;
 #if SHOPT_REGRESS
     char buf[PATH_MAX];

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -145,8 +145,8 @@ char *sh_mactry(Shell_t *shp,char *string)
 
 /*
  * Perform parameter expansion, command substitution, and arithmetic
- * expansion on <str>. 
- * If <mode> greater than 1 file expansion is performed if the result 
+ * expansion on <str>.
+ * If <mode> greater than 1 file expansion is performed if the result
  * yields a single pathname.
  * If <mode> negative, than expansion rules for assignment are applied.
  */
@@ -249,7 +249,7 @@ int sh_macexpand(Shell_t* shp, struct argnod *argp, struct argnod **arghead,int 
 		endfield(mp,mp->quoted|mp->atmode);
 		flags = mp->fields;
 		if(flags==1 && shp->argaddr)
-			argp->argchn.ap = *arghead; 
+			argp->argchn.ap = *arghead;
 	}
 	shp->argaddr = saveargaddr;
 	*mp = savemac;
@@ -425,7 +425,7 @@ char *sh_macpat(Shell_t *shp,struct argnod *arg, int flags)
 }
 
 /*
- * Process the characters up to <endch> or end of input string 
+ * Process the characters up to <endch> or end of input string
  */
 static void copyto(Mac_t *mp,int endch, int newquote)
 {
@@ -542,7 +542,7 @@ static void copyto(Mac_t *mp,int endch, int newquote)
 						break;
 				}
 				/* followed by file expansion */
-				if(!mp->lit && (n==S_ESC || (!mp->quote && 
+				if(!mp->lit && (n==S_ESC || (!mp->quote &&
 					(n==S_PAT||n==S_ENDCH||n==S_SLASH||n==S_BRACT||*cp=='-'))))
 				{
 					cp += (n!=S_EOF);
@@ -1482,7 +1482,7 @@ retry1:
 				else
 					v = nv_getval(np);
 				mp->atmode = (v && mp->quoted && mode=='@');
-				/* special case --- ignore leading zeros */  
+				/* special case --- ignore leading zeros */
 				if((mp->let || (mp->arith&&nv_isattr(np,(NV_LJUST|NV_RJUST|NV_ZFILL)))) && !nv_isattr(np,NV_INTEGER) && (offset==0 || isspace(c) || strchr(",.+-*/=%&|^?!<>",c)))
 					mp->zeros = 1;
 			}
@@ -1515,7 +1515,7 @@ retry1:
 			{
 				ap->flags &= ~ARRAY_SCAN;
 				dolg = 0;
-		
+
 			}
 		}
 		break;
@@ -2076,7 +2076,6 @@ static void comsubst(Mac_t *mp,Shnode_t* t, volatile int type)
 	struct _mac_		savemac;
 	int			savtop = stktell(stkp);
 	char			*savptr = stkfreeze(stkp,0);
-	ssize_t                 len;
 	int			was_history = sh_isstate(mp->shp,SH_HISTORY);
 	int			was_verbose = sh_isstate(mp->shp,SH_VERBOSE);
 	int			was_interactive = sh_isstate(mp->shp,SH_INTERACTIVE);
@@ -2127,7 +2126,6 @@ static void comsubst(Mac_t *mp,Shnode_t* t, volatile int type)
 		}
 		else if(type==2 && t && (t->tre.tretyp&COMMSK)==0 && t->com.comarg)
 		{
-			Namval_t *np;
 			str = NULL;
 			if(!(t->com.comtyp&COMSCAN))
 			{
@@ -2180,7 +2178,7 @@ static void comsubst(Mac_t *mp,Shnode_t* t, volatile int type)
 			if(sp)
 				sfclose(sp);
 			sh_pushcontext(mp->shp,&buff,SH_JMPIO);
-			if((ip=t->tre.treio) && 
+			if((ip=t->tre.treio) &&
 				((ip->iofile&IOLSEEK) || !(ip->iofile&IOUFD)) &&
 				(r=sigsetjmp(buff.buff,0))==0)
 				fd = sh_redirect(mp->shp,ip,3);
@@ -2226,7 +2224,7 @@ static void comsubst(Mac_t *mp,Shnode_t* t, volatile int type)
 	sh_offstate(mp->shp,SH_INTERACTIVE);
 	if((foff = sfseek(sp,(Sfoff_t)0,SEEK_END)) > 0)
 	{
-		size_t soff = stktell(stkp); 
+		size_t soff = stktell(stkp);
 		sfseek(sp,(Sfoff_t)0,SEEK_SET);
 		stkseek(stkp,soff+foff+64);
 		stkseek(stkp,soff);
@@ -2625,7 +2623,7 @@ static int sh_btilde(int argc, char *argv[], Shbltin_t *context)
 	sfputr(sfstdout, cp, '\n');
 	return(0);
 }
- 
+
 /*
  * <offset> is byte offset for beginning of tilde string
  */
@@ -2680,7 +2678,7 @@ static void tilde_expand2(Shell_t *shp, int offset)
  * If ~name  is replaced with login directory of name.
  * If string doesn't start with ~ or ~... not found then 0 returned.
  */
-                                                            
+
 static char *sh_tilde(Shell_t *shp,const char *string)
 {
 	char		*cp;
@@ -2855,7 +2853,7 @@ static void mac_error(Namval_t *np)
  * Given pattern/string, replace / with 0 and return pointer to string
  * \ characters are stripped from string.  The \ are stripped in the
  * replacement string unless followed by a digit or \.
- */ 
+ */
 static char *mac_getstring(char *pattern)
 {
 	char	*cp=pattern, *rep=0, *dp;

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -37,7 +37,7 @@
 static char	*savesub = 0;
 static char	Null[1];
 static Namval_t	NullNode;
-static Dt_t	*Refdict;		
+static Dt_t	*Refdict;
 static Dtdisc_t	_Refdisc =
 {
 	offsetof(struct Namref,np),sizeof(struct Namval_t*),sizeof(struct Namref)
@@ -268,7 +268,7 @@ struct argnod *nv_onlist(struct argnod *arg, const char *name)
 	int len = strlen(name);
 	for(;arg; arg=arg->argnxt.ap)
 	{
-		if(*arg->argval==0 && arg->argchn.ap && !(arg->argflag&~(ARG_APPEND|ARG_QUOTED|ARG_MESSAGE))) 
+		if(*arg->argval==0 && arg->argchn.ap && !(arg->argflag&~(ARG_APPEND|ARG_QUOTED|ARG_MESSAGE)))
 			cp = ((struct fornod*)arg->argchn.ap)->fornam;
 		else
 			cp = arg->argval;
@@ -381,7 +381,7 @@ Namval_t **sh_setlist(Shell_t *shp,struct argnod *arg,int flags, Namval_t *typ)
 						while(ap->argnxt.ap)
 							ap = ap->argnxt.ap;
 						ap->argnxt.ap = tp->com.comarg;
-						
+
 					}
 					tp->com.comarg = tp->com.comset;
 					tp->com.comset = 0;
@@ -570,7 +570,7 @@ Namval_t **sh_setlist(Shell_t *shp,struct argnod *arg,int flags, Namval_t *typ)
 						_nv_unset(np,NV_EXPORT);
 						if(ap && ap->fun)
 							 nv_setarray(np,nv_associative);
-				
+
 					}
 				}
 				else
@@ -933,7 +933,7 @@ Namval_t *nv_create(const char *name,  Dt_t *root, int flags, Namfun_t *dp)
 				if(shp->namespace && root==nv_dict(shp->namespace))
 				{
 					flags |= NV_NOSCOPE;
-					shp->last_table = shp->namespace; 
+					shp->last_table = shp->namespace;
 				}
 			}
 			if(c)
@@ -1018,7 +1018,7 @@ Namval_t *nv_create(const char *name,  Dt_t *root, int flags, Namfun_t *dp)
 					ssize_t	xlen;
 					c = (cp-sp);
 					/* eliminate namespace name */
-					if(shp->last_table && !nv_type(shp->last_table)) 
+					if(shp->last_table && !nv_type(shp->last_table))
 					{
 						xp = nv_name(shp->last_table);
 						xlen = strlen(xp);
@@ -1067,7 +1067,7 @@ Namval_t *nv_create(const char *name,  Dt_t *root, int flags, Namfun_t *dp)
 #endif /* SHOPT_FIXEDARRAY */
 				if(!np)
 				{
-					if(!nq && !shp->namref_root && *sp=='[' && *cp==0 && cp[-1]==']') 
+					if(!nq && !shp->namref_root && *sp=='[' && *cp==0 && cp[-1]==']')
 					{
 						/*
 						 * for backward compatibility
@@ -1120,7 +1120,7 @@ Namval_t *nv_create(const char *name,  Dt_t *root, int flags, Namfun_t *dp)
 						flags &= ~NV_FARRAY;
 						if(fixed)
 							flags &= ~NV_ARRAY;
-							
+
 #endif /* SHOPT_FIXEDARRAY */
 #if 0
 						if(scan)
@@ -1174,7 +1174,7 @@ Namval_t *nv_create(const char *name,  Dt_t *root, int flags, Namfun_t *dp)
 							memcpy(sp+1,sub,n-2);
 							sp[n-1] = ']';
 							cp = sp+n;
-							
+
 						}
 					}
 					else if(c==0 && mode && (n=nv_aindex(np))>=0)
@@ -1427,7 +1427,7 @@ Namval_t *nv_open(const char *name, Dt_t *root, int flags)
 #if NVCACHE
 	struct Cache_entry	*xp;
 #endif
-	
+
 	memset(&fun,0,sizeof(fun));
 	shp->openmatch = 0;
 	shp->last_table = 0;
@@ -1483,7 +1483,7 @@ Namval_t *nv_open(const char *name, Dt_t *root, int flags)
 			root = sh_subaliastree(shp,1);
 		if(c= *--cp)
 			*cp = 0;
-		np = nv_search(name, root, (flags&NV_NOADD)?0:NV_ADD); 
+		np = nv_search(name, root, (flags&NV_NOADD)?0:NV_ADD);
 		if(c)
 			*cp = c;
 		goto skip;
@@ -1622,7 +1622,7 @@ skip:
 			if(sh_isoption(shp,SH_XTRACE) && nv_isarray(np))
 #endif /* SHOPT_FIXEDARRAY */
 				sub = nv_getsub(np);
-			c = msg==e_aliname? 0: (append | (flags&NV_EXPORT)); 
+			c = msg==e_aliname? 0: (append | (flags&NV_EXPORT));
 			if(isref)
 				nv_offattr(np,NV_REF);
 			if(!append && (flags&NV_UNJUST))
@@ -1698,7 +1698,6 @@ void nv_putval(Namval_t *np, const char *string, int flags)
 	int size = 0;
 	int dot;
 	int	was_local = nv_local;
-	union Value u;
 #if SHOPT_FIXEDARRAY
 	Namarr_t	*ap;
 #endif /* SHOPT_FIXEDARRAY */
@@ -1735,7 +1734,7 @@ void nv_putval(Namval_t *np, const char *string, int flags)
 		nv_offattr(np,NV_BINARY);
 	if(flags&(NV_NOREF|NV_NOFREE))
 	{
-		if(np->nvalue.cp && np->nvalue.cp!=sp && !nv_isattr(np,NV_NOFREE)) 
+		if(np->nvalue.cp && np->nvalue.cp!=sp && !nv_isattr(np,NV_NOFREE))
 			free((void*)np->nvalue.cp);
 		np->nvalue.cp = (char*)sp;
 		nv_setattr(np,(flags&~NV_RDONLY)|NV_NOFREE);
@@ -1909,7 +1908,7 @@ void nv_putval(Namval_t *np, const char *string, int flags)
 				{
 					if(!up->lp)
 						up->lp = new_of(int32_t,0);
-					else if(flags&NV_APPEND)	
+					else if(flags&NV_APPEND)
 						ol =  *(up->lp);
 					*(up->lp) = l+ol;
 				}
@@ -2077,7 +2076,7 @@ void nv_putval(Namval_t *np, const char *string, int flags)
 					nv_offattr(np,NV_NOFREE);
 				}
 			}
-			
+
 		}
 		else
 			cp = 0;
@@ -2139,7 +2138,7 @@ static void rightjust(char *str, int size, int fill)
         	return;
         }
 	else *(sp = str+size) = 0;
-	if (n == 0)  
+	if (n == 0)
         {
         	while (sp > str)
                		*--sp = ' ';
@@ -2463,13 +2462,13 @@ void sh_scope(Shell_t *shp, struct argnod *envlist, int fun)
 	{
 		dtview(rp->sdict,newroot);
 		newroot = rp->sdict;
-	
+
 	}
 	dtview(newscope,(Dt_t*)newroot);
 	shp->var_tree = newscope;
 }
 
-/* 
+/*
  * Remove freeable local space associated with the nvalue field
  * of nnod. This includes any strings representing the value(s) of the
  * node, as well as its dope vector, if it is an array.
@@ -2980,7 +2979,7 @@ char *nv_getval(Namval_t *np)
 done:
 #if (_AST_VERSION>=20030127L)
 	/*
-	 * if NV_RAW flag is on, return pointer to binary data 
+	 * if NV_RAW flag is on, return pointer to binary data
 	 * otherwise, base64 encode the data and return this string
 	 */
 	if(up->cp && nv_isattr(np,NV_BINARY) && !nv_isattr(np,NV_RAW))
@@ -2988,7 +2987,7 @@ done:
 		char *cp;
 		char *ep;
 		int size= nv_size(np), insize=(4*size)/3+size/45+8;
-		base64encode(up->cp, size, (void**)0, cp=getbuf(insize), insize, (void**)&ep); 
+		base64encode(up->cp, size, (void**)0, cp=getbuf(insize), insize, (void**)&ep);
 		*ep = 0;
 		return(cp);
 	}
@@ -3231,7 +3230,7 @@ static char *oldgetenv(const char *string)
 		c1= '=';
 	while(cp = *av++)
 	{
-		if(cp[0]!=c0 || cp[1]!=c1) 
+		if(cp[0]!=c0 || cp[1]!=c1)
 			continue;
 		sp = string;
 		while(*sp && *sp++ == *++cp);
@@ -3540,7 +3539,7 @@ bool nv_rename(Namval_t *np, int flags)
 }
 
 /*
- * Create a reference node from <np> to $np in dictionary <hp> 
+ * Create a reference node from <np> to $np in dictionary <hp>
  */
 void nv_setref(Namval_t *np, Dt_t *hp, int flags)
 {
@@ -3586,11 +3585,11 @@ void nv_setref(Namval_t *np, Dt_t *hp, int flags)
 				nq = nr;
 			else
 				nr = 0;
-		
+
 		}
 		hp = hp?(openmatch?openmatch:shp->var_base):shp->var_tree;
 	}
-	if(nr==np) 
+	if(nr==np)
 	{
 		if(shp->namespace && nv_dict(shp->namespace)==hp)
 			errormsg(SH_DICT,ERROR_exit(1),e_selfref,nv_name(np));
@@ -3716,7 +3715,6 @@ Shscope_t *sh_getscope_20120720(Shell_t *shp,int index, int whence)
 #undef sh_getscope
 Shscope_t *sh_getscope(int index, int whence)
 {
-	Shell_t *shp = sh_getinterp();
 	return(sh_getscope_20120720(sh_getinterp(),index,whence));
 }
 

--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -375,7 +375,7 @@ char *nv_dirnext(void *dir)
 					else
 						root = (Dt_t*)np;
 					/* check for recursive walk */
-					for(save=dp; save;  save=save->prev) 
+					for(save=dp; save;  save=save->prev)
 					{
 						if(save->root==root)
 							break;
@@ -430,7 +430,7 @@ static void outtype(Namval_t *np, Namfun_t *fp, Sfio_t* out, const char *prefix)
 {
 	char *type=0;
 	Namval_t *tp = fp->type;
-	if(!tp && fp->disc && fp->disc->typef) 
+	if(!tp && fp->disc && fp->disc->typef)
 		tp = (*fp->disc->typef)(np,fp);
 	for(fp=fp->next;fp;fp=fp->next)
 	{
@@ -464,7 +464,7 @@ void nv_attribute(Namval_t *np,Sfio_t *out,char *prefix,int noname)
 	char *cp;
 	unsigned val,mask,attr;
 	char *ip=0;
-	Namfun_t *fp=0; 
+	Namfun_t *fp=0;
 	Namval_t *typep=0;
 #if SHOPT_FIXEDARRAY
 	int fixed=0;
@@ -913,7 +913,6 @@ static void outval(char *name, const char *vname, struct Walk *wp)
 		isarray=1;
 		if(array_elem(nv_arrayptr(np))==0)
 		{
-			Namval_t *mp;
 			isarray=2;
 			if(tp  && (last_table->nvname[0]!='_' || last_table->nvname[1]))
 				return;
@@ -950,7 +949,6 @@ static void outval(char *name, const char *vname, struct Walk *wp)
 	{
 		if(*name!='.')
 		{
-			Namarr_t *ap;
 			if(!json)
 				nv_attribute(np,wp->out,"typeset",'=');
 #if xSHOPT_FIXEDARRAY
@@ -963,7 +961,7 @@ static void outval(char *name, const char *vname, struct Walk *wp)
 #endif /* SHOPT_FIXEDARRAY */
 		}
 		outname(wp->shp,wp->out,name,-1, json);
-		if((np->nvalue.cp && np->nvalue.cp!=Empty) || nv_isattr(np,~(NV_MINIMAL|NV_NOFREE)) || nv_isvtree(np))  
+		if((np->nvalue.cp && np->nvalue.cp!=Empty) || nv_isattr(np,~(NV_MINIMAL|NV_NOFREE)) || nv_isvtree(np))
 			if(!json)
 				sfputc(wp->out,(isarray==2?(wp->indent>=0?'\n':';'):'='));
 		if(isarray==2)
@@ -1005,7 +1003,6 @@ static char **genvalue(char **argv, const char *prefix, int n, struct Walk *wp)
 	bool		json = (wp->flags&NV_JSON);
 	bool		array_parent = (wp->flags&NV_ARRAY);
 	char		endchar = json?'}':')';
-	char		**names;
 	wp->flags &= ~NV_ARRAY;
 	if(n==0)
 		m = strlen(prefix);
@@ -1097,7 +1094,7 @@ static char **genvalue(char **argv, const char *prefix, int n, struct Walk *wp)
 					continue;
 				if((wp->array = nv_isarray(np)) && (aq=nv_arrayptr(np)))
 					k = array_elem(aq);
-					
+
 				if(wp->indent>0)
 					sfnputc(outfile,'\t',wp->indent);
 				if(json)
@@ -1204,7 +1201,7 @@ static char *walk_tree(Namval_t *np, Namval_t *xp, int flags)
 	Sfoff_t	off = 0;
 	int len, savtop = stktell(shp->stk);
 	char *savptr = stkfreeze(shp->stk,0);
-	struct argnod *ap=0; 
+	struct argnod *ap=0;
 	struct argnod *arglist=0;
 	char *name,*cp, **argv;
 	char *subscript=0;
@@ -1272,7 +1269,7 @@ static char *walk_tree(Namval_t *np, Namval_t *xp, int flags)
 				char *nvenv = mq->nvenv;
 				if(dp->table==nq)
 				{
-					dp = dp->prev; 
+					dp = dp->prev;
 					odir = dir;
 					dir = dp;
 				}
@@ -1289,7 +1286,7 @@ static char *walk_tree(Namval_t *np, Namval_t *xp, int flags)
 		sfputr(shp->stk,cp,-1);
 		ap = (struct argnod*)stkfreeze(shp->stk,1);
 		ap->argflag = ARG_RAW;
-		ap->argchn.ap = arglist; 
+		ap->argchn.ap = arglist;
 		n++;
 		arglist = ap;
 	}

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -746,7 +746,7 @@ static int typeinfo(Opt_t* op, Sfio_t *out, const char *str, Optdisc_t *od)
 			{
 				if(nv_isattr(bp->bltins[i],NV_OPTGET))
 					sfprintf(out,"\b%s.%s\b(3), ",np->nvname,bp->bnames[i]);
-                        }
+				}
 		}
 		return(0);
 	}
@@ -760,7 +760,7 @@ static int typeinfo(Opt_t* op, Sfio_t *out, const char *str, Optdisc_t *od)
 			continue;
 		if(tp=nv_type(nq))
 		{
-			Namfun_t *pp = nv_hasdisc(nq,&type_disc);
+			nv_hasdisc(nq,&type_disc);
 			sfprintf(out,"\t[+%s?%s.\n",nq->nvname,tp->nvname);
 			n = strlen(nq->nvname);
 			while((cp=nv_namptr(dp->nodes,i+1)->nvname) && strncmp(cp,nq->nvname,n)==0 && cp[n]=='.')

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -134,9 +134,9 @@ static pid_t path_xargs(Shell_t *shp,const char *path, char *argv[],char *const 
 	size = shp->gd->lim.arg_max-1024;
 	for(ev=envp; cp= *ev; ev++)
 		size -= strlen(cp)-1;
-	for(av=argv; (cp= *av) && av< &argv[shp->xargmin]; av++)  
+	for(av=argv; (cp= *av) && av< &argv[shp->xargmin]; av++)
 		size -= strlen(cp)-1;
-	for(av=avlast; cp= *av; av++,nlast++)  
+	for(av=avlast; cp= *av; av++,nlast++)
 		size -= strlen(cp)-1;
 	av =  &argv[shp->xargmin];
 	if(!spawn)
@@ -210,7 +210,7 @@ char *path_pwd(Shell_t *shp,int flag)
 	int count = 0;
 	if(shp->pwd)
 		return((char*)shp->pwd);
-	while(1) 
+	while(1)
 	{
 		/* try from lowest to highest */
 		switch(count++)
@@ -227,7 +227,7 @@ char *path_pwd(Shell_t *shp,int flag)
 			case 3:
 			{
 				if(cp=getcwd(NIL(char*),0))
-				{  
+				{
 					nv_offattr(PWDNOD,NV_NOFREE);
 					_nv_unset(PWDNOD,0);
 					PWDNOD->nvalue.cp = cp;
@@ -273,7 +273,7 @@ void  path_delete(Pathcomp_t *first)
 		}
 		else
 			old = pp;
-		pp = ppnext; 
+		pp = ppnext;
 	}
 }
 
@@ -340,7 +340,7 @@ static void path_checkdup(Shell_t *shp,Pathcomp_t *pp)
 	int			fd = -1;
 #if SHOPT_ATFUN
 	if((fd=open(name,O_search|O_CLOEXEC))<0 || fstat(fd,&statb)<0 ||  !S_ISDIR(statb.st_mode))
-	
+
 #else
 	if(stat(name,&statb)<0 || !S_ISDIR(statb.st_mode))
 #endif /* SHOPT_ATFUN */
@@ -728,7 +728,6 @@ Pathcomp_t *path_absolute(Shell_t *shp,const char *name, Pathcomp_t *pp)
 	Pathcomp_t	*oldpp;
 	Namval_t	*np;
 	char		*cp;
-	char		*bp;
 	shp->path_err = ENOENT;
 	if(!pp && !(pp=path_get(shp,"")))
 		return(0);
@@ -758,7 +757,7 @@ Pathcomp_t *path_absolute(Shell_t *shp,const char *name, Pathcomp_t *pp)
 			Shbltin_f addr;
 			int n;
 #endif
-			if(*stkptr(shp->stk,PATH_OFFSET)=='/' && (np=nv_search(stkptr(shp->stk,PATH_OFFSET),shp->bltin_tree,0)) && !nv_isattr(np,BLT_DISABLE)) 
+			if(*stkptr(shp->stk,PATH_OFFSET)=='/' && (np=nv_search(stkptr(shp->stk,PATH_OFFSET),shp->bltin_tree,0)) && !nv_isattr(np,BLT_DISABLE))
 				return(oldpp);
 			if((oldpp->flags&PATH_BIN) && (bp = strrchr(oldpp->name,'/')))
 			{
@@ -1100,7 +1099,7 @@ static int vexexec(void *ptr, uintmax_t fd1, uintmax_t fd2)
 pid_t path_spawn(Shell_t *shp,const char *opath,char **argv, char **envp, Pathcomp_t *libpath, int spawn)
 {
 	char *path;
-	char **xp=0, *xval, *libenv = (libpath?libpath->lib:0); 
+	char **xp=0, *xval, *libenv = (libpath?libpath->lib:0);
 	Namval_t*	np;
 	char		*s, *v;
 	int		n, pidsize;
@@ -1111,7 +1110,7 @@ pid_t path_spawn(Shell_t *shp,const char *opath,char **argv, char **envp, Pathco
 	{
 		spawnvex_add(shp->vex, SPAWN_pgrp, spawn>>1,0,0);
 	}
-	spawnvex_add(shp->vex,SPAWN_noexec,0,vexexec,(void*)shp);	
+	spawnvex_add(shp->vex,SPAWN_noexec,0,vexexec,(void*)shp);
 #endif /* SPAWN_cwd */
 	/* leave room for inserting _= pathname in environment */
 	envp--;
@@ -1459,7 +1458,7 @@ static void exscript(Shell_t *shp,char *path,char *argv[],char *const*envp)
 		sh_close( fd);
 	}
     }
- 
+
     /*
      * Produce a pseudo-floating point representation
      * with 3 bits base-8 exponent, 13 bits fraction.
@@ -1561,7 +1560,7 @@ bool path_cmdlib(Shell_t *shp, const char *dir, bool on)
 
 /*
  * This function checks for the .paths file in directory in <pp>
- * it assumes that the directory is on the stack at <offset> 
+ * it assumes that the directory is on the stack at <offset>
  */
 static bool path_chkpaths(Shell_t *shp,Pathcomp_t *first, Pathcomp_t* old,Pathcomp_t *pp, int offset)
 {
@@ -1648,7 +1647,7 @@ Pathcomp_t *path_addpath(Shell_t *shp,Pathcomp_t *first, const char *path,int ty
 	Pathcomp_t *old=0;
 	int offset = stktell(shp->stk);
 	char *savptr;
-	
+
 	if(!path && type!=PATH_PATH)
 		return(first);
 	if(type!=PATH_FPATH)
@@ -1807,7 +1806,7 @@ Pathcomp_t *path_unsetfpath(Shell_t *shp)
 				}
 				continue;
 			}
-			
+
 		}
 		old = pp;
 		pp = pp->next;
@@ -1820,7 +1819,7 @@ Pathcomp_t *path_dirfind(Pathcomp_t *first,const char *name,int c)
 	Pathcomp_t *pp=first;
 	while(pp)
 	{
-		if(memcmp(name,pp->name,pp->len)==0 && name[pp->len]==c) 
+		if(memcmp(name,pp->name,pp->len)==0 && name[pp->len]==c)
 			return(pp);
 		pp = pp->next;
 	}

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -58,7 +58,6 @@ static void	coproc_init(Shell_t*, int pipes[]);
 static void	*timeout;
 static char	nlock;
 static char	pipejob;
-static char	nopost;
 static int	restorefd;
 static int	restorevex;
 
@@ -329,7 +328,7 @@ static int sh_tclear(Shell_t *shp, Shnode_t *t)
 	{
 		case TTIME:
 		case TPAR:
-			return(sh_tclear(shp,t->par.partre)); 
+			return(sh_tclear(shp,t->par.partre));
 		case TCOM:
 			return(p_comarg(shp,(struct comnod*)t));
 		case TSETIO:
@@ -365,7 +364,7 @@ static int sh_tclear(Shell_t *shp, Shnode_t *t)
 			return(n+sh_tclear(shp,(Shnode_t*)t->funct.functargs));
 		case TTST:
 			if((t->tre.tretyp&TPAREN)==TPAREN)
-				return(sh_tclear(shp,t->lst.lstlef)); 
+				return(sh_tclear(shp,t->lst.lstlef));
 			else
 			{
 				n=p_arg(shp,&(t->lst.lstlef->arg),0);
@@ -460,7 +459,7 @@ struct Level
  * this is for a debugger but it hasn't been tested yet
  * if a debug script sets .sh.level it should set up the scope
  *  as if you were executing in that level
- */ 
+ */
 static void put_level(Namval_t* np,const char *val,int flags,Namfun_t *fp)
 {
 	Shell_t		*shp = sh_ptr(np);
@@ -488,7 +487,7 @@ static void put_level(Namval_t* np,const char *val,int flags,Namfun_t *fp)
 	{
 		sh_setscope(shp,sp);
 		error_info.id = sp->cmdname;
-		
+
 	}
 }
 
@@ -865,7 +864,7 @@ static Namval_t *enter_namespace(Shell_t *shp, Namval_t *nsp)
 	}
 	if(!nsp && !onsp)
 		return(0);
-	if(onsp == nsp) 
+	if(onsp == nsp)
 		return(nsp);
 	if(onsp)
 	{
@@ -1001,7 +1000,7 @@ int sh_exec(Shell_t *shp,const Shnode_t *t, int flags)
 				np = 0;
 				if(!(com0= *(com+=n)))
 					break;
-				np = nv_bfsearch(com0, shp->bltin_tree, &nq, &cp); 
+				np = nv_bfsearch(com0, shp->bltin_tree, &nq, &cp);
 			}
 			if(shp->xargexit)
 			{
@@ -1052,7 +1051,7 @@ int sh_exec(Shell_t *shp,const Shnode_t *t, int flags)
 				if(!np && !strchr(com0,'/'))
 				{
 					Dt_t *root = command?shp->bltin_tree:shp->fun_tree;
-					np = nv_bfsearch(com0, root, &nq, &cp); 
+					np = nv_bfsearch(com0, root, &nq, &cp);
 					if(shp->namespace && !nq && !cp)
 						np = sh_fsearch(shp,com0,0);
 				}
@@ -1084,7 +1083,7 @@ tryagain:
 							sh_scope(shp,(struct argnod*)0,0);
 							shp->st.var_local = shp->var_tree;
 						}
-			
+
 					}
 #endif /* SHOPT_BASH */
 					if(np==SYSTYPESET ||  (np && np->nvalue.bfp==SYSTYPESET->nvalue.bfp))
@@ -1124,7 +1123,7 @@ tryagain:
 							else
 							shp->prefix = NV_CLASS;
 							flgs |= NV_TYPE;
-			
+
 						}
 						if((shp->fn_depth && !shp->prefix) || np==SYSLOCAL)
 							flgs |= NV_NOSCOPE;
@@ -1478,7 +1477,7 @@ tryagain:
 							else
 							np = nv_search(com0,shp->fun_tree,HASH_NOSCOPE);
 						}
-						
+
 						if(!np->nvalue.ip)
 						{
 							if(indx==1)
@@ -2779,7 +2778,7 @@ shp,SH_BASH) && !sh_isoption(shp,SH_LASTPIPE))
 			{
 				static Dtdisc_t		_Rpdisc =
 				{
-				        offsetof(struct Ufunction,fname), -1, sizeof(struct Ufunction) 
+				        offsetof(struct Ufunction,fname), -1, sizeof(struct Ufunction)
 				};
 				struct functnod *fp;
 				struct comnod *ac = t->funct.functargs;
@@ -2915,7 +2914,7 @@ shp,SH_BASH) && !sh_isoption(shp,SH_LASTPIPE))
 				if(traceon)
 					sfwrite(sfstderr,e_tstend,4);
 			}
-			shp->exitval = ((!n)^negate); 
+			shp->exitval = ((!n)^negate);
 			if(!skipexitset)
 				exitset(shp);
 			break;
@@ -2935,7 +2934,7 @@ shp,SH_BASH) && !sh_isoption(shp,SH_LASTPIPE))
 			sh_timetraps(shp);
 		}
 		if(shp->trapnote || (shp->exitval && sh_isstate(shp,SH_ERREXIT)) &&
-			t && echeck) 
+			t && echeck)
 			sh_chktrap(shp);
 		/* set $_ */
 		if(mainloop && com0)
@@ -3031,7 +3030,7 @@ bool sh_trace(Shell_t *shp,char *argv[], int nl)
 			char *argv0 = *argv;
 			nl = (nl?'\n':-1);
 			/* don't quote [ and [[ */
-			if(*(cp=argv[0])=='[' && (!cp[1] || !cp[2]&&cp[1]=='['))  
+			if(*(cp=argv[0])=='[' && (!cp[1] || !cp[2]&&cp[1]=='['))
 			{
 				sfputr(sfstderr,cp,*++argv?' ':nl);
 				bracket = 1;
@@ -3288,14 +3287,14 @@ Sfdouble_t sh_mathfun(Shell_t *shp,void *fp, int nargs, Sfdouble_t *arg)
 	int		i;
 	np = (Namval_t*)fp;
 	funenv.node = np;
-	funenv.nref = nref; 
+	funenv.nref = nref;
 	funenv.env = 0;
 	memcpy(&node,SH_VALNOD,sizeof(node));
 	SH_VALNOD->nvfun = 0;
 	SH_VALNOD->nvenv = 0;
 	SH_VALNOD->nvflag = NV_LDOUBLE|NV_NOFREE;
 	SH_VALNOD->nvalue.ldp = 0;
-	for(i=0; i < nargs; i++)	
+	for(i=0; i < nargs; i++)
 	{
 		*nr++ = mp = nv_namptr(shp->mathnodes,i);
 		mp->nvalue.ldp = arg++;
@@ -3460,7 +3459,7 @@ int cmdrecurse(int argc, char* argv[], int ac, char* av[])
 }
 
 /*
- * set up pipe for cooperating process 
+ * set up pipe for cooperating process
  */
 static void coproc_init(Shell_t *shp, int pipes[])
 {
@@ -3473,7 +3472,7 @@ static void coproc_init(Shell_t *shp, int pipes[])
 		/* first co-process */
 		sh_pclose(shp->cpipe);
 		sh_pipe(shp->cpipe);
-		if((outfd=shp->cpipe[1]) < 10) 
+		if((outfd=shp->cpipe[1]) < 10)
 		{
 		        int fd=sh_fcntl(shp->cpipe[1],F_DUPFD_CLOEXEC,10);
 			if(fd>=10)
@@ -3604,7 +3603,7 @@ static pid_t sh_ntfork(Shell_t *shp,const Shnode_t *t,char *argv[],int *jobid,in
 	static int	savejobid;
 	struct checkpt	*buffp = (struct checkpt*)stkalloc(shp->stk,sizeof(struct checkpt));
 	int		otype=0, jmpval,jobfork=0, lineno=shp->st.firstline;
-	volatile int	jobwasset=0, scope=0, sigwasset=0;
+	volatile int	scope=0, sigwasset=0;
 	char		**arge, *path;
 	volatile pid_t	grp = 0;
 	Pathcomp_t	*pp;
@@ -3658,7 +3657,7 @@ static pid_t sh_ntfork(Shell_t *shp,const Shnode_t *t,char *argv[],int *jobid,in
 				sh_iorenumber(shp,sh_dup(shp->outpipe[1]),1);
 #endif
 			}
-	
+
 			if(t->fork.forkio)
 				sh_redirect(shp,t->fork.forkio,0);
 			if(optimize==0)
@@ -3743,7 +3742,7 @@ static pid_t sh_ntfork(Shell_t *shp,const Shnode_t *t,char *argv[],int *jobid,in
 			scope++;
 			sh_scope(shp,t->com.comset,0);
 		}
-		if(!strchr(path=argv[0],'/')) 
+		if(!strchr(path=argv[0],'/'))
 		{
 			Namval_t *np;
 			if((np=nv_search(path,shp->track_tree,0)) && !nv_isattr(np,NV_NOALIAS) && np->nvalue.cp)
@@ -3816,7 +3815,7 @@ static pid_t sh_ntfork(Shell_t *shp,const Shnode_t *t,char *argv[],int *jobid,in
 			argv[0] = argv[-1];
 		}
 	fail:
-		if(jobfork && spawnpid<0) 
+		if(jobfork && spawnpid<0)
 			job_fork(0);
 		if(spawnpid < 0) switch(errno=shp->path_err)
 		{

--- a/src/lib/libast/aso/aso.c
+++ b/src/lib/libast/aso/aso.c
@@ -41,8 +41,6 @@ NoN(aso)
  * Glenn Fowler 2011-11-11
  */
 
-static const char	lib[] = "libast:aso";
-
 typedef union
 {
 	uint8_t			c[2];
@@ -87,7 +85,7 @@ typedef union
 
 /*
  * used only when no cas intrinsic is available
- * should work most of the time in a single threaded process 
+ * should work most of the time in a single threaded process
  * with no multi-process shared mem access and low freq signals
  */
 

--- a/src/lib/libast/cdt/dtopen.c
+++ b/src/lib/libast/cdt/dtopen.c
@@ -20,7 +20,6 @@
 *                                                                      *
 ***********************************************************************/
 #include	"dthdr.h"
-static char*     Version = "\n@(#)$Id: cdt (AT&T Labs - Research) 2013-05-01 $\0\n";
 
 /* 	Make a new dictionary
 **

--- a/src/lib/libast/comp/setlocale.c
+++ b/src/lib/libast/comp/setlocale.c
@@ -2202,7 +2202,6 @@ ast_wcsrtombs(char* s, const wchar_t** w, size_t n, mbstate_t* q)
 	char*		t;
 	const wchar_t*	p;
 	size_t		m;
-	size_t		i;
 	char		buf[32];
 
 	p = *w;
@@ -2794,7 +2793,6 @@ _ast_setlocale(int category, const char* locale)
 		if (!initialized)
 		{
 			char*	u;
-			char	tmp[256];
 
 			/*
 			 * initialize from the environment

--- a/src/lib/libast/disc/sfdcdio.c
+++ b/src/lib/libast/disc/sfdcdio.c
@@ -137,8 +137,6 @@ Void_t*		data;
 Sfdisc_t*	disc;
 #endif
 {
-	Direct_t*	di = (Direct_t*)disc;
-
 	if(type == SF_FINAL || type == SF_DPOP)
 	{
 #ifdef F_DIOINFO

--- a/src/lib/libast/hash/hashalloc.c
+++ b/src/lib/libast/hash/hashalloc.c
@@ -27,8 +27,6 @@
  * hash table library
  */
 
-static const char id_hash[] = "\n@(#)$Id: hash (AT&T Research) 1996-08-11 $\0\n";
-
 #include "hashlib.h"
 
 Hash_info_t	hash_info = { 0 };
@@ -95,7 +93,7 @@ hashalloc(Hash_table_t* ref, ...)
 	tab->size = HASHMINSIZE;
 	for (;;)
 	{
-		switch (n) 
+		switch (n)
 		{
 		case HASH_alloc:
 			if (ref) goto out;

--- a/src/lib/libast/misc/debug.c
+++ b/src/lib/libast/misc/debug.c
@@ -59,7 +59,6 @@ debug_vsprintf(char* buf, size_t siz, const char* format, va_list ap)
 	char*			b;
 	char*			t;
 	void*			v;
-	wchar_t*		y;
 	char			num[32];
 	char			typ[32];
 
@@ -464,7 +463,7 @@ debug_indent(int n)
 
 double
 debug_elapsed(int set)
-{	
+{
 	double		tm;
 	struct rusage	ru;
 

--- a/src/lib/libast/misc/fastfind.c
+++ b/src/lib/libast/misc/fastfind.c
@@ -27,7 +27,7 @@
  * the bigram encoding steals the eighth bit (that's why its FF_old)
  * maybe one day we'll limit it to readonly:
  *
- * 0-2*FF_OFF	 likeliest differential counts + offset to make nonnegative 
+ * 0-2*FF_OFF	 likeliest differential counts + offset to make nonnegative
  * FF_ESC	 4 byte big-endian out-of-range count+FF_OFF follows
  * FF_MIN-FF_MAX ascii residue
  * >=FF_MAX	 bigram codes
@@ -69,8 +69,6 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-
-static const char id[] = "\n@(#)$Id: fastfind (AT&T Research) 2002-10-02 $\0\n";
 
 static const char lib[] = "libast:fastfind";
 
@@ -144,7 +142,7 @@ findopen(const char* file, const char* pattern, const char* type, Finddisc_t* di
 	char*		p;
 	char*		s;
 	char*		b;
-	int		i; 
+	int		i;
 	int		j;
 	char*			path;
 	int			brace = 0;
@@ -411,7 +409,7 @@ findopen(const char* file, const char* pattern, const char* type, Finddisc_t* di
 			setgid(getgid());
 		fp->stamp = st.st_mtime;
 		b = (s = fp->decode.temp) + 1;
-		for (i = 0; i < elementsof(fp->decode.bigram1); i++) 
+		for (i = 0; i < elementsof(fp->decode.bigram1); i++)
 		{
 			if ((j = sfgetc(fp->fp)) == EOF)
 				goto invalid;
@@ -875,7 +873,7 @@ findread(Find_t* fp)
 					s--;
 				if (*fp->decode.pattern == '/' && b > fp->decode.path)
 					b--;
-				for (; s >= b; s--) 
+				for (; s >= b; s--)
 					if (*s == *fp->decode.end || ignorecase && tolower(*s) == *fp->decode.end)
 					{
 						if (ignorecase)
@@ -1128,7 +1126,7 @@ findsync(Find_t* fp)
 					fp->encode.code[n][m] = 0;
 
 		/*
-		 * commit the real file 
+		 * commit the real file
 		 */
 
 		if (sfseek(fp->fp, (Sfoff_t)0, SEEK_SET))

--- a/src/lib/libast/misc/fgetcwd.c
+++ b/src/lib/libast/misc/fgetcwd.c
@@ -47,7 +47,7 @@ NoN(fgetcwd)
 
 /*
  * return a pointer to the absolute path name of fd
- * fd must be an fd to a directory open for read 
+ * fd must be an fd to a directory open for read
  * the resulting path may be longer than PATH_MAX
  *
  * a few environment variables are checked before the search algorithm
@@ -78,7 +78,6 @@ fgetcwd(int fd, char* buf, size_t len)
 	struct stat	curst;
 	struct stat	parst;
 	struct stat	tstst;
-	char		tst[PATH_MAX];
 
 	static struct
 	{

--- a/src/lib/libast/misc/mime.c
+++ b/src/lib/libast/misc/mime.c
@@ -28,8 +28,6 @@
  * mime/mailcap support library
  */
 
-static const char id[] = "\n@(#)$Id: mime library (AT&T Research) 2002-10-29 $\0\n";
-
 static const char lib[] = "libast:mime";
 
 #include "mimelib.h"

--- a/src/lib/libast/misc/spawnvex.c
+++ b/src/lib/libast/misc/spawnvex.c
@@ -874,7 +874,6 @@ spawnvex(const char* path, char* const argv[], char* const envv[], Spawnvex_t* v
 #endif
     ))
 	{
-		pid_t			pgid;
 		int			n;
 		int			m;
 		Spawnvex_noexec_t	nx;
@@ -896,7 +895,7 @@ spawnvex(const char* path, char* const argv[], char* const envv[], Spawnvex_t* v
 			msg[0] = msg[1] = -1;
 		}
 		else
- 		#if _lib_pipe2 
+ 		#if _lib_pipe2
  		    if (pipe2(msg, O_CLOEXEC) < 0)
 			    msg[0] = msg[1] = -1;
  		#else

--- a/src/lib/libast/misc/stack.c
+++ b/src/lib/libast/misc/stack.c
@@ -24,8 +24,6 @@
  * pointer stack routines
  */
 
-static const char id_stack[] = "\n@(#)$Id: stack (AT&T Bell Laboratories) 1984-05-01 $\0\n";
-
 #include <ast.h>
 #include <stack.h>
 

--- a/src/lib/libast/misc/state.c
+++ b/src/lib/libast/misc/state.c
@@ -21,8 +21,6 @@
 ***********************************************************************/
 #pragma prototyped
 
-static const char id[] = "\n@(#)$Id: ast (AT&T Research) 2013-11-26 $\0\n";
-
 #include <ast.h>
 
 #undef	strcmp

--- a/src/lib/libast/path/pathcanon.c
+++ b/src/lib/libast/path/pathcanon.c
@@ -34,7 +34,7 @@
  *	if (flags&(PATH_DOTDOT|PATH_PHYSICAL)) then each .. checked for access
  *	if (flags&PATH_EXISTS) then path must exist at each component
  *	if (flags&PATH_VERIFIED(n)) then first n chars of path exist
- * 
+ *
  * longer pathname possible if (flags&PATH_PHYSICAL) involved
  * 0 returned on error and if (flags&(PATH_DOTDOT|PATH_EXISTS)) then canon
  * will contain the components following the failure point
@@ -246,7 +246,6 @@ pathdev(int dfd, const char* path, char* canon, size_t size, int flags, Pathdev_
 	int	dots;
 	char*		v;
 	char*		x;
-	char*		y;
 	char*		z;
 	char*		a;
 	char*		b;
@@ -257,8 +256,6 @@ pathdev(int dfd, const char* path, char* canon, size_t size, int flags, Pathdev_
 	int		oerrno;
 	int		inplace;
 	Pathdev_t	nodev;
-
-	static int	path_one_head_slash = -1;
 
 	oerrno = errno;
 	if (!dev)

--- a/src/lib/libast/port/astconf.c
+++ b/src/lib/libast/port/astconf.c
@@ -26,8 +26,6 @@
  * extended to allow some features to be set per-process
  */
 
-static const char id[] = "\n@(#)$Id: getconf (AT&T Research) 2012-05-01 $\0\n";
-
 #include "univlib.h"
 
 #include <ast.h>
@@ -1684,7 +1682,7 @@ astconflist(Sfio_t* sp, const char* path, int flags, const char* pattern)
 						sfprintf(sp, "%*s %*s %d %2s %4d %5s %s\n", sizeof(conf[0].name), f, sizeof(prefix[look.standard].name), prefix[look.standard].name, look.section, call, 0, "N", s);
 					}
 					else if (flags & ASTCONF_parse)
-						sfprintf(sp, "%s %s - %s\n", state.id, f, s); 
+						sfprintf(sp, "%s %s - %s\n", state.id, f, s);
 					else
 						sfprintf(sp, "%s=%s\n", f, (flags & ASTCONF_quote) ? fmtquote(s, "\"", "\"", strlen(s), FMT_SHELL) : s);
 				}
@@ -1732,7 +1730,7 @@ astconflist(Sfio_t* sp, const char* path, int flags, const char* pattern)
 				sfprintf(sp, "%*s %*s %d %2s %4d %5s %s\n", sizeof(conf[0].name), fp->name, sizeof(prefix[fp->standard].name), prefix[fp->standard].name, 1, call, 0, flg, s);
 			}
 			else if (flags & ASTCONF_parse)
-				sfprintf(sp, "%s %s - %s\n", state.id, (flags & ASTCONF_lower) ? fmtlower(fp->name) : fp->name, fmtquote(s, "\"", "\"", strlen(s), FMT_SHELL)); 
+				sfprintf(sp, "%s %s - %s\n", state.id, (flags & ASTCONF_lower) ? fmtlower(fp->name) : fp->name, fmtquote(s, "\"", "\"", strlen(s), FMT_SHELL));
 			else
 				sfprintf(sp, "%s=%s\n", (flags & ASTCONF_lower) ? fmtlower(fp->name) : fp->name, (flags & ASTCONF_quote) ? fmtquote(s, "\"", "\"", strlen(s), FMT_SHELL) : s);
 		}

--- a/src/lib/libast/port/intercept.c
+++ b/src/lib/libast/port/intercept.c
@@ -575,7 +575,6 @@ ast_fcntl(int fd, int op, ...)
 	void*	p;
 	long	l;
 	int	r;
-	int	c;
 	va_list	ap;
 
 	va_start(ap, op);
@@ -710,7 +709,6 @@ ast_mkdir(const char* path, mode_t mode)
 int
 ast_open(const char* path, int flags, ...)
 {
-	int	r;
 	mode_t	mode;
 	va_list	ap;
 

--- a/src/lib/libast/string/utf32stowcs.c
+++ b/src/lib/libast/string/utf32stowcs.c
@@ -120,8 +120,6 @@ utf32stowcs(wchar_t* wchar, uint32_t* utf32, size_t n)
 			inbuf = outbuf;
 			if (mbwide())
 			{
-				ssize_t	len;
-
 				mbinit(&q);
 				for (outbuf = outbuf_start; i < n && outbuf < inbuf; i++)
 					if (mbchar(&wchar[i], outbuf, inbuf - outbuf, &q), mberrno(&q))

--- a/src/lib/libast/tm/tvtouch.c
+++ b/src/lib/libast/tm/tvtouch.c
@@ -81,7 +81,6 @@ tvtouch(const char* path, const Tv_t* av, const Tv_t* mv, const Tv_t* cv, int fl
 	int		oerrno;
 	struct stat	st;
 	Tv_t		now;
-	struct timespec	ts[2];
 	struct timeval	am[2];
 
 	oerrno = errno;

--- a/src/lib/libast/vmalloc/vmstat.c
+++ b/src/lib/libast/vmalloc/vmstat.c
@@ -41,8 +41,6 @@ Vmstat_t*	st;
 #endif
 {
 	Seg_t	*seg;
-	char	*bufp;
-	ssize_t	p;
 	int	rv;
 
 	memset(st, 0, sizeof(Vmstat_t));
@@ -53,7 +51,7 @@ Vmstat_t*	st;
 	if(!vm->meth.meth)
 		rv = -1;
 	else if((rv = (*vm->meth.statf)(vm, st, extra != 0)) >= 0 )
-	{	
+	{
 		st->extent += extra;
 		debug_sprintf(st->mesg, sizeof(st->mesg), "region %p size=%zu segs=%zu packs=%zu busy=%zu%% cache=%zu/%zu", vm, st->extent, st->n_seg, st->n_pack, (st->s_busy * 100) / st->extent, st->s_cache, st->n_cache);
 		st->mode = vm->data->mode;

--- a/src/lib/libcmd/context.c
+++ b/src/lib/libcmd/context.c
@@ -46,7 +46,6 @@ Context_t*
 context_open(Sfio_t* ip, size_t before, size_t after, Context_list_f listf, void* handle)
 {
 	Context_t*	cp;
-	int		j;
 
 	if (!(cp = newof(0, Context_t, 1, (before + after) * sizeof(Context_line_t))))
 		return 0;
@@ -70,7 +69,6 @@ context_line(Context_t* cp)
 	char*		e;
 	size_t		n;
 	size_t		m;
-	size_t		o;
 	ssize_t		r;
 
 	lp = &cp->line[cp->curline];
@@ -157,7 +155,6 @@ context_show(Context_t* cp)
 {
 	int	i;
 	int	j;
-	int	k;
 
 	j = cp->curline;
 	for (i = 0; i < cp->after; i++)
@@ -184,7 +181,6 @@ context_show(Context_t* cp)
 int
 context_close(Context_t* cp)
 {
-	int	i;
 	int	j;
 
 	for (j = 0; j < cp->total; j++)


### PR DESCRIPTION
This PR eliminates 51 cases of unused variables.

They are:
```log
../src/cmd/ksh93/bltins/alarm.c:214:9: warning: unused variable 'cp' [-Wunused-variable]
../src/cmd/ksh93/bltins/cd_pwd.c:314:13: warning: unused variable 'dir' [-Wunused-variable]
../src/cmd/ksh93/bltins/cd_pwd.c:317:8: warning: unused variable 'fd' [-Wunused-variable]
../src/cmd/ksh93/bltins/mkservice.c:469:11: warning: unused variable 'shp' [-Wunused-variable]
../src/cmd/ksh93/bltins/poll.c:454:5: warning: unused variable 's' [-Wunused-variable]
../src/cmd/ksh93/bltins/poll.c:463:7: warning: unused variable 'pi' [-Wunused-variable]
../src/cmd/ksh93/bltins/poll.c:465:5: warning: unused variable 'currpollfd' [-Wunused-variable]
../src/cmd/ksh93/bltins/read.c:117:10: warning: unused variable 'last' [-Wunused-variable]
../src/cmd/ksh93/bltins/typeset.c:1011:8: warning: unused variable 'library' [-Wunused-variable]
../src/cmd/ksh93/bltins/typeset.c:1014:16: warning: unused variable 'ver' [-Wunused-variable]
../src/cmd/ksh93/bltins/typeset.c:1016:7: warning: unused variable 'path' [-Wunused-variable]
../src/cmd/ksh93/bltins/typeset.c:1298:15: warning: unused variable 'ap' [-Wunused-variable]
../src/cmd/ksh93/edit/history.c:124:19: warning: unused variable 'wasopen' [-Wunused-variable]
../src/cmd/ksh93/edit/history.c:804:11: warning: unused variable 'shp' [-Wunused-variable]
../src/cmd/ksh93/edit/pcomplete.c:290:22: warning: unused variable 'wordlist' [-Wunused-variable]
../src/cmd/ksh93/sh/io.c:473:11: warning: unused variable 'e' [-Wunused-variable]
../src/cmd/ksh93/sh/macro.c:2079:26: warning: unused variable 'len' [-Wunused-variable]
../src/cmd/ksh93/sh/macro.c:2130:14: warning: unused variable 'np' [-Wunused-variable]
../src/cmd/ksh93/sh/name.c:1701:14: warning: unused variable 'u' [-Wunused-variable]
../src/cmd/ksh93/sh/name.c:3719:11: warning: unused variable 'shp' [-Wunused-variable]
../src/cmd/ksh93/sh/nvtree.c:916:14: warning: unused variable 'mp' [-Wunused-variable]
../src/cmd/ksh93/sh/nvtree.c:953:14: warning: unused variable 'ap' [-Wunused-variable]
../src/cmd/ksh93/sh/nvtree.c:1008:10: warning: unused variable 'names' [-Wunused-variable]
../src/cmd/ksh93/sh/nvtype.c:763:14: warning: unused variable 'pp' [-Wunused-variable]
../src/cmd/ksh93/sh/path.c:731:9: warning: unused variable 'bp' [-Wunused-variable]
../src/cmd/ksh93/sh/xec.c:61:13: warning: unused variable 'nopost' [-Wunused-variable]
../src/cmd/ksh93/sh/xec.c:3607:15: warning: unused variable 'jobwasset' [-Wunused-variable]
../src/lib/libast/aso/aso.c:44:19: warning: unused variable 'lib' [-Wunused-const-variable]
../src/lib/libast/cdt/dtopen.c:23:18: warning: unused variable 'Version' [-Wunused-variable]
../src/lib/libast/comp/setlocale.c:2205:10: warning: unused variable 'i' [-Wunused-variable]
../src/lib/libast/comp/setlocale.c:2797:9: warning: unused variable 'tmp' [-Wunused-variable]
../src/lib/libast/disc/sfdcdio.c:140:12: warning: unused variable 'di' [-Wunused-variable]
../src/lib/libast/hash/hashalloc.c:30:19: warning: unused variable 'id_hash' [-Wunused-const-variable]
../src/lib/libast/misc/debug.c:62:12: warning: unused variable 'y' [-Wunused-variable]
../src/lib/libast/misc/fastfind.c:73:19: warning: unused variable 'id' [-Wunused-const-variable]
../src/lib/libast/misc/fgetcwd.c:81:8: warning: unused variable 'tst' [-Wunused-variable]
../src/lib/libast/misc/mime.c:31:19: warning: unused variable 'id' [-Wunused-const-variable]
../src/lib/libast/misc/spawnvex.c:877:11: warning: unused variable 'pgid' [-Wunused-variable]
../src/lib/libast/misc/stack.c:27:19: warning: unused variable 'id_stack' [-Wunused-const-variable]
../src/lib/libast/misc/state.c:24:19: warning: unused variable 'id' [-Wunused-const-variable]
../src/lib/libast/path/pathcanon.c:249:9: warning: unused variable 'y' [-Wunused-variable]
../src/lib/libast/path/pathcanon.c:261:13: warning: unused variable 'path_one_head_slash' [-Wunused-variable]
../src/lib/libast/port/astconf.c:29:19: warning: unused variable 'id' [-Wunused-const-variable]
../src/lib/libast/port/intercept.c:578:6: warning: unused variable 'c' [-Wunused-variable]
../src/lib/libast/port/intercept.c:713:6: warning: unused variable 'r' [-Wunused-variable]
../src/lib/libast/string/utf32stowcs.c:123:13: warning: unused variable 'len' [-Wunused-variable]
../src/lib/libast/tm/tvtouch.c:84:18: warning: unused variable 'ts' [-Wunused-variable]
../src/lib/libast/vmalloc/vmstat.c:44:8: warning: unused variable 'bufp' [-Wunused-variable]
../src/lib/libast/vmalloc/vmstat.c:45:10: warning: unused variable 'p' [-Wunused-variable]
../src/lib/libcmd/context.c:49:7: warning: unused variable 'j' [-Wunused-variable]
../src/lib/libcmd/context.c:160:6: warning: unused variable 'k' [-Wunused-variable]
../src/lib/libcmd/context.c:187:6: warning: unused variable 'i' [-Wunused-variable]
../src/lib/libcmd/context.c:73:10: warning: unused variable 'o' [-Wunused-variable]
```