### PR TITLE
In case statement, stop trying pattern as literal string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ was subsequently created to document the work being done.
 None at this time.
 
 ## Notable non-backward compatible changes
+
+- `case "[0-9]" in [0-9]) echo match;; esac` has stopped matching. When a case
+  statement doesn't match a pattern, it no longer tries to use the pattern as
+  a literal string (issue #476).
 - echo builtin now interprets escape sequences and parses command line options
   on all platforms. (issue #370)
 - Support for the UWIN environment has been removed (issue #284).

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -53,7 +53,6 @@ static pid_t sh_ntfork(Shell_t *, const Shnode_t *, char *[], int *, int);
 #endif  // SHOPT_SPAWN
 
 static void sh_funct(Shell_t *, Namval_t *, int, char *[], struct argnod *, int);
-static bool trim_eq(const char *, const char *);
 static void coproc_init(Shell_t *, int pipes[]);
 
 static void *timeout;
@@ -2257,8 +2256,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                             s = rex->argval;
                         }
                         type = (rex->argflag & ARG_RAW);
-                        if ((type && strcmp(r, s) == 0) ||
-                            (!type && (strmatch(r, s) || trim_eq(r, s)))) {
+                        if ((type && strcmp(r, s) == 0) || (!type && strmatch(r, s))) {
                             do {
                                 sh_exec(shp, t->reg.regcom,
                                         (t->reg.regflag ? (flags & sh_state(SH_ERREXIT)) : flags));
@@ -2618,20 +2616,6 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
         if (was_errexit) sh_onstate(shp, SH_ERREXIT);
     }
     return shp->exitval;
-}
-
-//
-// Test for equality with second argument trimmed.
-// Returns 1 if r == trim(s) otherwise 0.
-//
-static bool trim_eq(const char *r, const char *s) {
-    char c;
-
-    while ((c = *s++)) {
-        if (c == '\\') c = *s++;
-        if (c && c != *r++) return (0);
-    }
-    return *r == 0;
 }
 
 //

--- a/src/cmd/ksh93/tests/case.sh
+++ b/src/cmd/ksh93/tests/case.sh
@@ -83,3 +83,8 @@ expect=foo.h
 
 x=$($SHELL -ec 'case a in a) echo 1; false; echo 2 ;& b) echo 3;; esac')
 [[ $x == 1 ]] || log_error 'set -e ignored on case fail through'
+
+# https://github.com/att/ast/issues/476
+case "[0-9]" in
+[0-9])    log_error 'literal "[0-9]" matches pattern [0-9]';;
+esac


### PR DESCRIPTION
`case "[0-9]" in [0-9]) echo match;; esac` now stops matching. When a
case statement doesn't match a pattern -- as the string "[0-9]"
doesn't match the pattern [0-9] for a single digit -- then it no
longer tries to use the pattern as a literal string.

Now `case word in pattern)` in ksh behaves like `[[ word = pattern ]]`
in ksh and case statements in most other shells.

Resolves #476