### PR TITLE
Fix "dangling else" cases.

### DIFF
--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -605,13 +605,15 @@ static int     setall(char **argv,int flag,Dt_t *troot,struct tdata *tp)
 					if(shp->namespace)
 						np = sh_fsearch(shp,name,HASH_NOSCOPE);
 					if(!np)
-					if(np=nv_search(name,troot,0))
 					{
-						if(!is_afunction(np))
-							np = 0;
+						if(np=nv_search(name,troot,0))
+						{
+							if(!is_afunction(np))
+								np = 0;
+						}
+						else if(memcmp(name,".sh.math.",9)==0 && sh_mathstd(name+9))
+							continue;
 					}
-					else if(memcmp(name,".sh.math.",9)==0 && sh_mathstd(name+9))
-						continue;
 				}
 				if(np && ((flag&NV_LTOU) || !nv_isnull(np) || nv_isattr(np,NV_LTOU)))
 				{

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -2516,10 +2516,12 @@ yankeol:
 				i = cur_virt;
 				c = virtual[cur_virt];
 				if((c&~STRIP)==0)
-				if( isupper(c) )
-					c = tolower(c);
-				else if( islower(c) )
-					c = toupper(c);
+				{
+					if( isupper(c) )
+						c = tolower(c);
+					else if( islower(c) )
+						c = toupper(c);
+				}
 				replace(vp,c, 1);
 			}
 			return(GOOD);

--- a/src/lib/libast/misc/optget.c
+++ b/src/lib/libast/misc/optget.c
@@ -1176,6 +1176,7 @@ init(char* s, Optpass_t* p)
 	}
 	s = next(s, 0);
 	if (*s != '[')
+	{
 		for (t = s, a = 0; *t; t++)
 			if (!a && *t == '-')
 			{
@@ -1186,6 +1187,7 @@ init(char* s, Optpass_t* p)
 				a++;
 			else if (*t == ']')
 				a--;
+	}
 	if (!p->version && (t = strchr(s, '(')) && strchr(t, ')') && (state.cp || (state.cp = sfstropen())))
 	{
 		/*

--- a/src/lib/libcoshell/cowait.c
+++ b/src/lib/libcoshell/cowait.c
@@ -167,6 +167,7 @@ cowait(Coshell_t* co, Cojob_t* job, int timeout)
 		errormsg(state.lib, 2, "coshell %d zombie wait %lu timeout=%d outstanding=<%d,%d> running=<%d,%d>", co->index, serial, timeout, co->outstanding, co->svc_outstanding, co->running, co->svc_running);
 #endif
 		if ((co->outstanding + co->svc_outstanding) > (co->running + co->svc_running))
+		{
 			for (cj = co->jobs; cj; cj = cj->next)
 				if (cj->pid == CO_PID_ZOMBIE && (!job || cj == job))
 				{
@@ -187,6 +188,7 @@ cowait(Coshell_t* co, Cojob_t* job, int timeout)
 					cj->service = 0;
 					co->svc_running--;
 				}
+		}
 		if (co->running > 0)
 			active = 1;
 		else if (co->svc_running > 0)


### PR DESCRIPTION
There are 4 cases of "dangling else" that `gcc` points out.
Adding surrounding curly braces makes the code clearer for humans, and avoids the complier warning, too.

This PR fixes "dangling else" cases.