### PR TITLE
Don't call vfork() in OpenBSD

### DIFF
--- a/features/meson.build
+++ b/features/meson.build
@@ -223,6 +223,12 @@ posix_spawn_feature_result = cc.run(posix_spawn_feature_file,
                                     args: feature_test_args)
 feature_data.set10('_lib_posix_spawn', posix_spawn_feature_result.returncode() == 0)
 
+vfork_feature_file = files('vfork.c')
+vfork_feature_result = cc.run(vfork_feature_file,
+                              name: 'vfork exists and it works',
+                              args: feature_test_args)
+feature_data.set10('_lib_vfork', vfork_feature_result.returncode() == 0)
+
 newgrp = find_program('newgrp', required: false)
 feature_data.set10('_cmd_newgrp', newgrp.found())
 

--- a/features/vfork.c
+++ b/features/vfork.c
@@ -1,0 +1,45 @@
+// This is for the Meson config stage to check if vfork() acts like
+// ksh expects.  We need vfork() to pause the parent and share memory
+// with the child until the child execs or exits.
+//
+// These systems do pause the parent and share memory:
+// - FreeBSD: https://www.freebsd.org/cgi/man.cgi?vfork
+// - Illumos: https://illumos.org/man/vfork
+// - Linux: http://man7.org/linux/man-pages/man2/vfork.2.html
+// - NetBSD: http://netbsd.gw.com/cgi-bin/man-cgi?vfork
+//
+// This system doesn't share memory:
+// - OpenBSD: https://man.openbsd.org/vfork
+
+#include <errno.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+    pid_t pid;
+    int m;
+    volatile int exec_errno;
+    volatile int *volatile exec_errno_ptr;
+
+    // Mimic how libast/misc/spawnvex.c calls vfork().
+    exec_errno = 0;
+    exec_errno_ptr = &exec_errno;
+    pid = vfork();
+    if (pid == -1) {
+        return 1;  // fail, can't fork
+    } else if (!pid) {
+        // As child, pretend to exec something.
+        *exec_errno_ptr = ENOEXEC;
+        _exit(126);
+    }
+
+    // As parent, read errno from child, immediately after returning
+    // from vfork() and before calling waitpid().
+    m = *exec_errno_ptr;
+    while (waitpid(pid, NULL, 0) == -1 && errno == EINTR) continue;
+    if (m == ENOEXEC) {
+        return 0;  // pass
+    } else {
+        return 1;  // fail, got wrong errno
+    }
+}

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1640,7 +1640,12 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                     sh_redirect(shp, t->tre.treio, 1 | IOUSEVEX);
                     if (rewrite) {
                         job_lock();
-                        while ((parent = vfork()) < 0) _sh_fork(shp, parent, 0, NULL);
+#if _lib_vfork
+#define vfork_or_fork vfork
+#else
+#define vfork_or_fork fork
+#endif  // _lib_vfork
+                        while ((parent = vfork_or_fork()) < 0) _sh_fork(shp, parent, 0, NULL);
                         if (parent) {
                             job.toclear = 0;
                             job_post(shp, parent, 0);


### PR DESCRIPTION
The child of vfork() uses shared memory to pass the errno from
execve() to the parent. OpenBSD's vfork() doesn't share memory, so the
errno got lost. This caused `chmod +x script; ./script` to fail if the
script had no `#! line`. The parent didn't see ENOEXEC from the child,
then didn't run the script.

Add a feature test for vfork(). Add back the define `_lib_vfork`; it
had disappeared from spawnvex.c in git commit ed6ba1d. If vfork()
doesn't share memory, then don't call vfork(). This drops the number
of failing tests in OpenBSD from above 50 to about 28.