### PR TITLE
Make ksh build on Cygwin

### DIFF
--- a/src/lib/libast/include/ast_iconv.h
+++ b/src/lib/libast/include/ast_iconv.h
@@ -9,8 +9,14 @@
 #define _lib_iconv	1	/* iconv() in default lib(s) */
 #include <ast_common.h>
 #include <ccode.h>
-#define LIBICONV_PLUG 1 /* prefer more recent GNU libiconv */
-#include <iconv.h>	/* the native iconv.h */
+
+#if !__CYGWIN__
+// Under Cygwin the iconv shared library exports the symbols we need with a
+// `lib` prefix. So we don't want the LIBICONV_PLUG behavior on that platform.
+// On others we either want this or it's a no-op.
+#define LIBICONV_PLUG 1  // prefer more recent GNU libiconv
+#endif
+#include <iconv.h>  // the native iconv.h
 
 #define ICONV_VERSION		20121001L
 

--- a/src/lib/libast/meson.build
+++ b/src/lib/libast/meson.build
@@ -215,11 +215,14 @@ subdir('misc')
 subdir('tm')
 subdir('vmalloc')
 
-m_dep = cc.find_library('m', required: false)
-iconv_dep = cc.find_library('iconv', required: false)
+libm_dep = cc.find_library('m', required: false)
+libiconv_dep = cc.find_library('iconv', required: false)
+# On Cygwin the message catalog functions (e.g., `catopen()`) are in this
+# library.
+libcatgets_dep = cc.find_library('catgets', required: false)
 
 libast = library('ast', libast_files,
                  include_directories: incdir,
                  c_args: libast_c_args,
-                 dependencies: [m_dep, iconv_dep],
+                 dependencies: [libm_dep, libiconv_dep, libcatgets_dep],
                  install: true)

--- a/src/lib/libast/misc/meson.build
+++ b/src/lib/libast/misc/meson.build
@@ -21,16 +21,22 @@ _lib_posix_spawn_test = '''
 	#include <signal.h>
 	#include <fcntl.h>
 	#include <string.h>
+	#include <stdio.h>
+
 	/* if it uses fork() why bother? */
 	#undef fork
 	pid_t fork (void) { printf("uses fork()"); return -1; }
 	pid_t _fork (void) { printf("uses _fork()"); return -1; }
 	pid_t __fork (void) { printf("uses __fork()"); return -1; }
-	int
-	main(argc, argv)
-	int	argc;
-	char**	argv;
-	{
+
+	int main(int argc, char **argv) {
+        #if __CYGWIN__
+            // Not only does it not work it causes the meson configure step to
+            // take tens or minutes to complete and results in a huge cascade
+            // of child processes.
+            printf("Cygwin doesn't have a working posix_spawn()\n");
+            _exit(0);
+        #else  // __CYGWIN__
 		char*			s;
 		pid_t			pid;
 		posix_spawnattr_t	attr;
@@ -43,17 +49,17 @@ _lib_posix_spawn_test = '''
 		signal(SIGHUP, SIG_IGN);
 		if (posix_spawnattr_init(&attr))
 		{
-			printf("posix_spawnattr_init() FAILED");
+			printf("posix_spawnattr_init() FAILED\n");
 			_exit(0);
 		}
 		if (posix_spawnattr_setpgroup(&attr, 0))
 		{
-			printf("posix_spawnattr_setpgroup() FAILED");
+			printf("posix_spawnattr_setpgroup() FAILED\n");
 			_exit(0);
 		}
 		if (posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETPGROUP))
 		{
-			printf("posix_spawnattr_setflags() FAILED");
+			printf("posix_spawnattr_setflags() FAILED\n");
 			_exit(0);
 		}
 		/* first try an a.out and verify that SIGHUP is ignored */
@@ -63,25 +69,25 @@ _lib_posix_spawn_test = '''
 		cmd[3] = 0;
 		if (posix_spawn(&pid, cmd[0], 0, &attr, cmd, 0))
 		{
-			printf("posix_spawn() FAILED");
+			printf("posix_spawn() FAILED\n");
 			_exit(0);
 		}
 		status = 1;
 		if (wait(&status) < 0)
 		{
-			printf("wait() FAILED");
+			printf("wait() FAILED\n");
 			_exit(0);
 		}
 		if (status != 0)
 		{
-			printf("SIGHUP ignored in parent not ignored in child");
+			printf("SIGHUP ignored in parent not ignored in child\n");
 			_exit(0);
 		}
 		/* must return exec-type errors or its useless to us *unless* there is no [v]fork() */
 		n = strlen(cmd[0]);
 		if (n >= (sizeof(tmp) - 3))
 		{
-			printf("test executable path too long");
+			printf("test executable path too long\n");
 			_exit(0);
 		}
 		strcpy(tmp, cmd[0]);
@@ -94,7 +100,7 @@ _lib_posix_spawn_test = '''
                     write(n, "exit 99\n", 8) != 8 ||
                     close(n) < 0)
 		{
-			printf("test script create FAILED");
+			printf("test script create FAILED\n");
 			_exit(0);
 		}
 		cmd[0] = tmp;
