### PR TITLE
Fix for macro re-definition of SF_APPEND

### DIFF
--- a/src/lib/libast/include/sfio.h
+++ b/src/lib/libast/include/sfio.h
@@ -191,6 +191,7 @@ struct _sffmt_s
 
 /* namespace incursion workarounds -- migrate to the new names */
 #if !_mac_SF_APPEND
+#undef SF_APPEND_
 #define SF_APPEND	SF_APPENDWR	/* BSDI sys/stat.h		*/
 #endif
 #if !_mac_SF_CLOSE

--- a/src/lib/libast/include/sfio.h
+++ b/src/lib/libast/include/sfio.h
@@ -190,8 +190,7 @@ struct _sffmt_s
 #define SF_UNBOUND	(-1)	/* unbounded buffer size		*/
 
 /* namespace incursion workarounds -- migrate to the new names */
-#if !_mac_SF_APPEND
-#undef SF_APPEND_
+#ifdef SF_APPEND
 #define SF_APPEND	SF_APPENDWR	/* BSDI sys/stat.h		*/
 #endif
 #if !_mac_SF_CLOSE


### PR DESCRIPTION
This PR fixes issue #309.

It un-defines SF_APPEND before redefining it.

On macOS SF_APPEND is defined in <sys/stat.h>, as seen in issue #309.
There its value is 0x00040000.

In sfio.h it is SF_APPENDWR - or 0000010 once resolved.
And this value must be used in the end.
