### PR TITLE
Fix exporting variables from function local scope

### DIFF
--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -2848,6 +2848,7 @@ static void local_exports(Namval_t *np, void *data) {
     if (cp && (mp = nv_search(nv_name(np), shp->var_tree, NV_ADD | HASH_NOSCOPE)) &&
         nv_isnull(mp)) {
         nv_putval(mp, cp, 0);
+        mp->nvflag = np->nvflag;
     }
 }
 

--- a/src/cmd/ksh93/tests/functions.sh
+++ b/src/cmd/ksh93/tests/functions.sh
@@ -1338,4 +1338,10 @@ foo()
 
 $SHELL -c 'function ftest { ftest2; }; function ftest2 { unset -f ftest; }; ftest' 2> /dev/null || err_exit 'unset of function in the calling stack fails'
 
+# Check if environment variables passed while invoking a function are exported
+# https://github.com/att/ast/issues/32
+function f2 { env | grep -q "^foo" || err_exit "Environment variable is not propogated from caller function"; }
+function f1 { f2; env | grep -q "^foo" || err_exit "Environment variable is not passed to a function"; }
+foo=bar f1
+
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
While copying variables from function's local scope to a new scope,
variable attributes were not copied. Such variables were not marked
to be exported in the new function. For e.g.

function f2 { env | grep -i "^foo"; }
function f1 { env | grep -i "^foo"; f2; }
foo=bar f1

prints 'foo=bar' only once, but it should print be twice. This patch
fixes it.

Resolves: #32