### PR TITLE
Update version number string in copr builds

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -2,6 +2,6 @@ mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
 
 srpm:
-	dnf -y install git-core
+	dnf -y install git-core sed
 	$(current_dir)/prep.sh
 	rpmbuild -bs -D "dist %{nil}" -D "_sourcedir packaging/fedora" -D "_srcrpmdir $(outdir)" --nodeps packaging/fedora/ksh.spec

--- a/.copr/prep.sh
+++ b/.copr/prep.sh
@@ -11,4 +11,6 @@ sed "s,#COMMIT#,${COMMIT},;
      s,#COMMITDATE#,${COMMIT_DATE}," \
          packaging/fedora/ksh.spec.in > packaging/fedora/ksh.spec
 
+sed -i "s/#define SH_RELEASE.*/#define SH_RELEASE \"${COMMIT_DATE}+git.${COMMIT_NUM}.${COMMIT_SHORT}\"/" src/cmd/ksh93/include/version.h 
+
 git archive --prefix "ast-${COMMIT}/" --format "tar.gz" "${COMMIT}" -o "packaging/fedora/ksh-${COMMIT_SHORT}.tar.gz"


### PR DESCRIPTION
This string is displayed with 'ksh --version'. Use the same version
as used by rpm package.