### PR TITLE
Implment AST vmalloc buffer poisoning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,8 @@ feature_test_args = ['-std=gnu99', '-D_GNU_SOURCE']
 # To use these add `--setup=malloc` to your `meson test` command.
 #
 malloc_debug_env = environment()
+# These env vars are recognized by AST vmalloc.
+malloc_debug_env.set('VMALLOC_OPTIONS', 'junk')
 # These env vars are recognized by GNU malloc.
 malloc_debug_env.set('MALLOC_CHECK_', '3')
 malloc_debug_env.set('MALLOC_PERTURB_', '165')  # 0xA5

--- a/src/lib/libast/vmalloc/vmhdr.h
+++ b/src/lib/libast/vmalloc/vmhdr.h
@@ -129,6 +129,8 @@ typedef struct _seg_s Seg_t;     /* the type of a raw memory segment	*/
 #define VM_safe 0x08000000   /* safe MAP_ANON emulation of sbrk()	*/
 #define VM_zero 0x10000000   /* /dev/zero block allocator		*/
 
+#define VM_junk 0x20000000   /* fill allocated and freed blocks with junk */
+
 #define VM_GETMEMORY (VM_anon | VM_break | VM_native | VM_safe | VM_zero)
 
 #ifndef DEBUG


### PR DESCRIPTION
This is to help debug issue #398 without going all the way of replacing
AST vmalloc with the system malloc. It causes buffers allocated (other
than via `calloc()`) and freed to be poisoned with a known pattern that
will result in a SIGSEGV if it is used as a pointer.