### PR TITLE
Keep exit status consistent for non-executable commands

### DIFF
--- a/src/cmd/ksh93/tests/path.sh
+++ b/src/cmd/ksh93/tests/path.sh
@@ -140,18 +140,15 @@ then
     log_error "leading : in path not working"
 fi
 
-log_info "TODO: Enable this test when bug #485 is fixed."
-# Disabled because once in a while (~20% of the time) the exit status is 126 (ENOENT) rather than
-# the expected 127 (ENOEXEC).
-#
-# (
-#     rm -rf noexec
-#     print 'print cannot execute' > noexec
-#     noexec > /dev/null 2>&1
-# )
-# actual=$?
-# expect=127
-# [[ $actual == $expect ]] || log_error "exit status of non-executable is wrong" "$expect" "$actual"
+# POSIX: If a command is found, but is not executable, exit status should be 126.
+(
+    rm -rf noexec
+    print 'print cannot execute' > noexec
+    noexec > /dev/null 2>&1
+)
+actual=$?
+expect=126
+[[ $actual == $expect ]] || log_error "exit status of non-executable is wrong" "$expect" "$actual"
 
 builtin -d rm 2> /dev/null
 chmod=$(whence chmod)


### PR DESCRIPTION
POSIX has 2 different statements about searching commands in PATH:

If a command is not found, the exit status shall be 127. If the command
name is found, but it is not an executable utility, the exit status
shall be 126. Applications that invoke utilities without using the shell
should use these exit status values to report similar errors.

and

The list shall be searched from beginning to end, applying the filename
to each prefix, until an executable file with the specified name and
appropriate execution permissions is found.

It means that shell should not stop searching if a command is found, but
not executable. And it should return 126 only when executable command is
not present in other elements of PATH.

Ksh already complies with this behavior. However if a command is found,
but not executable, it was returning with wrong exit code in some cases:

1. If a command is found in the last element of PATH but is not
executable, ksh returns with status 126.

2. If a command is found before last element of PATH but is not
executable, ksh continues to search for it further in other paths. It
returns with status 127 when executable command could not be found in
other paths.

It should behave consistently and return with status 126 when a command
is found in PATH but is not executable.

Resolves: #485