### PR TITLE
Remove conditional compilation with #if 0.

### DIFF
--- a/src/cmd/INIT/ratz.c
+++ b/src/cmd/INIT/ratz.c
@@ -810,10 +810,6 @@ void   zcfree  OF((voidpf opaque, voidpf ptr));
 #ifndef _ZUTIL_C
 #define _ZUTIL_C
 
-#if 0 && !_PACKAGE_ast && !defined(STDC)
-extern void exit OF((int));
-#endif
-
 #ifndef HAVE_MEMCPY
 
 void zmemcpy(dest, source, len)
@@ -960,14 +956,6 @@ void  zcfree (voidpf opaque, voidpf ptr)
 
 
 #ifndef MY_ZCALLOC /* Any system without a special alloc function */
-
-#if 0 && !_PACKAGE_ast
-#ifndef STDC
-extern voidp  malloc OF((uInt size));
-extern voidp  calloc OF((uInt items, uInt size));
-extern void   free   OF((voidpf ptr));
-#endif
-#endif
 
 voidpf zcalloc (opaque, items, size)
     voidpf opaque;
@@ -3611,13 +3599,6 @@ typedef voidp gzFile;
    FILE *fdopen(int, const char *);
 #endif
 
-#if 0 && !_PACKAGE_ast
-#ifndef STDC
-extern voidp  malloc OF((uInt size));
-extern void   free   OF((voidpf ptr));
-#endif
-#endif
-
 #define ALLOC(size) malloc(size)
 #define TRYFREE(p) {if (p) free(p);}
 
@@ -5156,7 +5137,7 @@ char**	argv;
 						break;
 					}
 					printf("%c", c);
-					m = 0400; 
+					m = 0400;
 					while (m)
 					{
 						printf("%c", (n & m) ? 'r' : '-');


### PR DESCRIPTION
  In all 3 cases, system functions are declared: exit(), malloc(), calloc() and free().