### PR TITLE
Enable malloc debug features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
         echo ==== Running unit tests;
         ulimit -n 1024;
         export MESON_TESTTHREADS=$(( 4 * CORE_COUNT ));
-        if ! meson test; then cat meson-logs/testlog.txt; exit 1; fi;
+        if ! meson test --setup=malloc; then cat meson-logs/testlog.txt; exit 1; fi;
         "
 
     - chmod a+x build.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,10 +275,14 @@ by the project. To run the tests:
 
 ```
 cd build
-meson test
+meson test --setup=malloc
 ```
 
-To run a specific test include its name: `meson test types`.
+To run a specific test include its name: `meson test --setup=malloc types`.
+
+The `--setup=malloc` will enable malloc integrity features provided by your
+system's malloc implementation if it supports such things via environment
+variables. That flag can be ommitted but its use is recommended.
 
 ### Testing with Valgrind
 

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,27 @@ add_global_arguments('-D_GNU_SOURCE', language: 'c')
 # in an array that will be used by the feature tests.
 feature_test_args = ['-std=gnu99', '-D_GNU_SOURCE']
 
+# Enable malloc debug options for macOS, GNU, FreeBSD, and other
+# implementations. This isn't a replacement for Valgrind or Asan but is useful
+# for detecting problems without incurring the overhead of those tools.
+#
+# To use these add `--setup=malloc` to your `meson test` command.
+#
+malloc_debug_env = environment()
+# These env vars are recognized by GNU malloc.
+malloc_debug_env.set('MALLOC_CHECK_', '3')
+# These env vars are recognized by macOS malloc.
+malloc_debug_env.set('MallocGuardEdges', '1')
+malloc_debug_env.set('MallocScribble', '1')
+malloc_debug_env.set('MallocErrorAbort', '1')
+# These env vars are recognized by jemalloc as used by FreeBSD, OpenBSD, and
+# other distros.  See https://github.com/jemalloc/jemalloc/wiki/Getting-Started.
+# The "junk=true" setting enables setting both allocated and freed memory to
+# "0xA5" and "0x5A" respectively (other than, obviously, `calloc()`'d memory).
+malloc_debug_env.set('MALLOC_CONF', 'junk:true')
+# Add a malloc specific test setup environment.
+add_test_setup('malloc', env: malloc_debug_env)
+
 cc = meson.get_compiler('c')
 system = host_machine.system()
 # So the `config_ast.h` header can be found (see below).


### PR DESCRIPTION
This enables malloc debugging features provided by various
implementations. This is only really useful when issue #396 is resolved
so that `ksh` no longer uses the AST Vmalloc subsystem. I'm recommending
merging this now to to make it obvious that any bugs involving the use
of the native malloc subsystem are caught sooner rather than later.