### PR TITLE
Build static libraries by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('ksh93', 'c', default_options: ['b_lundef=false'])
+project('ksh93', 'c', default_options: ['b_lundef=false', 'default_library=static'])
 system = host_machine.system()
 
 run_command('bin/libast_prereq.sh')

--- a/src/lib/libast/meson.build
+++ b/src/lib/libast/meson.build
@@ -95,4 +95,4 @@ libast = library('ast', libast_files,
                  include_directories: incdir,
                  c_args: libast_c_args,
                  dependencies: [libm_dep, libiconv_dep, libcatgets_dep],
-                 install: true)
+                 install: get_option('default_library') == 'shared')

--- a/src/lib/libcmd/meson.build
+++ b/src/lib/libcmd/meson.build
@@ -8,4 +8,4 @@ incdir = include_directories('../libast/include', '../libast/features/')
 libcmd = library('cmd', libcmd_files, c_args: libcmd_c_args,
                  include_directories: incdir,
                  link_with: libast,
-                 install: true)
+                 install: get_option('default_library') == 'shared')

--- a/src/lib/libcoshell/meson.build
+++ b/src/lib/libcoshell/meson.build
@@ -14,4 +14,4 @@ libcoshell = library('coshell', libcoshell_files,
                      include_directories: libcoshell_incdir,
                      c_args: libcoshell_c_args,
                      link_with: libast,
-                     install: true)
+                     install: get_option('default_library') == 'shared')


### PR DESCRIPTION
Since most of the systems we care about build static libraries by
default we should do the same. For building dynamic libraries you
can manually set 'default_library=shared' user option on command
line:

meson -Ddefault_library=shared build

Resolves: #379