### PR TITLE
Fix syntax error in pty.sh

### DIFF
--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -48,7 +48,7 @@ x=$( $SHELL <<- \EOF
         #sleep 1
         jobs
         kill $$
-    EOF
+	EOF
 )
 [[ $x == *Stop* ]] && err_exit 'monitor mode enabled incorrectly causes job to stop'
 


### PR DESCRIPTION
The second here-doc marker may only have tab characters preceding it.
The PR converts the space into a tab character.

It would also work if the `EOF` were at the beginning of the line.

This PR fixes #358.
