### PR TITLE
Replace several memcmp() calls with strncmp()

### DIFF
--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -574,7 +574,7 @@ static ssize_t fmtbase64(Shell_t *shp, Sfio_t *iop, char *string, const char *fm
     } else if (nv_isarray(np) && (ap = nv_arrayptr(np)) && array_elem(ap) &&
                (ap->flags & (ARRAY_UNDEF | ARRAY_SCAN))) {
         Namval_t *nspace = shp->namespace;
-        if (*string == '.' && memcmp(string, ".sh.", 4)) shp->namespace = shp->last_table;
+        if (*string == '.' && strncmp(string, ".sh.", 4)) shp->namespace = shp->last_table;
         nv_outnode(np, iop, (alt ? -1 : 0), 0);
         sfputc(iop, ')');
         shp->namespace = nspace;
@@ -582,13 +582,13 @@ static ssize_t fmtbase64(Shell_t *shp, Sfio_t *iop, char *string, const char *fm
     } else {
         Namval_t *nspace = shp->namespace;
         if (alt == 1 && nv_isvtree(np)) nv_onattr(np, NV_EXPORT);
-        if (fmt && memcmp(fmt, "json", 4) == 0) nv_onattr(np, NV_JSON);
+        if (fmt && strncmp(fmt, "json", 4) == 0) nv_onattr(np, NV_JSON);
         if (*string == '.') shp->namespace = 0;
         cp = nv_getval(np);
         if (*string == '.') shp->namespace = nspace;
         if (alt == 1) {
             nv_offattr(np, NV_EXPORT);
-        } else if (fmt && memcmp(fmt, "json", 4) == 0) {
+        } else if (fmt && strncmp(fmt, "json", 4) == 0) {
             nv_offattr(np, NV_JSON);
         }
 

--- a/src/cmd/ksh93/bltins/test.c
+++ b/src/cmd/ksh93/bltins/test.c
@@ -382,7 +382,7 @@ int test_unop(Shell_t *shp, int op, const char *arg) {
         }
         case 'a':
         case 'e': {
-            if (memcmp(arg, "/dev/", 5) == 0 && sh_open(arg, O_NONBLOCK)) return (1);
+            if (strncmp(arg, "/dev/", 5) == 0 && sh_open(arg, O_NONBLOCK)) return (1);
             return permission(arg, F_OK);
         }
         case 'o': {

--- a/src/cmd/ksh93/bltins/trap.c
+++ b/src/cmd/ksh93/bltins/trap.c
@@ -302,7 +302,7 @@ static int sig_number(Shell_t *shp, const char *string) {
             sfputc(shp->stk, c);
         } while (c);
         stkseek(shp->stk, o);
-        if (memcmp(stkptr(shp->stk, o), "SIG", 3) == 0) {
+        if (strncmp(stkptr(shp->stk, o), "SIG", 3) == 0) {
             sig = 1;
             o += 3;
             if (isdigit(*stkptr(shp->stk, o))) {

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -579,7 +579,7 @@ static int setall(char **argv, int flag, Dt_t *troot, struct tdata *tp) {
                     if (!np) {
                         if (np = nv_search(name, troot, 0)) {
                             if (!is_afunction(np)) np = 0;
-                        } else if (memcmp(name, ".sh.math.", 9) == 0 && sh_mathstd(name + 9)) {
+                        } else if (strncmp(name, ".sh.math.", 9) == 0 && sh_mathstd(name + 9)) {
                             continue;
                         }
                     }

--- a/src/cmd/ksh93/sh/expand.c
+++ b/src/cmd/ksh93/sh/expand.c
@@ -157,7 +157,7 @@ int path_expand(Shell_t *shp, const char *pattern, struct argnod **arghead) {
     if (suflen) gp->gl_suffix = sufstr;
     gp->gl_intr = &shp->trapnote;
     suflen = 0;
-    if (memcmp(pattern, "~(N", 3) == 0) flags &= ~GLOB_NOCHECK;
+    if (strncmp(pattern, "~(N", 3) == 0) flags &= ~GLOB_NOCHECK;
     glob(pattern, flags, 0, gp);
 #if SHOPT_BASH
     if (off) {

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -1043,7 +1043,7 @@ static char *get_math(Namval_t *np, Namfun_t *fp) {
     fake.nvname = ".sh.math.";
     mp = (Namval_t *)dtprev(shp->fun_tree, &fake);
     while ((mp = (Namval_t *)dtnext(shp->fun_tree, mp))) {
-        if (memcmp(mp->nvname, ".sh.math.", 9)) break;
+        if (strncmp(mp->nvname, ".sh.math.", 9)) break;
         if (first++) sfputc(shp->strbuf, ' ');
         sfputr(shp->strbuf, mp->nvname + 9, -1);
     }

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -2470,7 +2470,7 @@ Sfio_t *sh_pathopen(Shell_t *shp, const char *cp) {
 Sfio_t *sh_pathopen(const char *cp) { return (sh_pathopen_20120720(sh_getinterp(), cp)); }
 
 bool sh_isdevfd(const char *fd) {
-    if (!fd || memcmp(fd, "/dev/fd/", 8) || fd[8] == 0) return false;
+    if (!fd || strncmp(fd, "/dev/fd/", 8) || fd[8] == 0) return false;
     for (fd = &fd[8]; *fd != '\0'; fd++) {
         if (*fd < '0' || *fd > '9') return false;
     }

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -1239,7 +1239,7 @@ breakloop:
         lp->arg->argflag |= ARG_ASSIGN;
         if (sh_isoption(shp, SH_NOEXEC)) {
             char *cp = strchr(state, '=');
-            if (cp && memcmp(++cp, "$((", 3) == 0) {
+            if (cp && strncmp(++cp, "$((", 3) == 0) {
                 errormsg(SH_DICT, ERROR_warn(0), e_lexarithwarn, shp->inlineno, cp - state, state,
                          cp + 3, state);
             }
@@ -1430,9 +1430,9 @@ static int comsub(Lex_t *lp, int endtok) {
                 word[n++] = c;
             }
             if (sh_lexstates[ST_NAME][c] == S_BREAK) {
-                if (memcmp(word, "case", 4) == 0) {
+                if (strncmp(word, "case", 4) == 0) {
                     lp->lex.incase = 1;
-                } else if (memcmp(word, "esac", 4) == 0) {
+                } else if (strncmp(word, "esac", 4) == 0) {
                     lp->lex.incase = 0;
                 }
             }

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -992,7 +992,7 @@ Namval_t *nv_create(const char *name, Dt_t *root, int flags, Namfun_t *dp) {
                                 nv_onattr(np, nofree);
                                 nofree = 0;
                                 np = nq;
-                            } else if (memcmp(cp, "[0]", 3)) {
+                            } else if (strncmp(cp, "[0]", 3)) {
                                 return nq;
                             } else {
                                 // Ignore [0].

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -179,7 +179,7 @@ static void check_typedef(Lex_t *lp, struct comnod *tp) {
     if (tp->comtyp & COMSCAN) {
         struct argnod *ap = tp->comarg;
         while ((ap = ap->argnxt.ap)) {
-            if (!(ap->argflag & ARG_RAW) || memcmp(ap->argval, "--", 2)) break;
+            if (!(ap->argflag & ARG_RAW) || strncmp(ap->argval, "--", 2)) break;
             if (lp->intypeset == 2) {
                 if (*ap->argval == '-') {
                     continue;
@@ -188,7 +188,7 @@ static void check_typedef(Lex_t *lp, struct comnod *tp) {
                 }
             }
             if (sh_isoption(lp->sh, SH_NOEXEC)) typeset_order(ap->argval, tp->comline);
-            if (memcmp(ap->argval, "-T", 2) == 0) {
+            if (strncmp(ap->argval, "-T", 2) == 0) {
                 if (ap->argval[2]) {
                     cp = ap->argval + 2;
                 } else if ((ap->argnxt.ap)->argflag & ARG_RAW) {
@@ -200,13 +200,13 @@ static void check_typedef(Lex_t *lp, struct comnod *tp) {
     } else {
         struct dolnod *dp = (struct dolnod *)tp->comarg;
         char **argv = dp->dolval + dp->dolbot + 1;
-        while ((cp = *argv++) && memcmp(cp, "--", 2)) {
+        while ((cp = *argv++) && strncmp(cp, "--", 2)) {
             if (lp->intypeset == 2) {
                 if (*cp == '-') continue;
                 break;
             }
             if (sh_isoption(lp->sh, SH_NOEXEC)) typeset_order(cp, tp->comline);
-            if (memcmp(cp, "-T", 2) == 0) {
+            if (strncmp(cp, "-T", 2) == 0) {
                 if (cp[2]) {
                     cp = cp + 2;
                 } else {
@@ -762,7 +762,7 @@ static Shnode_t *funct(Lex_t *lexp) {
             if (c) errormsg(SH_DICT, ERROR_exit(3), e_lexsyntax4, lexp->sh->inlineno);
             nargs = argv - argv0;
             size += sizeof(struct dolnod) + (nargs + ARG_SPARE) * sizeof(char *);
-            if (shp->shcomp && memcmp(".sh.math.", t->funct.functnam, 9) == 0) {
+            if (shp->shcomp && strncmp(".sh.math.", t->funct.functnam, 9) == 0) {
                 Namval_t *np = nv_open(t->funct.functnam, shp->fun_tree, NV_ADD | NV_VARNAME);
                 np->nvalue.rp = new_of(struct Ufunction, shp->funload ? sizeof(Dtlink_t) : 0);
                 memset((void *)np->nvalue.rp, 0, sizeof(struct Ufunction));
@@ -1331,7 +1331,7 @@ static Shnode_t *simple(Lex_t *lexp, int flag, struct ionod *io) {
             *settail = argp;
             settail = &(argp->argnxt.ap);
             lexp->assignok = (flag & SH_ASSIGN) ? SH_ASSIGN : 1;
-            if (memcmp(argp->argval, ".sh.value", 9) == 0) opt_get |= FSHVALUE;
+            if (strncmp(argp->argval, ".sh.value", 9) == 0) opt_get |= FSHVALUE;
             if (assignment) {
                 struct argnod *ap = argp;
                 char *last, *cp;

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -1386,7 +1386,7 @@ static bool path_chkpaths(Shell_t *shp, Pathcomp_t *first, Pathcomp_t *old, Path
             }
             *cp = 0;
             m = ep ? (ep - sp) : 0;
-            if (m == 0 || (m == 6 && memcmp((void *)sp, (void *)"FPATH=", m) == 0)) {
+            if (m == 0 || (m == 6 && strncmp(sp, "FPATH=", m) == 0)) {
                 if (first) {
                     char *ptr = stkptr(shp->stk, offset + pp->len + 1);
                     size_t len = strlen(ep);
@@ -1394,10 +1394,10 @@ static bool path_chkpaths(Shell_t *shp, Pathcomp_t *first, Pathcomp_t *old, Path
                     path_addcomp(shp, first, old, stkptr(shp->stk, offset),
                                  PATH_FPATH | PATH_BFPATH);
                 }
-            } else if (m == 11 && memcmp((void *)sp, (void *)"PLUGIN_LIB=", m) == 0) {
+            } else if (m == 11 && strncmp(sp, "PLUGIN_LIB=", m) == 0) {
                 if (pp->bbuf) free(pp->bbuf);
                 pp->blib = pp->bbuf = strdup(ep);
-            } else if (m == 4 && memcmp((void *)sp, (void *)"BIN=1", m) == 0) {
+            } else if (m == 4 && strncmp(sp, "BIN=1", m) == 0) {
                 pp->flags |= PATH_BIN;
             } else if (m) {
                 size_t z;

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1371,7 +1371,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                                 char *ep;
                                 bool type = 0;
                                 cp = np->nvname + 1;
-                                if (memcmp(cp, "sh.type.", 8) == 0) {
+                                if (strncmp(cp, "sh.type.", 8) == 0) {
                                     cp += 8;
                                     type = true;
                                 }


### PR DESCRIPTION
While running code through asan I noticed that ksh uses memcmp() instead
of strncmp() to compare strings which can cause invalid reads.

Since memcmp() slightly varies in behavior (it does not stop comparing
on NULL) I have only replaced those memcmp() calls with strncmp() which
compare hardcoded ascii strings. Rest of the calls should be checked
and replaced with strncmp() if they only compare ascii strings.