### PR TITLE
Check for invalid file descriptor in sh_close()

### DIFF
--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -445,7 +445,7 @@ int sh_close(int fd) {
         return -1;
     }
 
-    if (!(sp = shp->sftable[fd]) || (sp->_file != fd) || (sfclose(sp) < 0)) {
+    if (!(sp = shp->sftable[fd]) || (sffileno(sp) != fd) || (sfclose(sp) < 0)) {
         int err = errno;
         if (fdnotify) (*fdnotify)(fd, SH_FDCLOSE);
         while ((r = close(fd)) < 0 && errno == EINTR) errno = err;

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -445,11 +445,12 @@ int sh_close(int fd) {
         return -1;
     }
 
-    if (!(sp = shp->sftable[fd]) || sfclose(sp) < 0) {
+    if (!(sp = shp->sftable[fd]) || (sp->_file != fd) || (sfclose(sp) < 0)) {
         int err = errno;
         if (fdnotify) (*fdnotify)(fd, SH_FDCLOSE);
         while ((r = close(fd)) < 0 && errno == EINTR) errno = err;
     }
+
     if (fd > 2) shp->sftable[fd] = 0;
     r = (shp->fdstatus[fd] >> 8);
     if (r) close(r);

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -845,3 +845,10 @@ if [[ $actual != $expected ]]
 then
     err_exit -u2 "failed to capture subshell output when closing fd: case 3"
 fi
+
+builtin -d echo
+# Check if redirections work if backticks are nested inside $()
+foo=$(print `echo bar`)
+[[ $foo == "bar" ]] || err_exit 'Redirections do not work if backticks are nested inside $()'
+
+rm $tmpfile


### PR DESCRIPTION
There was a regression introduced after the last stable release which
causes mishandling of redirections in subshells. For e.g.

foo=$(print `/bin/echo bar`)
print foo=$foo

prints `bar` on stdout and the variable foo is empty.

Handling of redirections in $() style of command substitution was
changed after the last stable release. sh_subshell() function replaces
sfstdout with a newly created temporary stream with this line :

sp->saveout = sfswap(sfstdout, NULL);

The newly created stream has it's fd value set to -1. If `` style of
command subtitution happens inside $(), it tries to use this stream with
invalid fd and fails to close it. So redirections for stdout do not
work.

We should check if the stream that we are closing actually corresponds
to the file descriptor that we want to close. If not, directly invoke
close() on the fd.

Resolves: #478