### PR TITLE
Keep exit status consistent when command is not executable

### DIFF
--- a/src/cmd/ksh93/tests/path.sh
+++ b/src/cmd/ksh93/tests/path.sh
@@ -140,18 +140,15 @@ then
     log_error "leading : in path not working"
 fi
 
-log_info "TODO: Enable this test when bug #485 is fixed."
-# Disabled because once in a while (~20% of the time) the exit status is 126 (ENOENT) rather than
-# the expected 127 (ENOEXEC).
-#
-# (
-#     rm -rf noexec
-#     print 'print cannot execute' > noexec
-#     noexec > /dev/null 2>&1
-# )
-# actual=$?
-# expect=127
-# [[ $actual == $expect ]] || log_error "exit status of non-executable is wrong" "$expect" "$actual"
+(
+    rm -rf noexec
+    print 'print cannot execute' > noexec
+    noexec > /dev/null 2>&1
+)
+actual=$?
+# POSIX: If a command is found, but is not executable, exit status should be 126.
+expect=126
+[[ $actual == $expect ]] || log_error "exit status of non-executable is wrong" "$expect" "$actual"
 
 builtin -d rm 2> /dev/null
 chmod=$(whence chmod)

--- a/src/lib/libast/include/ast.h
+++ b/src/lib/libast/include/ast.h
@@ -51,10 +51,10 @@
 
 #define EXIT_BITS 8 /* # exit status bits	*/
 
-#define EXIT_USAGE 2                               /* usage exit code	*/
-#define EXIT_QUIT ((1 << (EXIT_BITS)) - 1)         /* parent should quit	*/
-#define EXIT_NOTFOUND ((1 << (EXIT_BITS - 1)) - 1) /* command not found	*/
-#define EXIT_NOEXEC ((1 << (EXIT_BITS - 1)) - 2)   /* other exec error	*/
+#define EXIT_USAGE 2            /* usage exit code	*/
+#define EXIT_QUIT 255           /* parent should quit	*/
+#define EXIT_NOTFOUND 127       /* command not found	*/
+#define EXIT_NOEXEC 126         /* other exec error	*/
 
 #define EXIT_CODE(x) ((x) & ((1 << EXIT_BITS) - 1))
 #define EXIT_CORE(x) (EXIT_CODE(x) | (1 << EXIT_BITS) | (1 << (EXIT_BITS - 1)))


### PR DESCRIPTION
Ksh performs command searching by trying to execute command in each
element of PATH. If a command is found, but is not executable, ksh
continues to search for it further in other paths.

According to POSIX, if shell finds a command which is not executable,
it should return with status 126. Current behavior of ksh is non
determinstic as it depends on if command is found in the last element
of PATH or not:

1. If a command is found in the last element of PATH but is not
executable, ksh returns with status 126.

2. If a command is found before last element of PATH but is not
executable, ksh continues to search  for it further in other paths. It
returns with status 127 when command could not be found.

Ksh should behave consistently and return immediately after a command is
found but is not executable.

Resolves: #485