### PR TITLE
Fix ratz.c drop amiga

### DIFF
--- a/src/cmd/INIT/ratz.c
+++ b/src/cmd/INIT/ratz.c
@@ -641,10 +641,6 @@ typedef unsigned long  ulg;
 #  endif
 #endif
 
-#ifdef AMIGA
-#  define OS_CODE  0x01
-#endif
-
 #if defined(VAXC) || defined(VMS)
 #  define OS_CODE  0x02
 #  define F_OPEN(name, mode) \
@@ -5156,7 +5152,7 @@ char**	argv;
 						break;
 					}
 					printf("%c", c);
-					m = 0400; 
+					m = 0400;
 					while (m)
 					{
 						printf("%c", (n & m) ? 'r' : '-');

--- a/src/cmd/INIT/ratz.c
+++ b/src/cmd/INIT/ratz.c
@@ -736,9 +736,6 @@ typedef unsigned long  ulg;
 #      define vsnprintf _vsnprintf
 #    endif
 #  endif
-#  ifdef __SASC
-#    define NO_vsnprintf
-#  endif
 #endif
 #ifdef VMS
 #  define NO_vsnprintf


### PR DESCRIPTION
This PR removes support for AMIGA, including SAS/C compiler.