### PR TITLE
Fix a memory leak in executing subshell if PATH is reset

### DIFF
--- a/src/cmd/ksh93/include/name.h
+++ b/src/cmd/ksh93/include/name.h
@@ -31,6 +31,7 @@
 #include <cdt.h>
 
 typedef int (*Nambfp_f)(int, char **, void *);
+struct pathcomp;
 
 // Nodes can have all kinds of values.
 union Value {
@@ -55,6 +56,7 @@ union Value {
     struct Namfun *funp;     // discipline pointer
     struct Namref *nrp;      // name reference
     Nambfp_f bfp;            // builtin entry point function pointer
+    struct pathcomp *pathcomp;
 };
 
 #include "nval.h"

--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -90,7 +90,7 @@ all_tests = [
     ['basic', 90], ['bracket'], ['builtins'], ['case'], ['comvar'],
     ['comvario'], ['coprocess', 50], ['cubetype'], ['directoryfd'], ['enum'],
     ['exit'], ['expand'], ['functions'], ['glob'], ['grep'], ['heredoc'],
-    ['io'], ['leaks', 60], ['locale'], ['math', 50], ['nameref'], ['namespace'],
+    ['io'], ['leaks', 180], ['locale'], ['math', 50], ['nameref'], ['namespace'],
     ['options'], ['path'], ['pointtype'], ['pty'], ['quoting'], ['quoting2'],
     ['readcsv'], ['recttype'], ['restricted'], ['return'], ['select'],
     ['sh_match'], ['sigchld', 100], ['signal', 100], ['statics'], ['subshell', 100],

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -1613,8 +1613,13 @@ void path_alias(Namval_t *np, Pathcomp_t *pp) {
         Shell_t *shp = sh_ptr(np);
         struct stat statb;
         char *sp;
+        Pathcomp_t *old;
         nv_offattr(np, NV_NOPRINT);
         nv_stack(np, &talias_init);
+        old = np->nvalue.pathcomp;
+        if (old && (--old->refcount <= 0)) {
+            free(old);
+        }
         np->nvalue.cp = (char *)pp;
         pp->refcount++;
         nv_setattr(np, NV_TAGGED | NV_NOFREE);

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -81,7 +81,6 @@ do
         if [ -d ${DIR} ]
         then
             PATH=${PATH}:${DIR}
-            true
         fi
         time=$(date +%T)
     done

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -70,6 +70,30 @@ then
     err_exit "Memory leak on associative array"
 fi
 
+# Test for leak in executing subshell after PATH is reset
+init_vsz=$(ps -o vsz $$ | tail -n 1 | tr -d '\n')
+
+for (( i=0; i<10000; i++ ))
+do
+    PATH=.
+    for DIR in /usr/bin /usr/sbin /bin /usr/local/bin
+    do
+        if [ -d ${DIR} ]
+        then
+            PATH=${PATH}:${DIR}
+            true
+        fi
+        time=$(date +%T)
+    done
+done
+
+curr_vsz=$(ps -o vsz $$ | tail -n 1 | tr -d '\n')
+
+if [[ $init_vsz -lt $curr_vsz ]];
+then
+    err_exit "Memory leak in executing subshell after PATH is reset"
+fi
+
 #TODO: Enable these tests when vmstate is a builtin
 
 #builtin vmstate 2>/dev/null || exit 0


### PR DESCRIPTION
Also, added test case for same.

Resolves: rhbz#1324990