### PR TITLE
Use fork()/exec() instead of posix_spawn() by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -66,6 +66,7 @@ endif
 
 shared_c_args = [
     '-DUSAGE_LICENSE=""',
+    '-D_AST_no_spawnveg=1',
 ]
 
 # Compiler arguments used when building `ksh93`, `shcomp`, and related AST

--- a/src/cmd/ksh93/include/fault.h
+++ b/src/cmd/ksh93/include/fault.h
@@ -97,10 +97,19 @@ struct checkpt {
 #endif
 };
 
+# if !_AST_no_spawnveg
 #define sh_pushcontext(shp, bp, n)                                                           \
     ((bp)->mode = (n), (bp)->olist = 0, (bp)->topfd = shp->topfd, (bp)->prev = shp->jmplist, \
-     (bp)->vexi = ((Spawnvex_t *)shp->vexp)->cur, (bp)->err = *ERROR_CONTEXT_BASE,           \
+     (bp)->vexi = ((Spawnvex_t *)shp->vexp)->cur, (bp)->err = *ERROR_CONTEXT_BASE, \
      shp->jmplist = (sigjmp_buf *)(&(bp)->buff))
+
+# else
+#define sh_pushcontext(shp, bp, n)                                                           \
+    ((bp)->mode = (n), (bp)->olist = 0, (bp)->topfd = shp->topfd, (bp)->prev = shp->jmplist, \
+     (bp)->err = *ERROR_CONTEXT_BASE, \
+     shp->jmplist = (sigjmp_buf *)(&(bp)->buff))
+#endif
+
 #define sh_popcontext(shp, bp) (shp->jmplist = (bp)->prev, errorpop(&((bp)->err)))
 
 typedef void (*sh_sigfun_t)(int);

--- a/src/cmd/ksh93/include/io.h
+++ b/src/cmd/ksh93/include/io.h
@@ -70,8 +70,10 @@ extern int sh_iorenumber(Shell_t *, int, int);
 extern void sh_pclose(int[]);
 extern int sh_rpipe(int[]);
 extern void sh_iorestore(Shell_t *, int, int);
+#if !_AST_no_spawnveg
 extern void sh_vexrestore(Shell_t *, int);
 extern void sh_vexsave(Shell_t *, int, int, Spawnvex_f, void *);
+#endif
 #if defined(__EXPORT__) && defined(_BLD_DLL) && defined(_BLD_shell)
 __EXPORT__
 #endif

--- a/src/cmd/ksh93/include/shell.h
+++ b/src/cmd/ksh93/include/shell.h
@@ -254,8 +254,10 @@ struct Shell_s {
     char **argaddr;
     void *optlist;
     void **siginfo;
+#if !_AST_no_spawnveg
     Spawnvex_t *vex;
     Spawnvex_t *vexp;
+#endif
     struct sh_scoped global;
     struct checkpt checkbase;
     Shinit_f userinit;

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -2383,8 +2383,10 @@ static char *sh_tilde(Shell_t *shp, const char *string) {
         char *s2;
         size_t len;
         int fd, offset = stktell(shp->stk);
+#ifdef SPAWN_cwd
         Spawnvex_t *vc = (Spawnvex_t *)shp->vex;
         if (!vc && (vc = spawnvex_open(0))) shp->vex = (void *)vc;
+#endif
         if (!(s2 = strchr(string++, '}'))) return NULL;
         len = s2 - string;
         sfwrite(shp->stk, string, len + 1);
@@ -2410,7 +2412,9 @@ static char *sh_tilde(Shell_t *shp, const char *string) {
         sfprintf(shp->stk, "/dev/fd/%d", fd);
 #endif
 #endif
+#ifdef SPAWN_cwd
         if (vc) spawnvex_add(vc, fd, fd, 0, 0);
+#endif
         return stkfreeze(shp->stk, 1);
     }
 #if _WINIX

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -35,6 +35,8 @@
 #include "test.h"
 #include "variables.h"
 
+#include <assert.h>
+
 #if SHOPT_DYNAMIC
 #include <dlldefs.h>
 #endif
@@ -70,13 +72,16 @@ static bool onstdpath(Shell_t *shp, const char *name) {
 
 static pid_t path_pfexecve(Shell_t *shp, const char *path, char *argv[], char *const envp[],
                            int spawn) {
+
+#ifdef SPAWN_cwd
     if (shp->vex->cur) {
         spawnvex_apply(shp->vex, 0, 0);
         spawnvex_apply(shp->vexp, 0, SPAWN_RESET);
     }
-
+#endif
     return execve(path, argv, envp);
 }
+
 
 static pid_t _spawnveg(Shell_t *shp, const char *path, char *const argv[], char *const envp[],
                        pid_t pgid) {
@@ -101,7 +106,8 @@ static pid_t _spawnveg(Shell_t *shp, const char *path, char *const argv[], char 
             }
         }
 #else
-        pid = spawnveg(path, argv, envp, pgid);
+        assert(0); // We should never reach here
+        // pid = spawnveg(path, argv, envp, pgid);
 #endif  // SPAWN_cwd
         if (pid >= 0 || errno != EAGAIN) break;
     }

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -902,7 +902,9 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                 type &= (COMMSK | COMSCAN);
                 sh_stats(STAT_SCMDS);
                 error_info.line = t->com.comline - shp->st.firstline;
+#ifdef SPAWN_cwd
                 spawnvex_add(shp->vex, SPAWN_frame, 0, 0, 0);
+#endif
                 com = sh_argbuild(shp, &argn, &(t->com), OPTIMIZE);
                 procsub = shp->procsub;
                 shp->procsub = 0;
@@ -1252,6 +1254,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                                 jmpval = 0;
                             }
                         }
