### PR TITLE
Fix posix_spawn feature test

### DIFF
--- a/features/meson.build
+++ b/features/meson.build
@@ -275,7 +275,11 @@ posix_spawn_feature_file = files('posix_spawn.c')
 posix_spawn_feature_result = cc.run(posix_spawn_feature_file,
                                     name: 'posix_spawn exists and it works and its worth using',
                                     args: feature_test_args)
-feature_data.set('_lib_posix_spawn', posix_spawn_feature_result.returncode())
+if posix_spawn_feature_result.returncode() == 0
+    feature_data.set('_lib_posix_spawn', 1)
+else
+    feature_data.set('_lib_posix_spawn', 0)
+endif
 
 newgrp = find_program('newgrp', required: false)
 if newgrp.found()

--- a/features/posix_spawn.c
+++ b/features/posix_spawn.c
@@ -7,6 +7,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 // If it uses fork() why bother?
 #undef fork
@@ -23,60 +24,60 @@ pid_t __fork(void) {
     return -1;
 }
 
+// Exits with status 0 if posix_spawn works, non-zero otherwise
 int main(int argc, char **argv) {
 #if __CYGWIN__
     // Not only does it not work it causes the meson configure step to
     // take tens or minutes to complete and results in a huge cascade
     // of child processes.
     printf("Cygwin doesn't have a working posix_spawn()\n");
-    _exit(0);
+    _exit(30);
 #else   // __CYGWIN__
     char *s;
     pid_t pid;
     posix_spawnattr_t attr;
     int n;
     int status;
-    char *cmd[4];
+    char *cmd[3];
     char tmp[1024];
-    if (argv[2]) {
+    if (argc > 1) {
         _exit(signal(SIGHUP, SIG_DFL) != SIG_IGN);
     }
     signal(SIGHUP, SIG_IGN);
     if (posix_spawnattr_init(&attr)) {
         printf("posix_spawnattr_init() FAILED\n");
-        _exit(0);
+        _exit(2);
     }
     if (posix_spawnattr_setpgroup(&attr, 0)) {
         printf("posix_spawnattr_setpgroup() FAILED\n");
-        _exit(0);
+        _exit(3);
     }
     if (posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETPGROUP)) {
         printf("posix_spawnattr_setflags() FAILED\n");
-        _exit(0);
+        _exit(4);
     }
     /* first try an a.out and verify that SIGHUP is ignored */
     cmd[0] = argv[0];
-    cmd[1] = argv[1];
-    cmd[2] = "test";
-    cmd[3] = 0;
+    cmd[1] = "test";
+    cmd[2] = 0;
     if (posix_spawn(&pid, cmd[0], 0, &attr, cmd, 0)) {
         printf("posix_spawn() FAILED\n");
-        _exit(0);
+        _exit(5);
     }
     status = 1;
     if (wait(&status) < 0) {
         printf("wait() FAILED\n");
-        _exit(0);
+        _exit(6);
     }
     if (status != 0) {
         printf("SIGHUP ignored in parent not ignored in child\n");
-        _exit(0);
+        _exit(7);
     }
     /* must return exec-type errors or its useless to us *unless* there is no [v]fork() */
     n = strlen(cmd[0]);
     if (n >= (sizeof(tmp) - 3)) {
         printf("test executable path too long\n");
-        _exit(0);
+        _exit(8);
     }
     strcpy(tmp, cmd[0]);
     tmp[n] = '.';
@@ -87,35 +88,38 @@ int main(int argc, char **argv) {
         chmod(tmp, S_IRWXU | S_IRWXG | S_IRWXO) < 0 || write(n, "exit 99\n", 8) != 8 ||
         close(n) < 0) {
         printf("test script create FAILED\n");
-        _exit(0);
+        _exit(9);
     }
     cmd[0] = tmp;
-    n = 0; /* 0 means reject */
     pid = -1;
     if (posix_spawn(&pid, cmd[0], 0, &attr, cmd, 0)) {
-        n = 2;
         printf("ENOEXEC produces posix_spawn() error (BEST)\n");
+        _exit(0);
     } else if (pid == -1) {
         printf("ENOEXEC returns pid == -1\n");
-}
-else if (wait(&status) != pid) {
-    printf("ENOEXEC produces no child process\n");
-}
-else if (!WIFEXITED(status)) {
-    printf("ENOEXEC produces signal exit\n");
-}
-else {
-    status = WEXITSTATUS(status);
-    if (status == 127) {
-        n = 1;
-        printf("ENOEXEC produces exit status 127 (GOOD)\n");
-    } else if (status == 99)
-        printf("ENOEXEC invokes sh\n");
-    else if (status == 0)
-        printf("ENOEXEC reports no error\n");
-    else
-        printf("ENOEXEC produces non-zero exit status\n");
-}
-_exit(n);
+        _exit(10);
+    } else if (wait(&status) != pid) {
+        printf("ENOEXEC produces no child process\n");
+        _exit(11);
+    } else if (!WIFEXITED(status)) {
+        printf("ENOEXEC produces signal exit\n");
+        _exit(12);
+    } else {
+        status = WEXITSTATUS(status);
+        if (status == 127) {
+            printf("ENOEXEC produces exit status 127 (GOOD)\n");
+            _exit(1);
+        } else if (status == 99) {
+            printf("ENOEXEC invokes sh\n");
+            _exit(13);
+        } else if (status == 0) {
+            printf("ENOEXEC reports no error\n");
+            _exit(14);
+        } else {
+            printf("ENOEXEC produces non-zero exit status\n");
+            _exit(15);
+        }
+    }
+    _exit(20);
 #endif  // __CYGWIN__
 }

--- a/src/lib/libast/misc/spawnvex.c
+++ b/src/lib/libast/misc/spawnvex.c
@@ -696,7 +696,7 @@ bad:
                              | VEXFLAG(SPAWN_umask)
 #endif
                                  ))
-#if _lib_posix_spawn < 2
+#if !_lib_posix_spawn
                 || !(vex->flags & SPAWN_EXEC)
 #endif
                     )) {


### PR DESCRIPTION
Include <unistd.h> for _exit(2) and close(2).
Shorten argv since meson's run() does not pass any arguments.
Rework exit codes for better output from meson.