### PR TITLE
Add _ast_ prefix to glob related functions

### DIFF
--- a/src/lib/libast/include/glob.h
+++ b/src/lib/libast/include/glob.h
@@ -134,8 +134,11 @@ struct _glob_ {
 #define extern __EXPORT__
 #endif
 
-extern int glob(const char *, int, int (*)(const char *, int), glob_t *);
-extern void globfree(glob_t *);
+extern int _ast_glob(const char *, int, int (*)(const char *, int), glob_t *);
+extern void _ast_globfree(glob_t *);
+
+#define glob _ast_glob
+#define globfree _ast_globfree
 
 #undef extern
 

--- a/src/lib/libast/misc/glob.c
+++ b/src/lib/libast/misc/glob.c
@@ -458,7 +458,7 @@ skip:
     if (err == REG_ESPACE) gp->gl_error = GLOB_NOSPACE;
 }
 
-int glob(const char *pattern, int flags, int (*errfn)(const char *, int), glob_t *gp) {
+int _ast_glob(const char *pattern, int flags, int (*errfn)(const char *, int), glob_t *gp) {
     globlist_t *ap;
     char *pat;
     globlist_t *top;
@@ -658,7 +658,7 @@ int glob(const char *pattern, int flags, int (*errfn)(const char *, int), glob_t
     return gp->gl_error;
 }
 
-void globfree(glob_t *gp) {
+void _ast_globfree(glob_t *gp) {
     if ((gp->gl_flags & GLOB_MAGIC) == GLOB_MAGIC) {
         gp->gl_flags &= ~GLOB_MAGIC;
         if (gp->gl_stak) stkclose(gp->gl_stak);


### PR DESCRIPTION
ASAN tries to replace calls to AST glob functions to glibc.
Implementation of AST glob functions slightly differs from glibc and
rest of the code depends on it. These functions should be renamed to
avoid any conflicts.