### PR TITLE
Fix a regression in appending to arrays

### DIFF
--- a/src/cmd/ksh93/sh/array.c
+++ b/src/cmd/ksh93/sh/array.c
@@ -1295,7 +1295,7 @@ void nv_setvec(Namval_t *np, int append, int argc, char *argv[]) {
             arg0 = 0;
         } else if (ap) {
             if (!(aq = (struct index_array *)ap->header.scope)) aq = ap;
-            if (ap->header.nelem > ap->last) ap->last = ap->header.nelem;
+            if (ap->header.nelem > ap->last) ap->last = array_maxindex(np);
             arg0 = ap->last;
         } else {
             nv_offattr(np, NV_ARRAY);
@@ -1307,7 +1307,7 @@ void nv_setvec(Namval_t *np, int append, int argc, char *argv[]) {
         nv_putsub(np, NULL, (long)argc + arg0, ARRAY_FILL | ARRAY_ADD);
         nv_putval(np, argv[argc], 0);
     }
-    if (!ap && (ap = (struct index_array *)nv_arrayptr(np))) ap->last = ap->header.nelem;
+    if (!ap && (ap = (struct index_array *)nv_arrayptr(np))) ap->last = array_maxindex(np);
 }
 
 #undef nv_putsub

--- a/src/cmd/ksh93/tests/arrays.sh
+++ b/src/cmd/ksh93/tests/arrays.sh
@@ -877,4 +877,9 @@ integer -A ar=([1]=9 [3]=12)
 ar=()
 [[ $(typeset -p ar) == 'typeset -A -l -i ar=()' ]] || err_exit 'ar=() for associative array should preserve attributes'
 
+unset foo bar
+typeset -a foo=([1]=w [2]=x) bar=(a b c)
+foo+=("${bar[@]}")
+[[ $(typeset -p foo) == 'typeset -a foo=([1]=w [2]=x [3]=a [4]=b [5]=c)' ]] || err_exit 'Appending does not work if array contains empty indexes'
+
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
Existing elements are getting overwritten while appending to arrays if an array contains empty indexes. For e.g.
```
typeset -a a=([1]=w [2]=x)
typeset -a b=(a b c)
a+=("${b[@]}")
typeset -p a
```

Actual output:
```    
typeset -a a=([1]=w [2]=a [3]=b [4]=c)
```    
Expected output:
```    
typeset -a a=([1]=w [2]=x [3]=a [4]=b [5]=c)
```
    
Current code was calculating index of the last element by counting number of elements in the array. It will not work if an array contains empty indexes. This commit fixes it.
    
Resolves: #23
