### PR TITLE
Change temp folder pattern to indicate which test script it is created for

### DIFF
--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -195,7 +195,7 @@ foreach testspec : all_tests
         if locale != ''
             locale = '/' + locale
         endif
-        test(testname + locale, ksh93_exe, timeout: timeout, args: [test_path],
+        test(testname + locale, ksh93_exe, timeout: timeout, args: [test_path, testname],
              env: [shell_var, lang_var, ld_library_path])
     endforeach
 
@@ -203,7 +203,7 @@ foreach testspec : all_tests
     lang_var = 'LANG='
     if not shcomp_tests_to_skip.contains(testname)
         test(testname + '/shcomp', ksh93_exe, timeout: timeout,
-             args: [ shcomp_test_path, test_path],
+             args: [ shcomp_test_path, test_path, testname],
              env: [shell_var, lang_var, shcomp_var, ld_library_path])
     endif
 endforeach

--- a/src/cmd/ksh93/tests/alias.sh
+++ b/src/cmd/ksh93/tests/alias.sh
@@ -29,7 +29,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 alias foo='print hello'

--- a/src/cmd/ksh93/tests/arith.sh
+++ b/src/cmd/ksh93/tests/arith.sh
@@ -29,7 +29,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 trap '' FPE # NOTE: osf.alpha requires this (no ieee math)

--- a/src/cmd/ksh93/tests/arrays.sh
+++ b/src/cmd/ksh93/tests/arrays.sh
@@ -28,7 +28,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 function fun

--- a/src/cmd/ksh93/tests/attributes.sh
+++ b/src/cmd/ksh93/tests/attributes.sh
@@ -29,7 +29,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 r=readonly u=Uppercase l=Lowercase i=22 i8=10 L=abc L5=def uL5=abcdef xi=20

--- a/src/cmd/ksh93/tests/basic.sh
+++ b/src/cmd/ksh93/tests/basic.sh
@@ -28,7 +28,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 # test basic file operations like redirection, pipes, file expansion

--- a/src/cmd/ksh93/tests/bracket.sh
+++ b/src/cmd/ksh93/tests/bracket.sh
@@ -28,7 +28,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 null=''

--- a/src/cmd/ksh93/tests/builtin_poll.sh
+++ b/src/cmd/ksh93/tests/builtin_poll.sh
@@ -60,7 +60,7 @@ typeset tmpdir
 
 # create temporary test directory
 ocwd="${PWD}"
-tmpdir="${ mktemp -t -d 'test_builtin_poll.XXXXXXXX' ; }" || err_exit 'Cannot create temporary directory.'
+tmpdir=$(mktemp -dt ksh.${Command}.XXXXXXXXXX ) || err_exit 'Cannot create temporary directory.'
 
 cd "${tmpdir}" || { err_exit "cd ${tmpdir} failed." ; exit $((Errors<125?Errors:125)) ; }
 

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -28,7 +28,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 # test shell builtin commands

--- a/src/cmd/ksh93/tests/comvario.sh
+++ b/src/cmd/ksh93/tests/comvario.sh
@@ -27,7 +27,7 @@ function err_exit
 }
 alias err_exit='err_exit $LINENO'
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 cd "$tmp"
 

--- a/src/cmd/ksh93/tests/coprocess.sh
+++ b/src/cmd/ksh93/tests/coprocess.sh
@@ -30,7 +30,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 if [[ -d /cygdrive ]]

--- a/src/cmd/ksh93/tests/directoryfd.sh
+++ b/src/cmd/ksh93/tests/directoryfd.sh
@@ -65,7 +65,7 @@ typeset tmpdir
 
 # create temporary test directory
 ocwd="${PWD}"
-tmpdir="${ mktemp -t -d 'test_directoryfd.XXXXXXXX' ; }" || err_exit 'Cannot create temporary directory.'
+tmpdir=$(mktemp -dt ksh.${Command}.XXXXXXXXXX ) || err_exit 'Cannot create temporary directory.'
 
 cd "${tmpdir}" || { err_exit "cd ${tmpdir} failed." ; exit $((Errors<125?Errors:125)) ; }
 

--- a/src/cmd/ksh93/tests/exit.sh
+++ b/src/cmd/ksh93/tests/exit.sh
@@ -28,7 +28,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 function abspath

--- a/src/cmd/ksh93/tests/functions.sh
+++ b/src/cmd/ksh93/tests/functions.sh
@@ -34,7 +34,7 @@ read -n4 c < $0 2> /dev/null
 
 ulimit -c 0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 integer foo=33

--- a/src/cmd/ksh93/tests/glob.sh
+++ b/src/cmd/ksh93/tests/glob.sh
@@ -28,7 +28,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer aware=0 contrary=0 Errors=0 ignorant=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 function test_glob

--- a/src/cmd/ksh93/tests/grep.sh
+++ b/src/cmd/ksh93/tests/grep.sh
@@ -29,7 +29,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 function grep

--- a/src/cmd/ksh93/tests/heredoc.sh
+++ b/src/cmd/ksh93/tests/heredoc.sh
@@ -29,7 +29,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 f=$tmp/here1

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -29,7 +29,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 unset HISTFILE

