### PR TITLE
Include <sys/sysinfo.h> if meson detects sysinfo()

### DIFF
--- a/src/lib/libast/port/astconf.c
+++ b/src/lib/libast/port/astconf.c
@@ -36,7 +36,9 @@
 #include <proc.h>
 #include <ls.h>
 #include <sys/utsname.h>
-
+#if _lib_sysinfo
+#  include <sys/sysinfo.h>
+#endif
 #include "conftab.h"
 
 #ifndef DEBUG_astconf


### PR DESCRIPTION
This PR fixes issue #311.
The function sysinfo() must be included via <sys/sysinfo.h> if the constant _lib_sysinfo is defined.