### PR TITLE
Fix proper indentation

### DIFF
--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -255,7 +255,7 @@ static void	assign(Namval_t *np,const char* val,int flags,Namfun_t *handle)
 	Namval_t	node;
 	union Value	*up = np->nvalue.up;
 	Namval_t	*tp, *nr;
-	if(val && (tp=nv_type(np)) && (nr=nv_open(val,shp->var_tree,NV_VARNAME|NV_ARRAY|NV_NOADD|NV_NOFAIL)) && tp==nv_type(nr)) 
+	if(val && (tp=nv_type(np)) && (nr=nv_open(val,shp->var_tree,NV_VARNAME|NV_ARRAY|NV_NOADD|NV_NOFAIL)) && tp==nv_type(nr))
 	{
 		char *sub = nv_getsub(np);
 		_nv_unset(np,0);
@@ -633,7 +633,7 @@ static void putdisc(Namval_t* np, const char* val, int flag, Namfun_t* fp)
 		nv_disc(np,fp,NV_POP);
 		if(!(fp->nofree&1))
 			free((void*)fp);
-			
+
 	}
 }
 
@@ -675,7 +675,7 @@ bool nv_adddisc(Namval_t *np, const char **names, Namval_t **funs)
 	else while(n>=0)
 		vp->bltins[n--] = 0;
 	vp->fun.disc = &Nv_bdisc;
-	vp->bnames = names; 
+	vp->bnames = names;
 	nv_stack(np,&vp->fun);
 	return(true);
 }
@@ -952,11 +952,11 @@ int nv_clone(Namval_t *np, Namval_t *mp, int flags)
 	if(flags&NV_APPEND)
 		return(1);
 	if(nv_size(mp) == size)
-	        nv_setsize(mp,nv_size(np));
+		nv_setsize(mp,nv_size(np));
 	if(mp->nvflag == flag)
-	        mp->nvflag = (np->nvflag&~(NV_MINIMAL))|(mp->nvflag&NV_MINIMAL);
-		if(nv_isattr(np,NV_EXPORT))
-			mp->nvflag |= (np->nvflag&NV_MINIMAL);
+		mp->nvflag = (np->nvflag&~(NV_MINIMAL))|(mp->nvflag&NV_MINIMAL);
+	if(nv_isattr(np,NV_EXPORT))
+		mp->nvflag |= (np->nvflag&NV_MINIMAL);
 	if(mp->nvalue.cp==val && !nv_isattr(np,NV_INTEGER))
 	{
 		if(np->nvalue.cp && np->nvalue.cp!=Empty && (flags&NV_COMVAR) && !(flags&NV_MOVE))
@@ -964,7 +964,7 @@ int nv_clone(Namval_t *np, Namval_t *mp, int flags)
 			if(size)
 				mp->nvalue.cp = (char*)memdup(np->nvalue.cp,size);
 			else
-			        mp->nvalue.cp = strdup(np->nvalue.cp);
+				mp->nvalue.cp = strdup(np->nvalue.cp);
 			nv_offattr(mp,NV_NOFREE);
 		}
 		else if((np->nvfun || !nv_isattr(np,NV_ARRAY)) && !(mp->nvalue.cp = np->nvalue.cp))
@@ -1110,7 +1110,7 @@ Namval_t *nv_search(const char *name, Dt_t *root, int mode)
  * and var contains the poiner to the variable
  * if last==0 and first component of name is a reference, nv_bfsearch()
 	will return 0.
- */ 
+ */
 Namval_t *nv_bfsearch(const char *name, Dt_t *root, Namval_t **var, char **last)
 {
 	Shell_t		*shp = dtuserdata(root,0,0);
@@ -1121,7 +1121,7 @@ Namval_t *nv_bfsearch(const char *name, Dt_t *root, Namval_t **var, char **last)
 	if(var)
 		*var = 0;
 	/* check for . in the name before = */
-	for(sp=(char*)name+1; *sp; sp++) 
+	for(sp=(char*)name+1; *sp; sp++)
 	{
 		if(*sp=='=')
 			return(0);
@@ -1140,7 +1140,7 @@ Namval_t *nv_bfsearch(const char *name, Dt_t *root, Namval_t **var, char **last)
 			cp = sp;
 		}
 		else if(*sp=='.')
-			cp = sp; 
+			cp = sp;
 	}
 	if(!cp)
 	{
@@ -1156,7 +1156,7 @@ Namval_t *nv_bfsearch(const char *name, Dt_t *root, Namval_t **var, char **last)
 	}
 	sfputr(shp->stk,name,0);
 	dname = cp+1;
-	cp = stkptr(shp->stk,offset) + (cp-name); 
+	cp = stkptr(shp->stk,offset) + (cp-name);
 	if(last)
 		*last = cp;
 	c = *cp;

--- a/src/lib/libast/path/pathcanon.c
+++ b/src/lib/libast/path/pathcanon.c
@@ -604,17 +604,17 @@ pathdev(int dfd, const char* path, char* canon, size_t size, int flags, Pathdev_
 	{
 		for (a = s + 2; *a == '/'; a++);
 #if NAMED_XATTR
-		if (!x && a[0] == '@' && a[1] == '/' && a[2] == '/')
-		{
-			if ((a - s) >= 4)
+			if (!x && a[0] == '@' && a[1] == '/' && a[2] == '/')
 			{
-				*t++ = *s++;
-				*t++ = *s++;
+				if ((a - s) >= 4)
+				{
+					*t++ = *s++;
+					*t++ = *s++;
+				}
 			}
-		}
-		else
+			else
 #endif
-			*t++ = *s++;
+				*t++ = *s++;
 	}
 #if NAMED_XATTR
 	z = 0;

--- a/src/lib/libast/regex/regsubexec.c
+++ b/src/lib/libast/regex/regsubexec.c
@@ -219,11 +219,11 @@ regsubexec(const regex_t* p, const char* s, size_t nmatch, oldregmatch_t* oldmat
 
 		if (!(match = oldof(0, regmatch_t, nmatch, 0)))
 			return -1;
-			for (i = 0; i < nmatch; i++)
-			{
-				match[i].rm_so = oldmatch[i].rm_so;
-				match[i].rm_eo = oldmatch[i].rm_eo;
-			}
+		for (i = 0; i < nmatch; i++)
+		{
+			match[i].rm_so = oldmatch[i].rm_so;
+			match[i].rm_eo = oldmatch[i].rm_eo;
+		}
 		if (!(r = regsubexec_20120528(p, s, nmatch, match)))
 			for (i = 0; i < nmatch; i++)
 			{


### PR DESCRIPTION
`gcc` complains in three cases that the indentation is misleading, and therefore the "guarding" is not evident.

The warnings look this:

```log
../src/lib/libast/path/pathcanon.c:605:3: warning: this ‘for’ clause does not guard... [-Wmisleading-indentation]
   for (a = s + 2; *a == '/'; a++);
   ^~~
../src/lib/libast/path/pathcanon.c:617:4: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘for’
    *t++ = *s++;
    ^
../src/lib/libast/path/pathcanon.c:683:107: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
     if ((flags & PATH_PHYSICAL) && (t - 1) > (x ? x : canon) && (loop < 32 || (flags & PATH_EXISTS) || *s && (flags & PATH_EXCEPT_LAST)))
                                                                                                        ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The PR corrects the indentation levels appropriately.

If this PR collides with the ongoing styling campaign, feel free to reject it.

Still, only 3 C source files have improper indentation from the view-point of a modern C compiler speaks for the discipline of the original engineers at work.