--- a/src/cmd/ksh93/tests/locale.sh
+++ b/src/cmd/ksh93/tests/locale.sh
@@ -31,7 +31,7 @@ integer Errors=0
 
 unset LANG ${!LC_*}
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 cd $tmp || exit
 

--- a/src/cmd/ksh93/tests/math.sh
+++ b/src/cmd/ksh93/tests/math.sh
@@ -35,7 +35,7 @@ set -o nounset
 typeset tmp
 
 # create temporary test directory
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 cd $tmp || exit
 

--- a/src/cmd/ksh93/tests/nameref.sh
+++ b/src/cmd/ksh93/tests/nameref.sh
@@ -29,7 +29,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 function checkref

--- a/src/cmd/ksh93/tests/namespace.sh
+++ b/src/cmd/ksh93/tests/namespace.sh
@@ -29,7 +29,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 foo=abc

--- a/src/cmd/ksh93/tests/options.sh
+++ b/src/cmd/ksh93/tests/options.sh
@@ -34,7 +34,7 @@ export LC_ALL=C ENV=
 
 ulimit -c 0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 if [[ $( ${SHELL-ksh} -s hello<<-\!

--- a/src/cmd/ksh93/tests/path.sh
+++ b/src/cmd/ksh93/tests/path.sh
@@ -29,7 +29,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 cd $tmp || exit

--- a/src/cmd/ksh93/tests/readcsv.sh
+++ b/src/cmd/ksh93/tests/readcsv.sh
@@ -29,7 +29,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 tmp1=$tmp/tmp1.csv

--- a/src/cmd/ksh93/tests/restricted.sh
+++ b/src/cmd/ksh93/tests/restricted.sh
@@ -29,7 +29,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 # test restricted shell

--- a/src/cmd/ksh93/tests/return.sh
+++ b/src/cmd/ksh93/tests/return.sh
@@ -30,7 +30,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 unset HISTFILE

--- a/src/cmd/ksh93/tests/select.sh
+++ b/src/cmd/ksh93/tests/select.sh
@@ -29,7 +29,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 PS3='ABC '

--- a/src/cmd/ksh93/tests/sh_match.sh
+++ b/src/cmd/ksh93/tests/sh_match.sh
@@ -65,7 +65,7 @@ typeset tmpdir
 
 # create temporary test directory
 ocwd="${PWD}"
-tmpdir="${ mktemp -t -d 'test_sh_match.XXXXXXXX' ; }" || err_exit 'Cannot create temporary directory.'
+tmpdir=$(mktemp -dt ksh.${Command}.XXXXXXXXXX ) || err_exit 'Cannot create temporary directory.'
 
 cd "${tmpdir}" || { err_exit "cd ${tmpdir} failed." ; exit $((Errors<125?Errors:125)) ; }
 

--- a/src/cmd/ksh93/tests/shcomptest
+++ b/src/cmd/ksh93/tests/shcomptest
@@ -1,5 +1,5 @@
 # Compile a test script through shcomp and run it through ksh93
-outfile=$(mktemp) 
+outfile=$(mktemp -t ksh.${2}.XXXXXXXX)
 if $SHCOMP $1 > $outfile; then
     $SHELL $outfile
 fi

--- a/src/cmd/ksh93/tests/sigchld.sh
+++ b/src/cmd/ksh93/tests/sigchld.sh
@@ -164,7 +164,7 @@ done
 (( d==2000 )) ||  err_exit "trap '' CHLD  causes side effects d=$d"
 trap - CHLD
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX)
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX)
 trap 'rm -rf $tmp' EXIT
 x=$($SHELL 2> /dev/null -ic '/bin/notfound; sleep .5 & sleep 1;jobs')
 [[ $x == *Done* ]] || err_exit 'SIGCHLD blocked after notfound'

--- a/src/cmd/ksh93/tests/signal.sh
+++ b/src/cmd/ksh93/tests/signal.sh
@@ -29,7 +29,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 cd $tmp || err_exit "cd $tmp failed"

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -29,7 +29,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0 Error_fd=2
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 # builtin getconf

--- a/src/cmd/ksh93/tests/tilde.sh
+++ b/src/cmd/ksh93/tests/tilde.sh
@@ -29,7 +29,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 if $SHELL -c '[[ ~root == /* ]]'

--- a/src/cmd/ksh93/tests/types.sh
+++ b/src/cmd/ksh93/tests/types.sh
@@ -29,7 +29,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 integer n=2

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -28,7 +28,7 @@ alias err_exit='err_exit $LINENO'
 Command=${0##*/}
 integer Errors=0
 
-tmp=$(mktemp -dt tmp.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
+tmp=$(mktemp -dt ksh.${Command}.XXXXXXXXXX) || { err_exit mktemp -dt failed; exit 1; }
 trap "cd /; rm -rf $tmp" EXIT
 
 [[ ${.sh.version} == "$KSH_VERSION" ]] || err_exit '.sh.version != KSH_VERSION'


### PR DESCRIPTION
This PR addresses the difficulty to associate the temp folder created by the test scripts.
The temp folder names are unique to allow for repeated invocation, and for the invocation
to happen in parallel.

This PR adds a prefix "ksh." plus the test name in front of the temp folder name.
It fixes #360.