### PR TITLE
Add a *CHANGELOG.md* file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# ksh x.y.z (version TBD, this is a work in progress)
+
+Starting in May 2017 maintenance of the Korn shell (`ksh`) resumed with
+the merging of some fixes from RedHat by Siteshwar Vashisht. In October
+2017 Kurtis Rader noticed that `ksh` had been open sourced and started
+contributing changes. This document was subsequently created to document
+the work being done. Whether the next stable version is considered a
+minor or major release is TBD.
+
+## Deprecations
+
+None at this time.
+
+## Notable non-backward compatible changes
+
+- Support for the UWIN environment has been removed (issue #284).
+- The `SHOPT_FIXEDARRAY` feature has been removed. This should not break any
+  existing uses of `ksh` since that feature is not believed to have been
+  enabled in any public release. It could break anyone who was building from
+  the source after its last public release (version `93u+`).
+
+## Notable fixes and improvements
+
+- Changes to the project are now validated by running unit tests on the Travis
+  continuous integration system.
+- The legacy Nmake build system has been replaced by Meson. This improves the
+  build time by roughly an order of magnitude (issue #42).
+- The ksh source now builds on BSD based systems such as macOS and FreeBSD.
+- The ksh source now builds on Cygwin.
+
+## Other significant changes
+
+- The code has been restyled according to new guidelines (issue #125)
+- Many features which used to be optionally included at build time are now
+  unconditionalied included (e.g., the code protected by `SHOPT_MULTIBYTE`,
+  `SHOPT_COMPLETE`, `SHOPT_BRACEPAT`, `SHOPT_RAWONLY`, `SHOPT_STATS,
+  `SHOPT_OPTIMIZE`, `SHOPT_SUID_EXEC`, `SHOPT_FILESCAN`, `SHOPT_POLL,
+  and `SHOPT_SYSRC`).
+- Unit tests can now be run under `valgrind` to help detect more bugs.
+- Any code not needed to build and run `ksh` has been removed from the master
+  branch.
+- Fixes backported from Solaris (issue #122).
+- Fixes backported from RedHat Fedora and Enterprise Linux (RHEL) distros
+  (issue #172).


### PR DESCRIPTION
Most projects have something analoguous to the *CHANGELOG.md* file
in this commit. The intent is to record significant changes from one
stable release to the next. This initial commit is going to be incomplete
because it was created long after the AT&T AST project was open sourced.
But hopefully it captures the significant changes made when maintenance
of the project resumed.