### PR TITLE
Fix ksh writing wrong byte sequence to terminal

### DIFF
--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -1416,7 +1416,7 @@ Shell_t *sh_init(int argc, char *argv[], Shinit_f userinit) {
 #endif  // SHOPT_TIMEOUT
     // Initialize jobs table.
     job_clear(shp);
-    sh_onoption(shp, SH_MULTILINE);
+
     if (argc > 0) {
         int dolv_index = -1;
         // Check for restricted shell.


### PR DESCRIPTION
Description from bugzilla:

In vi mode when accessing via HP ilo4 virtual serial port, carriage
return and newfeed on input do not work properly. The cursor stays on
the same line, and sometimes the first few characters of the prompt are
missing. Things seem okay in emacs mode and when coming in via ssh or
directly via a physical serial port.

strace shows that the new ksh is writing \0\n where the old one just
writes \n.

The ksh issue is caused by it writing \0\n instead of just \n. User
wrote a kernel probe that intercepts writes and if it finds the new ksh
trying to write \0\n it replaces the \0 with a space. With that probe,
everything works fine. Without the probe, the problem returns.

Resolves: rhbz#1016611