@@ -103,30 +109,31 @@ _lib_posix_spawn_test = '''
 		if (posix_spawn(&pid, cmd[0], 0, &attr, cmd, 0))
 		{
 			n = 2;
-			printf("ENOEXEC produces posix_spawn() error (BEST)");
+			printf("ENOEXEC produces posix_spawn() error (BEST)\n");
 		}
 		else if (pid == -1)
-			printf("ENOEXEC returns pid == -1");
+			printf("ENOEXEC returns pid == -1\n");
 		else if (wait(&status) != pid)
-			printf("ENOEXEC produces no child process");
+			printf("ENOEXEC produces no child process\n");
 		else if (!WIFEXITED(status))
-			printf("ENOEXEC produces signal exit");
+			printf("ENOEXEC produces signal exit\n");
 		else
 		{
 			status = WEXITSTATUS(status);
 			if (status == 127)
 			{
 				n = 1;
-				printf("ENOEXEC produces exit status 127 (GOOD)");
+				printf("ENOEXEC produces exit status 127 (GOOD)\n");
 			}
 			else if (status == 99)
-				printf("ENOEXEC invokes sh");
+				printf("ENOEXEC invokes sh\n");
 			else if (status == 0)
-				printf("ENOEXEC reports no error");
+				printf("ENOEXEC reports no error\n");
 			else
-				printf("ENOEXEC produces non-zero exit status");
+				printf("ENOEXEC produces non-zero exit status\n");
 		}
 		_exit(n);
+        #endif  // __CYGWIN__
         }
 '''
 

--- a/src/lib/libast/path/pathnative.c
+++ b/src/lib/libast/path/pathnative.c
@@ -33,30 +33,6 @@
 
 #include <ast.h>
 
-#if __CYGWIN__
-
-extern void	cygwin_conv_to_win32_path(const char*, char*);
-
-size_t
-pathnative(const char* path, char* buf, size_t siz)
-{
-	size_t		n;
-
-	if (!buf || siz < PATH_MAX)
-	{
-		char	tmp[PATH_MAX];
-
-		cygwin_conv_to_win32_path(path, tmp);
-		if ((n = strlen(tmp)) < siz && buf)
-			memcpy(buf, tmp, n + 1);
-		return n;
-	}
-	cygwin_conv_to_win32_path(path, buf);
-	return strlen(buf);
-}
-
-#else
-
 size_t
 pathnative(const char* path, char* buf, size_t siz)
 {
@@ -66,5 +42,3 @@ pathnative(const char* path, char* buf, size_t siz)
 		memcpy(buf, path, n + 1);
 	return n;
 }
-
-#endif

--- a/src/lib/libast/path/pathposix.c
+++ b/src/lib/libast/path/pathposix.c
@@ -33,30 +33,6 @@
 
 #include <ast.h>
 
-#if __CYGWIN__
-
-extern void	cygwin_conv_to_posix_path(const char*, char*);
-
-size_t
-pathposix(const char* path, char* buf, size_t siz)
-{
-	size_t		n;
-
-	if (!buf || siz < PATH_MAX)
-	{
-		char	tmp[PATH_MAX];
-
-		cygwin_conv_to_posix_path(path, tmp);
-		if ((n = strlen(tmp)) < siz && buf)
-			memcpy(buf, tmp, n + 1);
-		return n;
-	}
-	cygwin_conv_to_posix_path(path, buf);
-	return strlen(buf);
-}
-
-#else
-
 size_t
 pathposix(const char* path, char* buf, size_t siz)
 {
@@ -66,5 +42,3 @@ pathposix(const char* path, char* buf, size_t siz)
 		memcpy(buf, path, n + 1);
 	return n;
 }
-
-#endif

--- a/src/lib/libcmd/iconv.c
+++ b/src/lib/libcmd/iconv.c
@@ -68,7 +68,7 @@ USAGE_LICENSE
 ;
 
 #include <cmd.h>
-#include <iconv.h>
+#include <ast_iconv.h>
 
 /*
  * optget() info discipline function


### PR DESCRIPTION
The Cygwin UNIX environment on MS Windows systems has some quirks. This
changes adapts the project to those quirks.

Note that there are a huge number of test failures. But that's true for
macOS too. Also, `meson test` itself sometimes fails (showing a traceback)
for no obvious reason.

Fixes #300