### PR TITLE
Remove dependency on *bin/package*

### DIFF
--- a/bin/hosttype
+++ b/bin/hosttype
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# Generate the value for the HOSTTYPE macro. This used to be done by the
+# legacy Nmake *bin/package* command. This implementation is considerably
+# simpler and does not perform some of the dubious transformations of the
+# original. Such as changing `x86_64` to `i386`.
+#
+# See issue #297.
+#
+echo $(uname -s).$(uname -m) | tr '[:upper:]' '[:lower:]'

--- a/meson.build
+++ b/meson.build
@@ -6,20 +6,21 @@ run_command('bin/ksh93_prereq.sh')
 add_project_arguments('-D_PACKAGE_ast', language: 'c')
 add_project_arguments('-DMESON_BUILD=1', language: 'c')
 
-# We should remove all #prototyped pragmas from headers
+# We should remove all #prototyped pragmas from headers.
 add_project_arguments('-Wno-unknown-pragmas', language: 'c')
 # We sure we have symbolic debug info in the compiled binaries so that our
 # `dump_backtrace()` function can provide some minimally useful information.
 add_project_arguments('-g', language: 'c')
 
-hosttype_cmd=run_command('bin/package')
+hosttype_cmd=run_command('bin/hosttype')
 hosttype=hosttype_cmd.stdout().strip()
-
 add_project_arguments('-DHOSTTYPE="' + hosttype + '"', language: 'c')
-# Compiler arguments used by ksh93 and shcomp executables
-# aso feature tests need to modify this variable, so declaring it before
-# libast meson build file is processed
+
+# Compiler arguments used by ksh93 and shcomp executables. The aso feature
+# tests need to modify this variable, so declaring it before libast meson
+# build file is processed.
 shared_c_args = []
+
 subdir('src/lib/libast')
 subdir('src/lib/libcmd')
 subdir('src/lib/libcoshell')


### PR DESCRIPTION
This replaces the dependency on the legacy *bin/package* build script
with a much simpler script so that the former can be removed once we no
longer need the `iffe` command.

Fixes #297