### PR TITLE
Include <time.h>, which declares time()

### DIFF
--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -25,6 +25,7 @@
  *   AT&T Labs
  *
  */
+#include <time.h>
 
 /*
  * Each command in the history file starts on an even byte is null terminated.

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -31,6 +31,7 @@
 #include <ls.h>
 #include <sfio.h>
 #include <stak.h>
+#include <time.h>
 
 #include "history.h"
 #include "io.h"


### PR DESCRIPTION
This PR fixes issue #317.
It makes sure the function is declared, the compiler will not issue a warning.