### PR TITLE
Replace several memcmp() calls with strncmp()

### DIFF
--- a/src/cmd/ksh93/bltins/mkservice.c
+++ b/src/cmd/ksh93/bltins/mkservice.c
@@ -301,7 +301,7 @@ static char *setdisc(Namval_t *np, const char *event, Namval_t *action, Namfun_t
     Namval_t *nq;
 
     for (i = 0; (cp = disctab[i]); i++) {
-        if (memcmp(event, cp, n)) continue;
+        if (strncmp(event, cp, n)) continue;
         if (action == np) {
             action = sp->disc[i];
         } else {

--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -630,7 +630,7 @@ static int varname(const char *str, ssize_t n) {
 static const char *mapformat(Sffmt_t *fe) {
     const struct printmap *pm = Pmap;
     while (pm->size > 0) {
-        if (pm->size == fe->n_str && memcmp(pm->name, fe->t_str, fe->n_str) == 0) return pm->map;
+        if (pm->size == fe->n_str && strncmp(pm->name, fe->t_str, fe->n_str) == 0) return pm->map;
         pm++;
     }
     return 0;

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -1382,7 +1382,7 @@ static void print_scan(Sfio_t *file, int flag, Dt_t *root, int option, struct td
                 onp = np;
                 if (name) {
                     char *newname = nv_name(np);
-                    if (memcmp(name, newname, len) == 0 && newname[len] == '.') continue;
+                    if (strncmp(name, newname, len) == 0 && newname[len] == '.') continue;
                     name = 0;
                 }
                 if (flag & NV_ARRAY) {

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -1363,7 +1363,7 @@ int ed_histgen(Edit_t *ep, const char *pattern) {
     sfsprintf(cp, m, "@(%s)*%c", pattern, 0);
     if (ep->hlist) {
         m = strlen(ep->hpat) - 4;
-        if (memcmp(pattern, ep->hpat + 2, m) == 0) {
+        if (strncmp(pattern, ep->hpat + 2, m) == 0) {
             n = strcmp(cp, ep->hpat) == 0;
             for (argv = av = (char **)ep->hlist, mp = ep->hfirst; mp; mp = mp->next) {
                 if (n || strmatch(mp->data, cp)) *av++ = (char *)mp;

--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -884,7 +884,7 @@ int hist_match(History_t *hp, off_t offset, char *string, int *coffset) {
     m = sfvalue(hp->histfp);
     n = (int)strlen(string);
     while (m > n) {
-        if (*cp == *string && memcmp(cp, string, n) == 0) {
+        if (*cp == *string && strncmp(cp, string, n) == 0) {
             if (coffset) *coffset = (cp - first);
             return line;
         }

--- a/src/cmd/ksh93/edit/pcomplete.c
+++ b/src/cmd/ksh93/edit/pcomplete.c
@@ -404,7 +404,7 @@ again:
     sfseek(tmp, (Sfoff_t)0, SEEK_SET);
     while (str = sfgetr(tmp, '\n', 0)) {
         wlen = sfvalue(tmp) - 1;
-        if (prefix && memcmp(prefix, str, len)) continue;
+        if (prefix && strncmp(prefix, str, len)) continue;
         if (filter) {
             str[wlen] = 0;
             i = strmatch(str, filter);

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -1652,7 +1652,7 @@ static int curline_search(Vi_t *vp, const char *string) {
 
     ed_external(vp->u_space, (char *)vp->u_space);
     for (dp = (char *)vp->u_space, dpmax = dp + strlen(dp) - len; dp <= dpmax; dp++) {
-        if (*dp == *cp && memcmp(cp, dp, len) == 0) return (dp - (char *)vp->u_space);
+        if (*dp == *cp && strncmp(cp, dp, len) == 0) return (dp - (char *)vp->u_space);
     }
     ed_internal((char *)vp->u_space, vp->u_space);
     return -1;

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -676,9 +676,9 @@ static void astbin_update(Shell_t *shp, const char *from, const char *to) {
     for (np = (Namval_t *)dtfirst(shp->bltin_tree); np;
          np = (Namval_t *)dtnext(shp->bltin_tree, np)) {
         flen = len;
-        if (bin && memcmp(from + 4, np->nvname, len - 4) == 0) {
+        if (bin && strncmp(from + 4, np->nvname, len - 4) == 0) {
             flen -= 4;
-        } else if (memcmp(from, np->nvname, len)) {
+        } else if (strncmp(from, np->nvname, len)) {
             continue;
         }
         nv_onattr(np, BLT_DISABLE);

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -284,7 +284,7 @@ int job_cowalk(int (*fun)(struct process *, int), int arg, char *name) {
         n = cp - name;
     }
     for (csp = (struct cosh *)job.colist; csp; csp = csp->next) {
-        if (memcmp(name, csp->name, n) == 0 && csp->name[n] == 0) break;
+        if (strncmp(name, csp->name, n) == 0 && csp->name[n] == 0) break;
     }
     if (!csp) errormsg(SH_DICT, ERROR_exit(1), e_jobusage, name);
     if (cp) {

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -182,10 +182,10 @@ Namval_t *nv_addnode(Namval_t *np, int remove) {
         nv_delete(np, root, NV_NOFREE);
         np = nv_search(sp->rp->nvname, root, NV_ADD);
     }
-    if (sp->numnodes && memcmp(np->nvname, NV_CLASS, sizeof(NV_CLASS) - 1)) {
+    if (sp->numnodes && strncmp(np->nvname, NV_CLASS, sizeof(NV_CLASS) - 1)) {
         name = (sp->nodes[0])->nvname;
         i = strlen(name);
-        if (memcmp(np->nvname, name, i)) return (np);
+        if (strncmp(np->nvname, name, i)) return (np);
     }
     if (sp->rp && sp->numnodes) {
         // Check for a redefine.
@@ -231,7 +231,7 @@ struct argnod *nv_onlist(struct argnod *arg, const char *name) {
         } else {
             cp = arg->argval;
         }
-        if (memcmp(cp, name, len) == 0 && (cp[len] == 0 || cp[len] == '=')) return (arg);
+        if (strncmp(cp, name, len) == 0 && (cp[len] == 0 || cp[len] == '=')) return (arg);
     }
     return 0;
 }
@@ -856,7 +856,7 @@ Namval_t *nv_create(const char *name, Dt_t *root, int flags, Namfun_t *dp) {
                             xlen = strlen(xp);
                         }
                         cp = nv_name(np);
-                        if (xp && memcmp(cp, xp, xlen) && cp[xlen] == '.') cp += xlen + 1;
+                        if (xp && strncmp(cp, xp, xlen) && cp[xlen] == '.') cp += xlen + 1;
                         copy = strlen(cp);
                         dp->nofree |= 1;
                         name = copystack(shp, cp, sp, sub);
@@ -1217,7 +1217,7 @@ Namval_t *nv_open(const char *name, Dt_t *root, int flags) {
         if (xp->root != root) continue;
         if ((*name != '_' || name[1] != '.') && *name == *xp->name &&
             xp->namespace == shp->namespace && (flags & (NV_ARRAY | NV_NOSCOPE)) == xp->flags &&
-            memcmp(xp->name, name, xp->len) == 0 &&
+            strncmp(xp->name, name, xp->len) == 0 &&
             (name[xp->len] == 0 || name[xp->len] == '=' || name[xp->len] == '+')) {
             sh_stats(STAT_NVHITS);
             np = xp->np;
@@ -1977,7 +1977,7 @@ static int scanfilter(Dt_t *dict, void *arg, void *data) {
         if (tp && tp->mapname) {
             if (sp->scanflags == NV_FUNCTION || sp->scanflags == (NV_NOFREE | NV_BINARY | NV_RAW)) {
                 int n = strlen(tp->mapname);
-                if (memcmp(np->nvname, tp->mapname, n) || np->nvname[n] != '.' ||
+                if (strncmp(np->nvname, tp->mapname, n) || np->nvname[n] != '.' ||
                     strchr(&np->nvname[n + 1], '.')) {
                     return 0;
                 }
@@ -2113,7 +2113,7 @@ static void table_unset(Shell_t *shp, Dt_t *root, int flags, Dt_t *oroot) {
         if (nv_isvtree(np)) {
             int len = strlen(np->nvname);
             npnext = (Namval_t *)dtnext(root, np);
-            while ((nq = npnext) && memcmp(np->nvname, nq->nvname, len) == 0 &&
+            while ((nq = npnext) && strncmp(np->nvname, nq->nvname, len) == 0 &&
                    nq->nvname[len] == '.') {
                 _nv_unset(nq, flags);
                 npnext = (Namval_t *)dtnext(root, nq);
@@ -2751,7 +2751,7 @@ static void cache_purge(const char *name) {
 
     for (c = 0, xp = nvcache.entries; c < NVCACHE; xp = &nvcache.entries[++c]) {
         if (xp->len <= len || xp->name[len] != '.') continue;
-        if (memcmp(name, xp->name, len) == 0) xp->root = 0;
+        if (strncmp(name, xp->name, len) == 0) xp->root = 0;
     }
 }
 #endif  // NVCACHE
@@ -3162,7 +3162,7 @@ char *nv_name(Namval_t *np) {
         if (shp->namespace && is_afunction(np)) {
             char *name = nv_name(shp->namespace);
             int n = strlen(name);
-            if (memcmp(np->nvname, name, n) == 0 && np->nvname[n] == '.') {
+            if (strncmp(np->nvname, name, n) == 0 && np->nvname[n] == '.') {
                 return np->nvname + n + 1;
             }
         }

--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -890,7 +890,7 @@ static char **genvalue(char **argv, const char *prefix, int n, struct Walk *wp) 
                 if (*argv) continue;
                 break;
             } else if (outfile && !wp->nofollow && argv[1] &&
-                       memcmp(arg, argv[1], l = strlen(arg)) == 0 && argv[1][l] == '[') {
+                       strncmp(arg, argv[1], l = strlen(arg)) == 0 && argv[1][l] == '[') {
                 int k = 1;
                 Namarr_t *aq = 0;
                 np = nv_open(arg, wp->root, NV_VARNAME | NV_NOADD | NV_NOASSIGN | wp->noscope);
@@ -933,7 +933,7 @@ static char **genvalue(char **argv, const char *prefix, int n, struct Walk *wp) 
                     }
                 }
                 if ((wp->flags & NV_JSON) &&
-                    (!argv[1] || strlen(argv[1]) < m + n || memcmp(argv[1], arg, m + n - 1))) {
+                    (!argv[1] || strlen(argv[1]) < m + n || strncmp(argv[1], arg, m + n - 1))) {
                     wp->flags |= NV_JSON_LAST;
                 }
                 outval(cp, arg, wp);
@@ -962,7 +962,7 @@ static char **genvalue(char **argv, const char *prefix, int n, struct Walk *wp) 
         if (c == '.') cp[m - 1] = c;
         if (wp->indent > 0) sfnputc(outfile, '\t', --wp->indent);
         sfputc(outfile, endchar);
-        if (json && wp->indent > 0 && *argv && memcmp(arg, argv[-1], n) == 0) sfputc(outfile, ',');
+        if (json && wp->indent > 0 && *argv && strncmp(arg, argv[-1], n) == 0) sfputc(outfile, ',');
         if (*argv && n && wp->indent < 0) sfputc(outfile, ';');
     }
     wp->flags &= ~NV_JSON_LAST;

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -1306,7 +1306,7 @@ static Pathcomp_t *path_addcomp(Shell_t *shp, Pathcomp_t *first, Pathcomp_t *old
         len = strlen(name);
     }
     for (pp = first; pp; pp = pp->next) {
-        if (len == pp->len && memcmp(name, pp->name, len) == 0) {
+        if (len == pp->len && strncmp(name, pp->name, len) == 0) {
             pp->flags |= flag;
             return first;
         }
@@ -1573,7 +1573,7 @@ Pathcomp_t *path_dirfind(Pathcomp_t *first, const char *name, int c) {
     Pathcomp_t *pp = first;
 
     while (pp) {
-        if (memcmp(name, pp->name, pp->len) == 0 && name[pp->len] == c) return pp;
+        if (strncmp(name, pp->name, pp->len) == 0 && name[pp->len] == c) return pp;
         pp = pp->next;
     }
     return NULL;

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -272,7 +272,7 @@ Namval_t *sh_assignok(Namval_t *np, int add) {
         while ((mp = mpnext)) {
             walk = root->walk ? root->walk : root;
             mpnext = dtnext(root, mp);
-            if (memcmp(name, mp->nvname, len) || mp->nvname[len] != '.') break;
+            if (strncmp(name, mp->nvname, len) || mp->nvname[len] != '.') break;
             nv_delete(mp, walk, NV_NOFREE);
             *((Namval_t **)mp) = lp->child;
             lp->child = mp;

--- a/src/lib/libast/path/pathcanon.c
+++ b/src/lib/libast/path/pathcanon.c
@@ -322,7 +322,7 @@ again:
                                         errno = EINVAL;
                                         goto nope;
                                     } else if (oflags[n].length == c &&
-                                               !memcmp(oflags[n].name, v, c)) {
+                                               !strncmp(oflags[n].name, v, c)) {
                                         if (!oflags[n].oflag) {
                                             errno = ENXIO;
                                             goto nope;

--- a/src/lib/libast/port/astconf.c
+++ b/src/lib/libast/port/astconf.c
@@ -320,7 +320,7 @@ static char *synthesize(Feature_t *fp, const char *path, const char *value) {
                 ;
             n = s - v;
             if ((!path ||
-                 *path == *p && strlen(path) == (v - p - 1) && !memcmp(path, p, v - p - 1)) &&
+                 *path == *p && strlen(path) == (v - p - 1) && !strncmp(path, p, v - p - 1)) &&
                 strneq(v, value, n))
                 goto ok;
             for (; isspace(*s); s++)

--- a/src/lib/libast/port/mc.c
+++ b/src/lib/libast/port/mc.c
@@ -210,7 +210,7 @@ Mc_t *mcopen(Sfio_t *ip) {
             errno = oerrno;
             return 0;
         }
-        if (memcmp(buf, MC_MAGIC, MC_MAGIC_SIZE)) return 0;
+        if (strncmp(buf, MC_MAGIC, MC_MAGIC_SIZE)) return 0;
     }
 
     /*

--- a/src/lib/libast/string/swapop.c
+++ b/src/lib/libast/string/swapop.c
@@ -45,7 +45,7 @@ int swapop(const void *internal, const void *external, int size) {
     if (z <= 1) return 0;
     if (z <= sizeof(intmax_t))
         for (op = 0; op < z; op++)
-            if (!memcmp(internal, swapmem(op, external, tmp, z), z)) {
+            if (!strncmp(internal, swapmem(op, external, tmp, z), z)) {
                 if (size < 0 && z == 4 && op == 3) op = 7;
                 return op;
             }


### PR DESCRIPTION
In character encodings supported by ksh, strings are terminated by
NULL character. So it should be safe to replace memcmp() calls with
strncmp().