### PR TITLE
Fix tvtouch() implementation

### DIFF
--- a/config_ast.h.in
+++ b/config_ast.h.in
@@ -219,7 +219,6 @@
 #mesondefine _lib_utime
 #mesondefine _lib_utime_now
 #mesondefine _lib_utimensat
-#mesondefine _lib_utimets
 #mesondefine _lib_wcrtomb
 #mesondefine _lib_wcscmp
 #mesondefine _lib_wcsxfrm

--- a/features/meson.build
+++ b/features/meson.build
@@ -86,8 +86,6 @@ endif
 
 feature_data.set10('_lib_utimensat',
     cc.has_function('utimensat', prefix: '#include <sys/stat.h>', args: feature_test_args))
-feature_data.set10('_lib_utimets',
-    cc.has_function('utimets', prefix: '#include <sys/stat.h>', args: feature_test_args))
 feature_data.set10('_lib_sysinfo',
     cc.has_function('sysinfo', prefix: '#include <sys/systeminfo.h>', args: feature_test_args))
 feature_data.set10('_lib_pipe2',

--- a/src/lib/libast/tm/tvtouch.c
+++ b/src/lib/libast/tm/tvtouch.c
@@ -27,33 +27,21 @@
  */
 #include "config_ast.h"  // IWYU pragma: keep
 
-#if defined(__STDPP__directive) && defined(__STDPP__hide)
-__STDPP__directive pragma pp : hide utime
-#else
-#define utime ______utime
-#endif
-
-#ifndef _ATFILE_SOURCE
-#define _ATFILE_SOURCE 1
-#endif
-
-#include <ast.h>
-#include <error.h>
-#include <ls.h>
-#include <times.h>
-#include <tv.h>
-
 #include <utime.h>
 
-#if defined(__STDPP__directive) && defined(__STDPP__hide)
-                                   __STDPP__directive pragma pp
-    : nohide utime
-#else
-#undef utime
-#endif
+#include "ast.h"
+#include "error.h"
+#include "ls.h"
+#include "times.h"
+#include "tv.h"
 
-      extern int
-      utime(const char *, const struct utimbuf *);
+// NOTE: These symbols aren't actually available to any code calling tvtouch() since they are not
+// defined in any header that such code could include. See the NOTE below.
+//
+// TODO: Consider removing these and the code predicated on them since the capabilities controlled
+// by them cannot be used.
+#define TV_TOUCH_CREATE 1
+#define TV_TOUCH_PHYSICAL 2
 
 #define NS(n) (((uint32_t)(n)) < 1000000000L ? (n) : 0)
 
@@ -69,24 +57,29 @@ __STDPP__directive pragma pp : hide utime
  * NOTE: when *at() calls are integrated TV_TOUCH_* should be advertized!
  */
 
-#define TV_TOUCH_CREATE 1
-#define TV_TOUCH_PHYSICAL 2
-
-#if !defined(UTIME_NOW) || !defined(UTIME_OMIT) || defined(__stub_utimensat)
-#endif
-
-int tvtouch(const char *path, const Tv_t *av, const Tv_t *mv, const Tv_t *cv, int flags) {
-    int fd;
-    int mode;
-    int oerrno;
-    struct stat st;
-    Tv_t now;
-    struct timeval am[2];
-
-    oerrno = errno;
+// There are two implmentations of tvtouch() below. Which one is used depends on whether the build
+// time feature tests finds a usable utimensat(). The implementations are listed in order of
+// preference.
 
 #if _lib_utimensat
+
+// The system has a usable utimensat() function so use that.
+int tvtouch(const char *path, const Tv_t *av, const Tv_t *mv, const Tv_t *cv, int flags) {
     struct timespec ts[2];
+    int oerrno = errno;
+
+    if (!cv && av == TV_TOUCH_RETAIN && mv == TV_TOUCH_RETAIN) {
+        struct stat st;
+        if (!stat(path, &st) && !chmod(path, st.st_mode & S_IPERM)) {
+            // We were asked to retain existing timestamps but the file doesn't seem to exist. So do
+            // nothing and report success.
+            //
+            // TODO: Figure out if this really the right return code. It seems like -1 to indicate
+            // an error is more appropriate since we couldn't do what was requested.
+            return 0;
+        }
+    }
+
     if (!av) {
         ts[0].tv_sec = 0;
         ts[0].tv_nsec = UTIME_NOW;
@@ -97,6 +90,7 @@ int tvtouch(const char *path, const Tv_t *av, const Tv_t *mv, const Tv_t *cv, in
         ts[0].tv_sec = av->tv_sec;
         ts[0].tv_nsec = NS(av->tv_nsec);
     }
+
     if (!mv) {
         ts[1].tv_sec = 0;
         ts[1].tv_nsec = UTIME_NOW;
@@ -107,59 +101,46 @@ int tvtouch(const char *path, const Tv_t *av, const Tv_t *mv, const Tv_t *cv, in
         ts[1].tv_sec = mv->tv_sec;
         ts[1].tv_nsec = NS(mv->tv_nsec);
     }
-    if (!cv && av == TV_TOUCH_RETAIN && mv == TV_TOUCH_RETAIN && !stat(path, &st) &&
-        !chmod(path, st.st_mode & S_IPERM))
-        return 0;
-    if (!utimensat(
-            AT_FDCWD, path,
-            ts[0].tv_nsec == UTIME_NOW && ts[1].tv_nsec == UTIME_NOW ? (struct timespec *)0 : ts,
-            (flags & TV_TOUCH_PHYSICAL) ? AT_SYMLINK_NOFOLLOW : 0))
-        return 0;
-    if (errno != ENOSYS) {
-        if (errno != ENOENT || !(flags & TV_TOUCH_CREATE)) return -1;
-        umask(mode = umask(0));
-        mode = (~mode) & (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
-        if ((fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, mode)) < 0) return -1;
-        close(fd);
-        errno = oerrno;
-        if ((ts[0].tv_nsec != UTIME_NOW || ts[1].tv_nsec != UTIME_NOW) &&
-            utimensat(AT_FDCWD, path, ts, (flags & TV_TOUCH_PHYSICAL) ? AT_SYMLINK_NOFOLLOW : 0))
-            return -1;
-        return 0;
-    }
+
+    struct timespec *tsp = (ts[0].tv_nsec == UTIME_NOW && ts[1].tv_nsec == UTIME_NOW) ? NULL : ts;
+    int utimensat_flags = (flags & TV_TOUCH_PHYSICAL) ? AT_SYMLINK_NOFOLLOW : 0;
+    if (!utimensat(AT_FDCWD, path, tsp, utimensat_flags)) return 0;
+    if (errno != ENOENT || !(flags & TV_TOUCH_CREATE)) return -1;
+
+    // Create the file with the requested timestamps.
+    int mode = umask(0);
+    umask(mode);
+    mode = (~mode) & (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, mode);
+    if (fd == -1) return -1;
+    close(fd);
+    errno = oerrno;
+    if (ts[0].tv_nsec == UTIME_NOW && ts[1].tv_nsec == UTIME_NOW) return 0;
+    return utimensat(AT_FDCWD, path, ts, utimensat_flags);
+}
+
+#else  // _lib_utimensat
+
+// The system doesn't appear to have a usable utimensat() so use utimes().
+int tvtouch(const char *path, const Tv_t *av, const Tv_t *mv, const Tv_t *cv, int flags) {
+    struct stat st = {0};
+    Tv_t now;
+    struct timeval am[2];
+    int oerrno = errno;
+
+    UNUSED(cv);
+
     if ((av == TV_TOUCH_RETAIN || mv == TV_TOUCH_RETAIN) && stat(path, &st)) {
         errno = oerrno;
-        if (av == TV_TOUCH_RETAIN) av = 0;
-        if (mv == TV_TOUCH_RETAIN) mv = 0;
+        if (av == TV_TOUCH_RETAIN) av = NULL;
+        if (mv == TV_TOUCH_RETAIN) mv = NULL;
     }
     if (!av || !mv) {
         tvgettime(&now);
         if (!av) av = (const Tv_t *)&now;
         if (!mv) mv = (const Tv_t *)&now;
     }
-#elif _lib_utimets
-    struct timespec ts[2];
-    if (av == TV_TOUCH_RETAIN) {
-        ts[0].tv_sec = st.st_atime;
-        ts[0].tv_nsec = ST_ATIME_NSEC_GET(&st);
-    } else {
-        ts[0].tv_sec = av->tv_sec;
-        ts[0].tv_nsec = NS(av->tv_nsec);
-    }
-    if (mv == TV_TOUCH_RETAIN) {
-        ts[1].tv_sec = st.st_mtime;
-        ts[1].tv_nsec = ST_MTIME_NSEC_GET(&st);
-    } else {
-        ts[1].tv_sec = mv->tv_sec;
-        ts[1].tv_nsec = NS(mv->tv_nsec);
-    }
-    if (!utimets(path, ts)) return 0;
-    if (errno != ENOENT && av == (const Tv_t *)&now && mv == (const Tv_t *)&now &&
-        !utimets(path, NULL)) {
-        errno = oerrno;
-        return 0;
-    }
-#else
+
     if (av == TV_TOUCH_RETAIN) {
         am[0].tv_sec = st.st_atime;
         am[0].tv_usec = ST_ATIME_NSEC_GET(&st) / 1000;
@@ -174,39 +155,44 @@ int tvtouch(const char *path, const Tv_t *av, const Tv_t *mv, const Tv_t *cv, in
         am[1].tv_sec = mv->tv_sec;
         am[1].tv_usec = NS(mv->tv_nsec) / 1000;
     }
+
     if (!utimes(path, am)) return 0;
     if (errno != ENOENT && av == (const Tv_t *)&now && mv == (const Tv_t *)&now &&
         !utimes(path, NULL)) {
         errno = oerrno;
         return 0;
     }
+
     if (!access(path, F_OK)) {
         if (av != (const Tv_t *)&now || mv != (const Tv_t *)&now) {
             errno = EINVAL;
             return -1;
         }
-        if ((fd = open(path, O_RDWR | O_CLOEXEC)) >= 0) {
-            char c;
+
+        int fd = open(path, O_RDWR | O_CLOEXEC);
+        if (fd >= 0) {
+            int c;
 
             if (read(fd, &c, 1) == 1) {
-                if (c = (lseek(fd, 0L, 0) == 0L && write(fd, &c, 1) == 1)) errno = oerrno;
+                c = lseek(fd, 0, 0) == 0 && write(fd, &c, 1);
+                if (c) errno = oerrno;
                 close(fd);
                 if (c) return 0;
             }
             close(fd);
         }
     }
-#endif
     if (errno != ENOENT || !(flags & TV_TOUCH_CREATE)) return -1;
-    umask(mode = umask(0));
+
+    int mode = umask(0);
+    umask(mode);
     mode = (~mode) & (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
-    if ((fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, mode)) < 0) return -1;
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, mode);
+    if (fd == -1) return -1;
     close(fd);
     errno = oerrno;
     if (av == (const Tv_t *)&now && mv == (const Tv_t *)&now) return 0;
-#if _lib_utimets
-    return utimets(path, ts);
-#else
     return utimes(path, am);
-#endif
 }
+
+#endif  // _lib_utimensat


### PR DESCRIPTION
When the code was refactored as part of switching to the Meson build
system some statements were put inside the wrong `#if` blocks.

Also, the `timets()` support is only for IRIX which is a long dead OS so
remove that support.

Fixes #459