### PR TITLE
Fix compiler warnings in xec.c

### DIFF
--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -59,7 +59,9 @@ static void *timeout;
 static char nlock;
 static char pipejob;
 static int restorefd;
+#if SPAWN_cwd
 static int restorevex;
+#endif  // SPAWN_cwd
 
 struct funenv {
     Namval_t *node;
@@ -67,6 +69,7 @@ struct funenv {
     Namval_t **nref;
 };
 
+#if SHOPT_SPAWN
 static int io_usevex(struct ionod *iop) {
     struct ionod *first = iop;
     for (; iop; iop = iop->ionxt) {
@@ -74,6 +77,7 @@ static int io_usevex(struct ionod *iop) {
     }
     return (IOUSEVEX);
 }
+#endif  // SHOPT_SPAWN
 #if 1
 #undef IOUSEVEX
 #define IOUSEVEX 0


### PR DESCRIPTION
clang warned that variable `restorevex` and function `io_usevex()` are
unused.  Fix by adding `#if ... #endif`.