### PR TITLE
Make it possible to build `ksh` on OpenBSD 6.2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,10 @@ run_command('bin/ksh93_prereq.sh')
 
 add_project_arguments('-D_PACKAGE_ast', language: 'c')
 add_project_arguments('-DMESON_BUILD=1', language: 'c')
+# This was added because OpenBSD installs a lot of stuff in /usr/local/{include,lib}
+# that would normally be in /usr/{include,lib}. But the compiler doesn't
+# automatically search /usr/local/included for headers so force it to do so.
+add_project_arguments('-I/usr/local/include', language: 'c')
 
 # We require the C99 (aka ISO9899:1999) standard. Note we use `gnu99` rather
 # than `c99` because the former enables language features we need. The latter

--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -208,7 +208,7 @@ all_tests = [
     ['basic', 90], ['bracket'], ['builtins'], ['case'], ['comvar'],
     ['comvario'], ['coprocess', 50], ['cubetype'], ['directoryfd'], ['enum'],
     ['exit'], ['expand'], ['functions'], ['glob'], ['grep'], ['heredoc'],
-    ['io'], ['leaks', 60], ['locale'], ['math'], ['nameref'], ['namespace'],
+    ['io'], ['leaks', 60], ['locale'], ['math', 50], ['nameref'], ['namespace'],
     ['options'], ['path'], ['pointtype'], ['pty'], ['quoting'], ['quoting2'],
     ['readcsv'], ['recttype'], ['restricted'], ['return'], ['select'],
     ['sh_match'], ['sigchld', 100], ['signal', 100], ['statics'], ['subshell', 60],

--- a/src/lib/libast/aso/asothreadid.c
+++ b/src/lib/libast/aso/asothreadid.c
@@ -27,6 +27,14 @@
  * that support __thread may not support extern __thread in dlls
  */
 
+// For unknown reasons the gcc included in OpenBSD 6.2 does not support the `__thread` keyword.
+// Since ksh does not use or support threads just nullify that keyword. See issue #276.
+//
+// TODO: Figure out why this is needed on OpenBSD.
+#if defined(__OpenBSD__)
+#define __thread
+#endif
+
 static __thread unsigned int _AsoThreadId; /* thread local ID		*/
 
 static unsigned int _AsoThreadCount = 0; /* known thread count	*/

--- a/src/lib/libast/include/ast_iconv.h
+++ b/src/lib/libast/include/ast_iconv.h
@@ -9,7 +9,7 @@
 #include <ast_common.h>
 #include <ccode.h>
 
-#if !__CYGWIN__
+#if !defined(__CYGWIN__) && !defined(__OpenBSD__)
 // Under Cygwin the iconv shared library exports the symbols we need with a
 // `lib` prefix. So we don't want the LIBICONV_PLUG behavior on that platform.
 // On others we either want this or it's a no-op.

--- a/src/lib/libast/meson.build
+++ b/src/lib/libast/meson.build
@@ -216,7 +216,8 @@ subdir('tm')
 subdir('vmalloc')
 
 libm_dep = cc.find_library('m', required: false)
-libiconv_dep = cc.find_library('iconv', required: false)
+# On OpenBSD libiconv is in /usr/local/lib rather than /usr/lib.
+libiconv_dep = cc.find_library('iconv', required: false, dirs: ['/usr/lib', '/usr/local/lib'])
 # On Cygwin the message catalog functions (e.g., `catopen()`) are in this
 # library.
 libcatgets_dep = cc.find_library('catgets', required: false)


### PR DESCRIPTION
This makes it possible to build a working `ksh` binary on OpenBSD 6.2
and run the unit tests. Of course a record setting 52 tests fail but
it's a step in the right direction.

Resolves #276