+#ifdef SPAWN_cwd
                         if (np != SYSEXEC && shp->vex->cur) {
 #if 1
                             spawnvex_apply(shp->vex, 0, SPAWN_RESET | SPAWN_FRAME);
@@ -1262,6 +1265,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                                 spawnvex_add(shp->vex, fd, 1, 0, 0);
 #endif
                         }
+#endif
                         bp->bnode = NULL;
                         if (bp->ptr != nv_context(np)) np->nvfun = (Namfun_t *)bp->ptr;
                         if (execflg && !was_nofork) sh_offstate(shp, SH_NOFORK);
@@ -1312,7 +1316,9 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                         if ((shp->topfd > topfd) && !(shp->subshell && np == SYSEXEC)) {
                             sh_iorestore(shp, topfd, jmpval);
                         }
+#ifdef SPAWN_cwd
                         if (shp->vexp->cur > vexi) sh_vexrestore(shp, vexi);
+#endif
                         shp->redir0 = 0;
                         if (jmpval) siglongjmp(*shp->jmplist, jmpval);
 #if 0
@@ -1395,8 +1401,10 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                             sh_funct(shp, np, argn, com, t->com.comset, (flags & ~OPTIMIZE_FLAG));
                         }
                         enter_namespace(shp, namespace);
+#ifdef SPAWN_cwd
                         spawnvex_apply(shp->vex, 0, SPAWN_RESET | SPAWN_FRAME);
                         if (shp->vexp->cur > vexi) sh_vexrestore(shp, vexi);
+#endif
                         if (io) {
                             if (buffp->olist) free_list(buffp->olist);
                             sh_popcontext(shp, buffp);
@@ -1411,7 +1419,9 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                         goto setexit;
                     }
                 } else if (!io) {
+#ifdef SPAWN_cwd
                     spawnvex_apply(shp->vex, 0, SPAWN_RESET | SPAWN_FRAME);
+#endif
                 setexit:
                     exitset(shp);
                     break;
@@ -1647,7 +1657,9 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                             job_post(shp, parent, 0);
                             job_wait(parent);
                             sh_iorestore(shp, topfd, SH_JMPCMD);
+#ifdef SPAWN_cwd
                             if (shp->vexp->cur > vexi) sh_vexrestore(shp, vexi);
+#endif
                             sh_done(shp,
                                     (shp->exitval & SH_EXITSIG) ? (shp->exitval & SH_EXITMASK) : 0);
                         }
@@ -1724,7 +1736,9 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                 }
                 sh_popcontext(shp, buffp);
                 sh_iorestore(shp, buffp->topfd, jmpval);
+#ifdef SPAWN_cwd
                 if (shp->vexp->cur > vexi) sh_vexrestore(shp, buffp->vexi);
