### PR TITLE
Avoid word splitting process id in suspend alias

### DIFF
--- a/src/cmd/ksh93/data/aliases.c
+++ b/src/cmd/ksh93/data/aliases.c
@@ -50,7 +50,7 @@ const struct shtable2 shtab_aliases[] = {
     {"redirect", NV_NOFREE, "command exec"},
 #ifdef SIGTSTP
     {"stop", NV_NOFREE, "kill -s STOP"},
-    {"suspend", NV_NOFREE, "kill -s STOP $$"},
+    {"suspend", NV_NOFREE, "kill -s STOP \"$$\""},
 #endif  // SIGTSTP
     {"times", NV_NOFREE, "{ { time;} 2>&1;}"},
     {"type", NV_NOFREE, "whence -v"},

--- a/src/cmd/ksh93/ksh.1
+++ b/src/cmd/ksh93/ksh.1
@@ -807,7 +807,7 @@ but can be unset or redefined:
 .TP
 .B "stop=\(fmkill \-s \s-1STOP\s+1\(fm"
 .TP
-.B "suspend=\(fmkill \-s \s-1STOP\s+1 $$\(fm"
+.B "suspend=\(fmkill \-s \s-1STOP\s+1 \(dq$$\(dq\(fm"
 .TP
 .B "times=\(fm{ { time;} 2>&1;}\(fm"
 .TP


### PR DESCRIPTION
Fix definition of suspend alias to avoid word splitting.
Also fix related man page entry.

Resolves: #10