### PR TITLE
Include <sys/ioctl.h>, which declares ioctl()

### DIFF
--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -28,6 +28,7 @@
  */
 
 #include	<ast.h>
+#include  <sys/ioctl.h>
 #include	<errno.h>
 #include	<ccode.h>
 #   include	<utime.h>


### PR DESCRIPTION
This PR fixes issue #313.
It makes sure the function is defined, the compiler will not issue a warning.