+#endif
                 if (buffp->olist) free_list(buffp->olist);
                 if (type & FPIN) {
                     job.waitall = waitall;
@@ -3216,7 +3230,9 @@ static pid_t sh_ntfork(Shell_t *shp, const Shnode_t *t, char *argv[], int *jobid
         }
         if (t->fork.forkio || otype) {
             sh_iorestore(shp, buffp->topfd, jmpval);
+#ifdef SPAWN_cwd
             if (shp->vexp->cur > buffp->vexi) sh_vexrestore(shp, buffp->vexi);
+#endif
         }
         if (optimize == 0) {
             if (spawnpid > 0) _sh_fork(shp, spawnpid, otype, jobid);

--- a/src/lib/libast/include/ast_sys.h
+++ b/src/lib/libast/include/ast_sys.h
@@ -45,6 +45,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#if !_AST_no_spawnveg
 typedef struct Spawnvex_s {
     unsigned int cur;
     int io;
@@ -95,6 +96,16 @@ typedef int (*Spawnvex_f)(void *, uintmax_t, uintmax_t);
 #define SPAWN_truncate (-10)
 #define SPAWN_umask (-11)
 
+extern pid_t spawnveg(const char *, char *const[], char *const[], pid_t);
+extern pid_t spawnvex(const char *, char *const[], char *const[], Spawnvex_t *);
+extern Spawnvex_t *spawnvex_open(unsigned int);
+extern int spawnvex_add(Spawnvex_t *, intmax_t, intmax_t, Spawnvex_f, void *);
+extern int spawnvex_apply(Spawnvex_t *, int, int);
+extern intmax_t spawnvex_get(Spawnvex_t *, int, int);
+extern int spawnvex_close(Spawnvex_t *);
+
+#endif
+
 #if _BLD_ast && defined(__EXPORT__)
 #define extern __EXPORT__
 #endif
@@ -105,13 +116,6 @@ extern char *gettxt(const char *, const char *);
 extern void *memalign(size_t, size_t);
 extern void *pvalloc(size_t);
 extern char *resolvepath(const char *, char *, size_t);
-extern pid_t spawnveg(const char *, char *const[], char *const[], pid_t);
-extern pid_t spawnvex(const char *, char *const[], char *const[], Spawnvex_t *);
-extern Spawnvex_t *spawnvex_open(unsigned int);
-extern int spawnvex_add(Spawnvex_t *, intmax_t, intmax_t, Spawnvex_f, void *);
-extern int spawnvex_apply(Spawnvex_t *, int, int);
-extern intmax_t spawnvex_get(Spawnvex_t *, int, int);
-extern int spawnvex_close(Spawnvex_t *);
 extern size_t strlcat(char *, const char *, size_t);
 extern size_t strlcpy(char *, const char *, size_t);
 extern void swab(const void *, void *, ssize_t);

--- a/src/lib/libast/misc/meson.build
+++ b/src/lib/libast/misc/meson.build
@@ -7,6 +7,10 @@ libast_files += [
     'misc/optget.c', 'misc/optjoin.c', 'misc/procclose.c', 'misc/procfree.c',
     'misc/procopen.c', 'misc/procrun.c', 'misc/recfmt.c', 'misc/reclen.c',
     'misc/recstr.c', 'misc/setenviron.c', 'misc/sigcrit.c', 'misc/sigdata.c',
-    'misc/signal.c', 'misc/spawnvex.c', 'misc/stack.c', 'misc/state.c',
+    'misc/signal.c', 'misc/stack.c', 'misc/state.c',
     'misc/stk.c', 'misc/systrace.c', 'misc/translate.c', 'misc/univdata.c'
 ]
+
+if not shared_c_args.contains('-D_AST_no_spawnveg=1')
+    libast_files += [ 'misc/spawnvex.c' ]
+endif


### PR DESCRIPTION
Using posix_spawn() may result in a race condition while setting
terminal foreground process group. Copying dgk's response from related
discussion in ast-developers mailing list:

"
ksh93 uses posix_spawn() rather than fork/exec to run a simple command
for performance reasons.  However, posix_spawnv() doesn't have a way to
set the terminal group before the exec().  The parent process sets the
terminal group which leads to the race.

There is a simple change you can make to a program to guarentee that
the terminal will get set at the beginning of the program.
You can add two lines.  One line is
        #include        <termios.h>

and for the other line
        tcsetpgrp(2,getpgrp());

Alternatively, you can write a program that does these two lines and then
execs the original program.
"

Only way to reliably fix this problem in ksh is to switch back to fork()/
exec().

If there are any performance regressions or bugs caused by this change,
you can switch to posix_spawn() by setting '-D_AST_no_spawnveg=0'.

Related: #468
Related: rhbz#1160482