### PR TITLE
Remove re-definition of Empty

### DIFF
--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -28,7 +28,7 @@
 #include "variables.h"
 
 #define NVCACHE 8  // must be a power of 2
-#define Empty ((char *)(e_sptbnl + 3))
+
 static char *savesub = 0;
 static char Null[1];
 static Namval_t NullNode;


### PR DESCRIPTION
This PR fixes the issue #319.
It makes sure the constant `Empty` is taken from "defs.h" and used without modification.