### PR TITLE
Fix return value from `sfraise()`

### DIFF
--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -2178,9 +2178,11 @@ void _nv_unset(Namval_t *np, int flags) {
                 }
                 dtclose(rp->sdict);
             }
-            // Note that stkclose() calls sfclose() which frees the stream.
             if (flags & NV_TABLE) {
-                while (stkclose(slp->slptr) == 1) {
+                // Drop all references and close the stream.
+                // Note that stkclose() calls sfclose() which frees the stream.
+                // TODO: What should we do if `stkclose()` reports an error (by returning -1)?
+                while (stkclose(slp->slptr) > 0) {
                     ;  // empty loop
                 }
             } else {

--- a/src/lib/libast/sfio/sfraise.c
+++ b/src/lib/libast/sfio/sfraise.c
@@ -68,7 +68,10 @@ int sfraise(Sfio_t *f, int type, Void_t *data) {
 
         if (disc->exceptf) {
             SFOPEN(f, 0);
-            if ((rv = (*disc->exceptf)(f, type, data, disc)) != 0) SFMTXRETURN(f, rv);
+            // We do not return the value from the disc->exceptf function. That's because it can
+            // return a negative or positive value to indicate a problem. This function, however,
+            // must only return -1 on error. See issue #398.
+            if ((*disc->exceptf)(f, type, data, disc) != 0) SFMTXRETURN(f, -1);
             SFLOCK(f, 0);
         }
 


### PR DESCRIPTION
The `sfraise()` function must only return -1 or zero. Without this
change it can return one which breaks the `stkclose()` contract.

Partial fix for #389