### PR TITLE
<> operator should redirect stdin by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ None at this time.
   have been enabled in some Fedora and RHEL builds. But because it was
   experimental and undocumented this should not break any existing users of
   `ksh` built with this feature enabled. (issue #234)
+- <> operator now redirects standard input by default (issue #75).
 
 ## Notable fixes and improvements
 

--- a/src/cmd/ksh93/ksh.1
+++ b/src/cmd/ksh93/ksh.1
@@ -3653,7 +3653,7 @@ otherwise, the file is created.
 Open file
 .I word\^
 for reading and writing
-as standard output.
+as standard input.
 .TP
 .BI <>; word
 The same as

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -521,7 +521,7 @@ int sh_lex(Lex_t *lp) {
                     } else if (n == '|') {
                         c |= SYMPIPE;
                     } else if (c == '<' && n == '>') {
-                        lp->digits = 1;
+                        lp->digits = 0;
                         c = IORDWRSYM;
                         fcgetc(n);
                         if (fcgetc(n) == ';') {

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -589,4 +589,7 @@ redirect {fd}< $tmp
 ) & wait $!
 ((Errors += $?))
 
+# According to POSIX <> should redirect stdin when no fd is specified
+read -n 1 -t 0.1 <>/dev/zero || err_exit '<> should redirect stdin by default'
+
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
Ksh redirects stdout when no fd is specified with <> operator. According to POSIX <> operator should redirect stdin by default.
   
Resolves: #75
