### PR TITLE
Don't run wrong file with same name in PATH

### DIFF
--- a/src/cmd/ksh93/tests/functions.sh
+++ b/src/cmd/ksh93/tests/functions.sh
@@ -268,9 +268,11 @@ chmod +x $tmp/foobar
 FPATH=$tmp
 cd $tmp
 print 'function zzz { return 0;}' > zzz
-PATH=$PATH:
+# Remove other commands named zzz from PATH.
+old_path=$PATH
+PATH=.
 zzz  2> /dev/null || err_exit 'function not found in . when $PWD is in FPATH'
-PATH=${PATH%:}
+PATH=$old_path
 cd ~-
 autoload foobar
 if [[ $(foobar 2>/dev/null) != foo ]]
@@ -525,7 +527,7 @@ then
 fi
 
 print 'set a b c' > dotscript
-[[ $(PATH=$PATH: $SHELL -c '. dotscript;print $#') == 3 ]] || err_exit 'positional parameters not preserved with . script without arguments'
+[[ $(PATH=:$PATH $SHELL -c '. dotscript;print $#') == 3 ]] || err_exit 'positional parameters not preserved with . script without arguments'
 cd ~- || err_exit "cd back failed"
 function errcheck
 {

--- a/src/cmd/ksh93/tests/signal.sh
+++ b/src/cmd/ksh93/tests/signal.sh
@@ -266,7 +266,8 @@ chmod +x tst tst-?
 
 # end standalone test generation
 
-export PATH=$PATH:
+# Find our tst* scripts before any commands with the same name.
+export PATH=:$PATH
 typeset -A expected
 expected[---]="3-intr"
 expected[--d]="3-intr"


### PR DESCRIPTION
Tests would run the wrong `dotscript`, `tst`, `tst-1`, `tst-2`,
`tst-3`, or `zzz` if PATH had another script or command with the same
name. For example, functions.sh would run /usr/sbin/zzz (which puts
some BSD machines to sleep) instead of the test's own `zzz`.

Move the directory with the test's `dotscript` or `tst*` to the front
of PATH.  Remove most directories from PATH when searching for `zzz`,
because the test searches PATH before finding its `zzz` in FPATH.

I checked this change by putting scripts or commands with these names
in my own PATH before running `meson test`.

Resolves #429