### PR TITLE
Remove wrong call to setpgid(pid, 0)

### DIFF
--- a/src/lib/libast/misc/spawnvex.c
+++ b/src/lib/libast/misc/spawnvex.c
@@ -821,11 +821,7 @@ bad:
             close(msg[0]);
         }
         if (!(flags & SPAWN_FOREGROUND)) sigcritical(0);
-        if (pid != -1 && vex) {
-            if (vex->pgrp >= 0 && setpgid(pid, vex->pgrp) < 0 && vex->pgrp && errno == EPERM)
-                setpgid(pid, pid);
-            VEXINIT(vex);
-        }
+        if (pid != -1 && vex) VEXINIT(vex);
         errno = n;
         return pid;
     }


### PR DESCRIPTION
When spawnvex() calls fork(), it never sets vex->pgrp, so vex->pgrp is
always 0. It then called setpgid(pid, 0) on every fork() child. This
tried to put every child into a new process group, whether or not we
had a SPAWN_pgrp command.

In OpenBSD 6.2, if the child's execve() succeeded, then setpgid()
failed with EACCES. If the child's execve() failed, then setpgid()
succeeded, and the child possibly executed a shell script in the wrong
process group. This caused 4 failures in src/tests/signal.sh because
the `kill -s INT 0` failed to signal some shell scripts in the wrong
process group. The fork() child can execute a shell script since the
removal of vfork() in PR #444 to fix bug #443.

src/tests/signal.sh still has 2 other failures in OpenBSD.