### PR TITLE
Fix initialization of default PATH variable

### DIFF
--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -218,6 +218,8 @@ then
     err_exit    'command -v not working'
 fi
 
+$SHELL -c 'command -p ls >/dev/null' 2>/dev/null || err_exit 'command -p not working'
+
 read -r var <<\!
 
 !


### PR DESCRIPTION
Default PATH variable is getting used before it is initialized when ksh is started as a non-interactive shell. This patch fixes it.
    
Resolves: #426
