### PR TITLE
Fix various implicit declarations

### DIFF
--- a/config_ast.h.in
+++ b/config_ast.h.in
@@ -153,6 +153,7 @@
 #mesondefine _hdr_stdlib
 #mesondefine _hdr_string
 #mesondefine _hdr_stropts
+#mesondefine _hdr_sys_sysmacros
 #mesondefine _hdr_termio
 #mesondefine _hdr_termios
 #mesondefine _hdr_time

--- a/features/meson.build
+++ b/features/meson.build
@@ -66,6 +66,10 @@ if cc.has_header('termios.h', args: feature_test_args)
     feature_data.set('_hdr_termios', 1)
 endif
 
+if cc.has_header('sys/sysmacros.h', args: feature_test_args)
+    feature_data.set('_hdr_sys_sysmacros', 1)
+endif
+
 if cc.has_header('utmp.h', args: feature_test_args)
     feature_data.set('_hdr_utmp', 1)
 endif

--- a/features/meson.build
+++ b/features/meson.build
@@ -93,7 +93,7 @@ elif cc.has_function('utimets', prefix: '#include <sys/stat.h>', args: feature_t
     feature_data.set('_lib_utimets', 1)
 endif
 
-if cc.has_function('sysinfo', prefix: '#include <sys/sysinfo.h>', args: feature_test_args)
+if cc.has_function('sysinfo', prefix: '#include <sys/systeminfo.h>', args: feature_test_args)
     feature_data.set('_lib_sysinfo', 1)
 endif
 

--- a/features/stack_direction.c
+++ b/features/stack_direction.c
@@ -1,5 +1,5 @@
 // This is a Meson config stage feature test for stack growth direction.
-static growdown() {
+static int growdown() {
     static char *addr = 0;
     char array[4];
     if (!addr) {

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,11 @@ if system == 'openbsd'
     add_global_arguments('-I/usr/local/include', language: 'c')
 endif
 
+# Error on implicit declarations.
+if cc.has_argument('-Werror=implicit')
+    add_global_arguments('-Werror=implicit', language: 'c')
+endif
+
 shared_c_args = [
     '-DUSAGE_LICENSE=""',
 ]

--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -26,6 +26,7 @@
 #include "config_ast.h"  // IWYU pragma: keep
 
 #include <time.h>
+#include <times.h>
 
 //
 // Each command in the history file starts on an even byte is null terminated. The first byte must

--- a/src/cmd/ksh93/edit/pcomplete.c
+++ b/src/cmd/ksh93/edit/pcomplete.c
@@ -207,7 +207,7 @@ static bool keywords(Sfio_t *out) {
 }
 
 // Write wordlist to stack splitting on IFS, one word per line.
-static gen_wordlist(Sfio_t *iop, const char *word) {
+static void gen_wordlist(Sfio_t *iop, const char *word) {
     const char *ifs = nv_getval(IFSNOD);
     char c, n = 0;
 

--- a/src/lib/libast/include/ast_ioctl.h
+++ b/src/lib/libast/include/ast_ioctl.h
@@ -24,6 +24,10 @@
 
 #include <sys/ioctl.h>
 
+#ifndef _AST_INTERCEPT_IMPLEMENT
+#define _AST_INTERCEPT_IMPLEMENT 1
+#endif
+
 #if _AST_INTERCEPT_IMPLEMENT < 2
 
 #undef ioctl

--- a/src/lib/libast/port/astconf.c
+++ b/src/lib/libast/port/astconf.c
@@ -34,6 +34,9 @@
 #include <ls.h>
 #include <proc.h>
 #include <regex.h>
+#if _lib_sysinfo
+#include <sys/systeminfo.h>
+#endif
 #include <sys/utsname.h>
 
 #include "conftab.h"

--- a/src/lib/libast/port/intercept.c
+++ b/src/lib/libast/port/intercept.c
@@ -30,6 +30,8 @@
 #include <aso.h>
 #include <ast_ioctl.h>
 #include <error.h>
+#include <fcntl.h>
+#include <stdio.h>
 #include <sys/socket.h>
 
 static const char dot[] = ".";

--- a/src/lib/libast/string/fmtdev.c
+++ b/src/lib/libast/string/fmtdev.c
@@ -30,6 +30,9 @@
 #include <ast.h>
 #include <ctype.h>
 #include <ls.h>
+#if _hdr_sys_sysmacros
+#include <sys/sysmacros.h>
+#endif
 
 char *fmtdev(struct stat *st) {
     char *buf;


### PR DESCRIPTION
This series of commits fixes the errors that occur when building with `CFLAGS="-Werror=implicit"`. Implicit declarations can cause nasty runtime bugs.