### PR TITLE
Fix initialization of shp variable in several functions

### DIFF
--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -681,7 +681,7 @@ static Namval_t *nv_parentnode(Namval_t *np) {
 }
 
 Namval_t *nv_create(const char *name, Dt_t *root, int flags, Namfun_t *dp) {
-    Shell_t *shp = dtuserdata(root, 0, 0);
+    Shell_t *shp = sh_getinterp();
     char *sub = 0, *cp = (char *)name, *sp, *xp;
     int c;
     Namval_t *np = 0, *nq = 0;
@@ -1158,7 +1158,7 @@ void nv_delete(Namval_t *np, Dt_t *root, int flags) {
 // SH_INIT is only set while initializing the environment.
 //
 Namval_t *nv_open(const char *name, Dt_t *root, int flags) {
-    Shell_t *shp = dtuserdata(root, 0, 0);
+    Shell_t *shp = sh_getinterp();
     char *cp = (char *)name;
     int c;
     Namval_t *np = 0;

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -882,7 +882,7 @@ Namval_t *nv_mkclone(Namval_t *mp) {
 }
 
 Namval_t *nv_search(const char *name, Dt_t *root, int mode) {
-    Shell_t *shp = dtuserdata(root, 0, 0);
+    Shell_t *shp = sh_getinterp();
 
     if (!shp) shp = &sh;
 
@@ -907,7 +907,7 @@ Namval_t *nv_search(const char *name, Dt_t *root, int mode) {
             while ((next = dtvnext(root))) root = next;
         }
         np = (Namval_t *)dtinsert(root, newnode(name));
-        np->nvshell = dtuserdata(root, 0, 0);
+        np->nvshell = sh_getinterp();
     }
     if (dp) dtview(root, dp);
     return np;
@@ -920,7 +920,7 @@ Namval_t *nv_search(const char *name, Dt_t *root, int mode) {
 // variable. If last==0 and first component of name is a reference, nv_bfsearch() will return 0.
 //
 Namval_t *nv_bfsearch(const char *name, Dt_t *root, Namval_t **var, char **last) {
-    Shell_t *shp = dtuserdata(root, 0, 0);
+    Shell_t *shp = sh_getinterp();
     int c, offset = stktell(shp->stk);
     char *sp, *cp = 0;
     Namval_t *np, *nq;


### PR DESCRIPTION
In the last alpha release, several functions were modified to always
initialize value of shp variable through root parameter. This may
cause a crash if root parameter is NULL. This commit reverts changes
introduced in last alpha release and uses same style of initaizling this
variable as last stable release.

This fixes a crash while starting tksh and possibly other occurences of
similar crash.

Resolves: #53