### PR TITLE
Start building builtins for some standard commands from libcmd

### DIFF
--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -137,7 +137,7 @@ const struct shtable3 shtab_builtins[] = {
     {CMDLIST(dirname)},
     {CMDLIST(getconf)},
     {CMDLIST(head)},
-//    {CMDLIST(mkdir)},
+    {CMDLIST(mkdir)},
 //    {CMDLIST(logname)},
 //    {CMDLIST(cat)},
 //    {CMDLIST(cmp)},

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -133,7 +133,7 @@ const struct shtable3 shtab_builtins[] = {
 #include SHOPT_CMDLIB_HDR
 #else   // SHOPT_CMDLIB_HDR
     {CMDLIST(basename)},
-//    {CMDLIST(chmod)},
+    {CMDLIST(chmod)},
 //    {CMDLIST(dirname)},
 //    {CMDLIST(getconf)},
     {CMDLIST(head)},

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -135,7 +135,7 @@ const struct shtable3 shtab_builtins[] = {
     {CMDLIST(basename)},
     {CMDLIST(chmod)},
     {CMDLIST(dirname)},
-//    {CMDLIST(getconf)},
+    {CMDLIST(getconf)},
     {CMDLIST(head)},
 //    {CMDLIST(mkdir)},
 //    {CMDLIST(logname)},

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -138,7 +138,7 @@ const struct shtable3 shtab_builtins[] = {
     {CMDLIST(getconf)},
     {CMDLIST(head)},
     {CMDLIST(mkdir)},
-//    {CMDLIST(logname)},
+    {CMDLIST(logname)},
 //    {CMDLIST(cat)},
 //    {CMDLIST(cmp)},
 //    {CMDLIST(cut)},

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -144,7 +144,7 @@ const struct shtable3 shtab_builtins[] = {
 //    {CMDLIST(cut)},
     {CMDLIST(uname)},
 //    {CMDLIST(wc)},
-//    {CMDLIST(sync)},
+    {CMDLIST(sync)},
 #endif  // SHOPT_CMDLIB_HDR
 #if SHOPT_REGRESS
     {"__regress__", NV_BLTIN | BLT_ENV, bltin(__regress__)},

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -134,7 +134,7 @@ const struct shtable3 shtab_builtins[] = {
 #else   // SHOPT_CMDLIB_HDR
     {CMDLIST(basename)},
     {CMDLIST(chmod)},
-//    {CMDLIST(dirname)},
+    {CMDLIST(dirname)},
 //    {CMDLIST(getconf)},
     {CMDLIST(head)},
 //    {CMDLIST(mkdir)},

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -139,7 +139,7 @@ const struct shtable3 shtab_builtins[] = {
     {CMDLIST(head)},
     {CMDLIST(mkdir)},
     {CMDLIST(logname)},
-//    {CMDLIST(cat)},
+    {CMDLIST(cat)},
 //    {CMDLIST(cmp)},
 //    {CMDLIST(cut)},
 //    {CMDLIST(uname)},

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -41,18 +41,13 @@
 
 #ifndef SHOPT_CMDLIB_DIR
 #define SHOPT_CMDLIB_DIR SH_CMDLIB_DIR
-#endif  // SHOPT_CMDLIB_DIR
+#else
 #ifndef SHOPT_CMDLIB_HDR
 #define SHOPT_CMDLIB_HDR <cmdlist.h>
-#endif  // SHOPT_CMDLIB_HDR
+#endif // SHOPT_CMDLIB_HDR
+#endif // SHOPT_CMDLIB_DIR
 
-#if _AST_VERSION < 20121001L
 #define CMDLIST(f) SHOPT_CMDLIB_DIR "/" #f, NV_BLTIN | NV_BLTINOPT | NV_NOFREE, b_##f,
-#else  // _AST_VERSION < 20121001L
-#define CMDLIST(f, d)                                                                        \
-    d "/" #f, NV_BLTIN | NV_BLTINOPT | NV_NOFREE | BLT_DISABLE, b_##f, SH_CMDLIB_DIR "/" #f, \
-        NV_BLTIN | NV_BLTINOPT | NV_NOFREE, b_##f,
-#endif  // _AST_VERSION < 20121001L
 
 #undef basename
 #undef dirname
@@ -138,18 +133,18 @@ const struct shtable3 shtab_builtins[] = {
 #include SHOPT_CMDLIB_HDR
 #else   // SHOPT_CMDLIB_HDR
     {CMDLIST(basename)},
-    {CMDLIST(chmod)},
-    {CMDLIST(dirname)},
-    {CMDLIST(getconf)},
+//    {CMDLIST(chmod)},
+//    {CMDLIST(dirname)},
+//    {CMDLIST(getconf)},
     {CMDLIST(head)},
-    {CMDLIST(mkdir)},
-    {CMDLIST(logname)},
-    {CMDLIST(cat)},
-    {CMDLIST(cmp)},
-    {CMDLIST(cut)},
-    {CMDLIST(uname)},
-    {CMDLIST(wc)},
-    {CMDLIST(sync)},
+//    {CMDLIST(mkdir)},
+//    {CMDLIST(logname)},
+//    {CMDLIST(cat)},
+//    {CMDLIST(cmp)},
+//    {CMDLIST(cut)},
+//    {CMDLIST(uname)},
+//    {CMDLIST(wc)},
+//    {CMDLIST(sync)},
 #endif  // SHOPT_CMDLIB_HDR
 #if SHOPT_REGRESS
     {"__regress__", NV_BLTIN | BLT_ENV, bltin(__regress__)},

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -142,7 +142,7 @@ const struct shtable3 shtab_builtins[] = {
     {CMDLIST(cat)},
     {CMDLIST(cmp)},
 //    {CMDLIST(cut)},
-//    {CMDLIST(uname)},
+    {CMDLIST(uname)},
 //    {CMDLIST(wc)},
 //    {CMDLIST(sync)},
 #endif  // SHOPT_CMDLIB_HDR

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -140,7 +140,7 @@ const struct shtable3 shtab_builtins[] = {
     {CMDLIST(mkdir)},
     {CMDLIST(logname)},
     {CMDLIST(cat)},
-//    {CMDLIST(cmp)},
+    {CMDLIST(cmp)},
 //    {CMDLIST(cut)},
 //    {CMDLIST(uname)},
 //    {CMDLIST(wc)},

--- a/src/lib/libast/misc/fts.c
+++ b/src/lib/libast/misc/fts.c
@@ -1,0 +1,52 @@
+/***********************************************************************
+*                                                                      *
+*               This software is part of the ast package               *
+*          Copyright (c) 1985-2011 AT&T Intellectual Property          *
+*                      and is licensed under the                       *
+*                 Eclipse Public License, Version 1.0                  *
+*                    by AT&T Intellectual Property                     *
+*                                                                      *
+*                A copy of the License is available at                 *
+*          http://www.eclipse.org/org/documents/epl-v10.html           *
+*         (with md5 checksum b35adb5213ca9657e911e9befb180842)         *
+*                                                                      *
+*              Information and Software Systems Research               *
+*                            AT&T Research                             *
+*                           Florham Park NJ                            *
+*                                                                      *
+*                 Glenn Fowler <gsf@research.att.com>                  *
+*                  David Korn <dgk@research.att.com>                   *
+*                   Phong Vo <kpv@research.att.com>                    *
+*                                                                      *
+***********************************************************************/
+#pragma prototyped
+/*
+ * Phong Vo
+ * Glenn Fowler
+ * AT&T Research
+ *
+ * fts implementation unwound from the kpv ftwalk() of 1988-10-30
+ */
+
+#include <ast.h>
+#include <ast_dir.h>
+#include <error.h>
+#include <fts.h>
+
+/*
+ * return default (FTS_LOGICAL|FTS_META|FTS_PHYSICAL|FTS_SEEDOTDIR) flags
+ * conditioned by astconf()
+ */
+
+int
+fts_flags(void)
+{
+    char*	s;
+
+    s = astconf("PATH_RESOLVE", 0, 0);
+    if (streq(s, "logical"))
+        return FTS_LOGICAL;
+    if (streq(s, "physical"))
+        return FTS_PHYSICAL|FTS_SEEDOTDIR;
+    return FTS_META|FTS_PHYSICAL|FTS_SEEDOTDIR;
+}

--- a/src/lib/libast/misc/meson.build
+++ b/src/lib/libast/misc/meson.build
@@ -8,7 +8,8 @@ libast_files += [
     'misc/procopen.c', 'misc/procrun.c', 'misc/recfmt.c', 'misc/reclen.c',
     'misc/recstr.c', 'misc/setenviron.c', 'misc/sigcrit.c', 'misc/sigdata.c',
     'misc/signal.c', 'misc/stack.c', 'misc/state.c',
-    'misc/stk.c', 'misc/systrace.c', 'misc/translate.c', 'misc/univdata.c'
+    'misc/stk.c', 'misc/systrace.c', 'misc/translate.c', 'misc/univdata.c',
+    'misc/fts.c'
 ]
 
 if not shared_c_args.contains('-D_AST_no_spawnveg=1')

--- a/src/lib/libcmd/cat.c
+++ b/src/lib/libcmd/cat.c
@@ -143,7 +143,7 @@ static int vcat(char *states, Sfio_t *ip, Sfio_t *op, Reserve_f reserve, int fla
     header = flags & (B_FLAG | N_FLAG);
     line = 1;
     states[0] = T_ENDBUF;
-    if (!(raw = !mbwide())) mbinit(&q);
+    if (!(raw = !mbwide())) mbinit();
     for (;;) {
         cur = cp;
         if (raw)
@@ -155,7 +155,7 @@ static int vcat(char *states, Sfio_t *ip, Sfio_t *op, Reserve_f reserve, int fla
                     ;
                 if (n < T_CONTROL) break;
                 pp = cp - 1;
-                if ((m = mbsize(pp, MB_LEN_MAX, &q)) > 1)
+                if ((m = mbnsize(pp, MB_LEN_MAX)) > 1)
                     cp += m - 1;
                 else {
                     if (m <= 0) {
@@ -164,7 +164,7 @@ static int vcat(char *states, Sfio_t *ip, Sfio_t *op, Reserve_f reserve, int fla
                                 *end = last;
                                 last = -1;
                                 c = end - pp + 1;
-                                if ((m = mbsize(pp, MB_LEN_MAX, &q)) == c) {
+                                if ((m = mbnsize(pp, MB_LEN_MAX)) == c) {
                                     any = 1;
                                     if (header) {
                                         header = 0;
@@ -192,7 +192,7 @@ static int vcat(char *states, Sfio_t *ip, Sfio_t *op, Reserve_f reserve, int fla
                                     if ((n = end - cp + 1) >= (sizeof(tmp) - c))
                                         n = sizeof(tmp) - c - 1;
                                     memcpy(tmp + c, cp, n);
-                                    if ((m = mbsize(tmp, MB_LEN_MAX, &q)) >= c) {
+                                    if ((m = mbnsize(tmp, MB_LEN_MAX)) >= c) {
                                         any = 1;
                                         if (header) {
                                             header = 0;

--- a/src/lib/libcmd/chmod.c
+++ b/src/lib/libcmd/chmod.c
@@ -132,7 +132,7 @@ __STDPP__directive pragma pp : hide lchmod
 #endif
 
 #include <cmd.h>
-#include <fts_fix.h>
+#include <fts.h>
 #include <ls.h>
 
 #ifndef ENOSYS

--- a/src/lib/libcmd/cmdext.h
+++ b/src/lib/libcmd/cmdext.h
@@ -42,7 +42,7 @@ extern  int	b_dirname (int, char**, Shbltin_t*);
 //extern  int	b_fgrep (int, char**, Shbltin_t*);
 //extern  int	b_fmt (int, char**, Shbltin_t*);
 //extern  int	b_fold (int, char**, Shbltin_t*);
-//extern  int	b_getconf (int, char**, Shbltin_t*);
+extern  int	b_getconf (int, char**, Shbltin_t*);
 //extern  int	b_grep (int, char**, Shbltin_t*);
 extern int	b_head (int, char**, Shbltin_t*);
 //extern  int	b_iconv (int, char**, Shbltin_t*);

--- a/src/lib/libcmd/cmdext.h
+++ b/src/lib/libcmd/cmdext.h
@@ -72,7 +72,7 @@ extern  int	b_mkdir (int, char**, Shbltin_t*);
 //extern  int	b_sha512sum (int, char**, Shbltin_t*);
 //extern  int	b_stty (int, char**, Shbltin_t*);
 //extern  int	b_sum (int, char**, Shbltin_t*);
-//extern  int	b_sync (int, char**, Shbltin_t*);
+extern  int	b_sync (int, char**, Shbltin_t*);
 //extern  int	b_tail (int, char**, Shbltin_t*);
 //extern  int	b_tee (int, char**, Shbltin_t*);
 //extern  int	b_tr (int, char**, Shbltin_t*);

--- a/src/lib/libcmd/cmdext.h
+++ b/src/lib/libcmd/cmdext.h
@@ -52,7 +52,7 @@ extern int	b_head (int, char**, Shbltin_t*);
 //extern  int	b_logname (int, char**, Shbltin_t*);
 //extern  int	b_ls (int, char**, Shbltin_t*);
 //extern  int	b_md5sum (int, char**, Shbltin_t*);
-//extern  int	b_mkdir (int, char**, Shbltin_t*);
+extern  int	b_mkdir (int, char**, Shbltin_t*);
 //extern  int	b_mkfifo (int, char**, Shbltin_t*);
 //extern  int	b_mktemp (int, char**, Shbltin_t*);
 //extern  int	b_mv (int, char**, Shbltin_t*);

--- a/src/lib/libcmd/cmdext.h
+++ b/src/lib/libcmd/cmdext.h
@@ -25,7 +25,7 @@
 #include <shcmd.h>
 
 extern int	b_basename (int, char**, Shbltin_t*);
-//extern int	b_cat (int, char**, Shbltin_t*);
+extern int	b_cat (int, char**, Shbltin_t*);
 //extern int	b_chgrp (int, char**, Shbltin_t*);
 extern int	b_chmod (int, char**, Shbltin_t*);
 //extern int	b_chown (int, char**, Shbltin_t*);

--- a/src/lib/libcmd/cmdext.h
+++ b/src/lib/libcmd/cmdext.h
@@ -27,7 +27,7 @@
 extern int	b_basename (int, char**, Shbltin_t*);
 //extern int	b_cat (int, char**, Shbltin_t*);
 //extern int	b_chgrp (int, char**, Shbltin_t*);
-//extern int	b_chmod (int, char**, Shbltin_t*);
+extern int	b_chmod (int, char**, Shbltin_t*);
 //extern int	b_chown (int, char**, Shbltin_t*);
 //extern  int	b_cksum (int, char**, Shbltin_t*);
 //extern int	b_cmp (int, char**, Shbltin_t*);

--- a/src/lib/libcmd/cmdext.h
+++ b/src/lib/libcmd/cmdext.h
@@ -49,7 +49,7 @@ extern int	b_head (int, char**, Shbltin_t*);
 //extern  int	b_id (int, char**, Shbltin_t*);
 //extern  int	b_join (int, char**, Shbltin_t*);
 //extern  int	b_ln (int, char**, Shbltin_t*);
-//extern  int	b_logname (int, char**, Shbltin_t*);
+extern  int	b_logname (int, char**, Shbltin_t*);
 //extern  int	b_ls (int, char**, Shbltin_t*);
 //extern  int	b_md5sum (int, char**, Shbltin_t*);
 extern  int	b_mkdir (int, char**, Shbltin_t*);

--- a/src/lib/libcmd/cmdext.h
+++ b/src/lib/libcmd/cmdext.h
@@ -30,7 +30,7 @@ extern int	b_cat (int, char**, Shbltin_t*);
 extern int	b_chmod (int, char**, Shbltin_t*);
 //extern int	b_chown (int, char**, Shbltin_t*);
 //extern  int	b_cksum (int, char**, Shbltin_t*);
-//extern int	b_cmp (int, char**, Shbltin_t*);
+extern int	b_cmp (int, char**, Shbltin_t*);
 //extern int	b_comm (int, char**, Shbltin_t*);
 //extern int	b_cp (int, char**, Shbltin_t*);
 //extern  int	b_cut (int, char**, Shbltin_t*);

--- a/src/lib/libcmd/cmdext.h
+++ b/src/lib/libcmd/cmdext.h
@@ -35,7 +35,7 @@ extern int	b_chmod (int, char**, Shbltin_t*);
 //extern int	b_cp (int, char**, Shbltin_t*);
 //extern  int	b_cut (int, char**, Shbltin_t*);
 //extern  int	b_date (int, char**, Shbltin_t*);
-//extern  int	b_dirname (int, char**, Shbltin_t*);
+extern  int	b_dirname (int, char**, Shbltin_t*);
 //extern  int	b_egrep (int, char**, Shbltin_t*);
 //extern  int	b_expr (int, char**, Shbltin_t*);
 //extern  int	b_fds (int, char**, Shbltin_t*);

--- a/src/lib/libcmd/cmdext.h
+++ b/src/lib/libcmd/cmdext.h
@@ -77,7 +77,7 @@ extern  int	b_mkdir (int, char**, Shbltin_t*);
 //extern  int	b_tee (int, char**, Shbltin_t*);
 //extern  int	b_tr (int, char**, Shbltin_t*);
 //extern  int	b_tty (int, char**, Shbltin_t*);
-//extern  int	b_uname (int, char**, Shbltin_t*);
+extern  int	b_uname (int, char**, Shbltin_t*);
 //extern  int	b_uniq (int, char**, Shbltin_t*);
 //extern  int	b_vmstate (int, char**, Shbltin_t*);
 //extern  int	b_wc (int, char**, Shbltin_t*);

--- a/src/lib/libcmd/cmdext.h
+++ b/src/lib/libcmd/cmdext.h
@@ -1,0 +1,87 @@
+/***********************************************************************
+*                                                                      *
+*               This software is part of the ast package               *
+*          Copyright (c) 1992-2018 AT&T Intellectual Property          *
+*                      and is licensed under the                       *
+*                 Eclipse Public License, Version 1.0                  *
+*                    by AT&T Intellectual Property                     *
+*                                                                      *
+*                A copy of the License is available at                 *
+*          http://www.eclipse.org/org/documents/epl-v10.html           *
+*         (with md5 checksum b35adb5213ca9657e911e9befb180842)         *
+*                                                                      *
+*              Information and Software Systems Research               *
+*                            AT&T Research                             *
+*                           Florham Park NJ                            *
+*                                                                      *
+*               Glenn Fowler <glenn.s.fowler@gmail.com>                *
+*                    David Korn <dgkorn@gmail.com>                     *
+*                                                                      *
+***********************************************************************/
+
+#ifndef CMDEXT_H
+#define CMDEXT_H
+
+#include <shcmd.h>
+
+extern int	b_basename (int, char**, Shbltin_t*);
+//extern int	b_cat (int, char**, Shbltin_t*);
+//extern int	b_chgrp (int, char**, Shbltin_t*);
+//extern int	b_chmod (int, char**, Shbltin_t*);
+//extern int	b_chown (int, char**, Shbltin_t*);
+//extern  int	b_cksum (int, char**, Shbltin_t*);
+//extern int	b_cmp (int, char**, Shbltin_t*);
+//extern int	b_comm (int, char**, Shbltin_t*);
+//extern int	b_cp (int, char**, Shbltin_t*);
+//extern  int	b_cut (int, char**, Shbltin_t*);
+//extern  int	b_date (int, char**, Shbltin_t*);
+//extern  int	b_dirname (int, char**, Shbltin_t*);
+//extern  int	b_egrep (int, char**, Shbltin_t*);
+//extern  int	b_expr (int, char**, Shbltin_t*);
+//extern  int	b_fds (int, char**, Shbltin_t*);
+//extern  int	b_fgrep (int, char**, Shbltin_t*);
+//extern  int	b_fmt (int, char**, Shbltin_t*);
+//extern  int	b_fold (int, char**, Shbltin_t*);
+//extern  int	b_getconf (int, char**, Shbltin_t*);
+//extern  int	b_grep (int, char**, Shbltin_t*);
+extern int	b_head (int, char**, Shbltin_t*);
+//extern  int	b_iconv (int, char**, Shbltin_t*);
+//extern  int	b_id (int, char**, Shbltin_t*);
+//extern  int	b_join (int, char**, Shbltin_t*);
+//extern  int	b_ln (int, char**, Shbltin_t*);
+//extern  int	b_logname (int, char**, Shbltin_t*);
+//extern  int	b_ls (int, char**, Shbltin_t*);
+//extern  int	b_md5sum (int, char**, Shbltin_t*);
+//extern  int	b_mkdir (int, char**, Shbltin_t*);
+//extern  int	b_mkfifo (int, char**, Shbltin_t*);
+//extern  int	b_mktemp (int, char**, Shbltin_t*);
+//extern  int	b_mv (int, char**, Shbltin_t*);
+//extern  int	b_od (int, char**, Shbltin_t*);
+//extern  int	b_paste (int, char**, Shbltin_t*);
+//extern  int	b_pathchk (int, char**, Shbltin_t*);
+//extern  int	b_pids (int, char**, Shbltin_t*);
+//extern  int	b_readlink (int, char**, Shbltin_t*);
+//extern  int	b_realpath (int, char**, Shbltin_t*);
+//extern  int	b_rev (int, char**, Shbltin_t*);
+//extern  int	b_rm (int, char**, Shbltin_t*);
+//extern  int	b_rmdir (int, char**, Shbltin_t*);
+//extern  int	b_sha1sum (int, char**, Shbltin_t*);
+//extern  int	b_sha256sum (int, char**, Shbltin_t*);
+//extern  int	b_sha2sum (int, char**, Shbltin_t*);
+//extern  int	b_sha384sum (int, char**, Shbltin_t*);
+//extern  int	b_sha512sum (int, char**, Shbltin_t*);
+//extern  int	b_stty (int, char**, Shbltin_t*);
+//extern  int	b_sum (int, char**, Shbltin_t*);
+//extern  int	b_sync (int, char**, Shbltin_t*);
+//extern  int	b_tail (int, char**, Shbltin_t*);
+//extern  int	b_tee (int, char**, Shbltin_t*);
+//extern  int	b_tr (int, char**, Shbltin_t*);
+//extern  int	b_tty (int, char**, Shbltin_t*);
+//extern  int	b_uname (int, char**, Shbltin_t*);
+//extern  int	b_uniq (int, char**, Shbltin_t*);
+//extern  int	b_vmstate (int, char**, Shbltin_t*);
+//extern  int	b_wc (int, char**, Shbltin_t*);
+//extern  int	b_xargs (int, char**, Shbltin_t*);
+extern  int	b_xgrep (int, char**, Shbltin_t*);
+
+#endif

--- a/src/lib/libcmd/meson.build
+++ b/src/lib/libcmd/meson.build
@@ -1,6 +1,7 @@
 libcmd_files = ['context.c', 'cmdinit.c' ]
 
-libcmd_files += [ 'basename.c', 'chmod.c', 'dirname.c', 'stty.c', 'head.c', 'getconf.c', 'mkdir.c', 'logname.c' ]
+libcmd_files += [ 'basename.c', 'chmod.c', 'dirname.c', 'stty.c', 'head.c', 'getconf.c', 'mkdir.c', 
+                  'logname.c', 'cat.c' ]
 
 libcmd_c_args = shared_c_args + [
     '-DUSAGE_LICENSE=""',

--- a/src/lib/libcmd/meson.build
+++ b/src/lib/libcmd/meson.build
@@ -1,7 +1,7 @@
 libcmd_files = ['context.c', 'cmdinit.c' ]
 
 libcmd_files += [ 'basename.c', 'chmod.c', 'dirname.c', 'stty.c', 'head.c', 'getconf.c', 'mkdir.c', 
-                  'logname.c', 'cat.c', 'cmp.c', 'uname.c' ]
+                  'logname.c', 'cat.c', 'cmp.c', 'uname.c', 'sync.c' ]
 
 libcmd_c_args = shared_c_args + [
     '-DUSAGE_LICENSE=""',

--- a/src/lib/libcmd/meson.build
+++ b/src/lib/libcmd/meson.build
@@ -1,6 +1,6 @@
 libcmd_files = ['context.c', 'cmdinit.c' ]
 
-libcmd_files += [ 'basename.c', 'chmod.c', 'dirname.c', 'stty.c', 'head.c' ]
+libcmd_files += [ 'basename.c', 'chmod.c', 'dirname.c', 'stty.c', 'head.c', 'getconf.c' ]
 
 libcmd_c_args = shared_c_args + [
     '-DUSAGE_LICENSE=""',

--- a/src/lib/libcmd/meson.build
+++ b/src/lib/libcmd/meson.build
@@ -1,7 +1,7 @@
 libcmd_files = ['context.c', 'cmdinit.c' ]
 
 libcmd_files += [ 'basename.c', 'chmod.c', 'dirname.c', 'stty.c', 'head.c', 'getconf.c', 'mkdir.c', 
-                  'logname.c', 'cat.c', 'cmp.c' ]
+                  'logname.c', 'cat.c', 'cmp.c', 'uname.c' ]
 
 libcmd_c_args = shared_c_args + [
     '-DUSAGE_LICENSE=""',

--- a/src/lib/libcmd/meson.build
+++ b/src/lib/libcmd/meson.build
@@ -1,7 +1,7 @@
 libcmd_files = ['context.c', 'cmdinit.c' ]
 
 libcmd_files += [ 'basename.c', 'chmod.c', 'dirname.c', 'stty.c', 'head.c', 'getconf.c', 'mkdir.c', 
-                  'logname.c', 'cat.c' ]
+                  'logname.c', 'cat.c', 'cmp.c' ]
 
 libcmd_c_args = shared_c_args + [
     '-DUSAGE_LICENSE=""',

--- a/src/lib/libcmd/meson.build
+++ b/src/lib/libcmd/meson.build
@@ -1,8 +1,12 @@
-libcmd_files = ['context.c', 'cmdinit.c', 'stty.c']
+libcmd_files = ['context.c', 'cmdinit.c' ]
+
+libcmd_files += [ 'basename.c', 'stty.c', 'head.c' ]
+
 libcmd_c_args = shared_c_args + [
     '-DUSAGE_LICENSE=""',
     '-DERROR_CATALOG=0',
 ]
+
 incdir = include_directories('../libast/include', '../libast/features/')
 
 libcmd = library('cmd', libcmd_files, c_args: libcmd_c_args,

--- a/src/lib/libcmd/meson.build
+++ b/src/lib/libcmd/meson.build
@@ -1,6 +1,6 @@
 libcmd_files = ['context.c', 'cmdinit.c' ]
 
-libcmd_files += [ 'basename.c', 'chmod.c', 'stty.c', 'head.c' ]
+libcmd_files += [ 'basename.c', 'chmod.c', 'dirname.c', 'stty.c', 'head.c' ]
 
 libcmd_c_args = shared_c_args + [
     '-DUSAGE_LICENSE=""',

--- a/src/lib/libcmd/meson.build
+++ b/src/lib/libcmd/meson.build
@@ -1,6 +1,6 @@
 libcmd_files = ['context.c', 'cmdinit.c' ]
 
-libcmd_files += [ 'basename.c', 'chmod.c', 'dirname.c', 'stty.c', 'head.c', 'getconf.c', 'mkdir.c' ]
+libcmd_files += [ 'basename.c', 'chmod.c', 'dirname.c', 'stty.c', 'head.c', 'getconf.c', 'mkdir.c', 'logname.c' ]
 
 libcmd_c_args = shared_c_args + [
     '-DUSAGE_LICENSE=""',

--- a/src/lib/libcmd/meson.build
+++ b/src/lib/libcmd/meson.build
@@ -1,6 +1,6 @@
 libcmd_files = ['context.c', 'cmdinit.c' ]
 
-libcmd_files += [ 'basename.c', 'chmod.c', 'dirname.c', 'stty.c', 'head.c', 'getconf.c' ]
+libcmd_files += [ 'basename.c', 'chmod.c', 'dirname.c', 'stty.c', 'head.c', 'getconf.c', 'mkdir.c' ]
 
 libcmd_c_args = shared_c_args + [
     '-DUSAGE_LICENSE=""',

--- a/src/lib/libcmd/meson.build
+++ b/src/lib/libcmd/meson.build
@@ -1,6 +1,6 @@
 libcmd_files = ['context.c', 'cmdinit.c' ]
 
-libcmd_files += [ 'basename.c', 'stty.c', 'head.c' ]
+libcmd_files += [ 'basename.c', 'chmod.c', 'stty.c', 'head.c' ]
 
 libcmd_c_args = shared_c_args + [
     '-DUSAGE_LICENSE=""',

--- a/src/lib/libcmd/sync.c
+++ b/src/lib/libcmd/sync.c
@@ -52,31 +52,6 @@ static const char optsync[] =
 
     "[+SEE ALSO?\bfsync\b(2), \bsync\b(2), \bsyncfs\b(2), \bsfsync\b(3), \bshutdown\b(8)]";
 
-#ifndef ENOSYS
-#define ENOSYS EINVAL
-#endif
-
-#if !_lib_fsync
-int fsync(int fd) {
-    if (fcntl(fd, F_GETFL) >= 0) errno = ENOSYS;
-    return -1;
-}
-#endif
-
-#if !_lib_sync
-int sync(void) {
-    errno = ENOSYS;
-    return -1;
-}
-#endif
-
-#if !_lib_syncfs
-int syncfs(int fd) {
-    if (fcntl(fd, F_GETFL) >= 0) errno = ENOSYS;
-    return -1;
-}
-#endif
-
 int b_sync(int argc, char **argv, Shbltin_t *context) {
     int fsync_fd = -1;
     int syncfs_fd = -1;


### PR DESCRIPTION
Start building builtins for these commands :

- basename
- chmod
- dirname
- getconf
- head
- mkdir
- logname
- cat
- cmp
- uname
- sync

These builtins are disabled by default and can be enabled by running `builtin <command name>`.