### PR TITLE
Include "times.h", which declares touch()

### DIFF
--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -45,6 +45,7 @@
 #include	"terminal.h"
 #include	"history.h"
 #include	"edit.h"
+#include	"times.h"
 
 static char CURSOR_UP[20] = { ESC, '[', 'A', 0 };
 static char KILL_LINE[20] = { ESC, '[', 'J', 0 };


### PR DESCRIPTION
This PR fixes issue #315.
It makes sure the function is declared, the compiler will not issue a warning.