### PR TITLE
Fix job control if ksh is started as session leader

### DIFF
--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -619,8 +619,8 @@ void job_init(Shell_t *shp, int lflag) {
 #endif  // SIGTSTP
     }
 #ifdef SIGTSTP
-    possible = setpgid(0, job.mypgid) >= 0;
-    if (possible || errno == EPERM) {
+    possible = (setpgid(0,job.mypgid)>=0) || errno==EPERM;
+    if (possible) {
         // Wait until we are in the foreground.
         while ((job.mytgid = tcgetpgrp(JOBTTY)) != job.mypgid) {
             if (job.mytgid <= 0) return;


### PR DESCRIPTION
Ksh fails to initalize job control if it is started as login shell. A
login shell is started as a session leader. Ksh tries to verify if job
control is set up properly by calling setpgid() on it's own process.
According to POSIX, calling setpgid() on a session leader should fail
with EPERM. This was causing ksh to skip initialzing job control.

We should be able to initalize job control by safely assuming that ksh
is started in a valid process group.

Resolves: #437