### PR TITLE
Find libexecinfo in OpenBSD

### DIFF
--- a/features/meson.build
+++ b/features/meson.build
@@ -17,28 +17,36 @@ else
     feature_data.set('_more_long_int', 0)
 endif
 
+if system == 'openbsd'
+    # OpenBSD puts some libraries, like libexecinfo and libiconv, in
+    # /usr/local/lib, but the compiler doesn't automatically search there.
+    dirs = ['/usr/local/lib']
+else
+    dirs = []
+endif
+
 # On some platforms the math functions (e.g., `sin()`) that we need are found in
 # libc, on others they are found in libm.
-libm_dep = cc.find_library('m', required: false)
+libm_dep = cc.find_library('m', required: false, dirs: dirs)
 
 # On some platforms `dladdr()` and related functions are found in libc,
 # on others they are found in libdl.
-libdl_dep = cc.find_library('dl', required: false)
+libdl_dep = cc.find_library('dl', required: false, dirs: dirs)
 
 # On some systems (e.g., FreeBSD) `libutil` contains functions we may need
 # such as `openpty()`.
-libutil_dep = cc.find_library('util', required: false)
+libutil_dep = cc.find_library('util', required: false, dirs: dirs)
 
 # On some platforms `backtrace()` and related functions are found in libc,
 # on others they are found in libexecinfo.
-libexecinfo_dep = cc.find_library('execinfo', required: false)
+libexecinfo_dep = cc.find_library('execinfo', required: false, dirs: dirs)
 
-# On OpenBSD libiconv is in /usr/local/lib rather than /usr/lib.
-libiconv_dep = cc.find_library('iconv', required: false, dirs: ['/usr/lib', '/usr/local/lib'])
+# On some systems (e.g., OpenBSD) `iconv()` is in libiconv.
+libiconv_dep = cc.find_library('iconv', required: false, dirs: dirs)
 
 # On Cygwin the message catalog functions (e.g., `catopen()`) are in this
 # library.
-libcatgets_dep = cc.find_library('catgets', required: false)
+libcatgets_dep = cc.find_library('catgets', required: false, dirs: dirs)
 
 
 # It was turned off on Linux but the iffe test was botched, keeping it on here.

--- a/meson.build
+++ b/meson.build
@@ -50,12 +50,13 @@ configuration_incdir = include_directories(['.', 'features/locales'])
 if system == 'openbsd'
     # This is needed because OpenBSD installs a lot of stuff in
     # /usr/local/{include,lib} that would normally be in /usr/{include,lib}.
-    # But the compiler doesn't automatically search /usr/local/included for
+    # But the compiler doesn't automatically search /usr/local/include for
     # headers so force it to do so.
     #
     # We could do this unconditionally but it's safer to limit the scope to
     # the platforms that need it.
     add_global_arguments('-I/usr/local/include', language: 'c')
+    feature_test_args += '-I/usr/local/include'
 endif
 
 # Error on implicit declarations.


### PR DESCRIPTION
OpenBSD installs libexecinfo in /usr/local, where the compiler does
not search by default. Add -I/usr/local/include to feature tests so
execinfo.h gets found. Look for all libraries (not only libiconv) in
/usr/local so libexecinfo gets found. Do this only for OpenBSD.

Issue #460 is still a problem on OpenBSD; ksh can now use libexecinfo
to print a backtrace, but can't find the right symbols.