### PR TITLE
Correctly restore value of .sh.file after sourcing

### DIFF
--- a/src/cmd/ksh93/bltins/misc.c
+++ b/src/cmd/ksh93/bltins/misc.c
@@ -297,7 +297,6 @@ int b_dot_cmd(int n, char *argv[], Shbltin_t *context) {
         }
     }
     sh_popcontext(shp, &buff);
-    nv_putval(SH_PATHNAMENOD, shp->st.filename, NV_NOFREE);
     if (buffer) free(buffer);
     if (!np) free(shp->st.filename);
     shp->dot_depth--;
@@ -311,6 +310,7 @@ int b_dot_cmd(int n, char *argv[], Shbltin_t *context) {
     // Only restore the top Shscope_t portion for posix functions.
     memcpy((void *)&shp->st, (void *)prevscope, sizeof(Shscope_t));
     shp->topscope = (Shscope_t *)prevscope;
+    nv_putval(SH_PATHNAMENOD, shp->st.filename, NV_NOFREE);
     if (jmpval && jmpval != SH_JMPFUN) siglongjmp(*shp->jmplist, jmpval);
     return shp->exitval;
 }

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -790,5 +790,12 @@ def=bar
 OPTIND=2
 [[ ${$OPTIND:1:1} == e ]] || err_exit '${$OPTIND:1:1} not correct with OPTIND=2 and $2=def'
 
+# Check if ${.sh.file} is set to correct value after sourcing a file
+# https://github.com/att/ast/issues/472
+cat > $tmp/foo.sh <<EOF
+echo "foo"
+EOF
+. $tmp/foo.sh > /dev/null
+[[ ${.sh.file} == $0 ]] || err_exit ".sh.file is not set to correct value after sourcing a file"
 
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
Commit e3dd5b1 introduced a regression which was causing .sh.file to be
set to corrupted value after sourcing. This commit reverts part of it.

Resolves: #472