### PR TITLE
Make the ksh unit tests more hermetic

### DIFF
--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -77,7 +77,7 @@ ld_library_path = 'LD_LIBRARY_PATH=' + ':'.join(
 # The emptry string is POSIX locale.
 # TODO: Check how ksh code handles '' string while setting locales and
 # explicitly set string to 'C' or 'POSIX' here if possible.
-locales = ['', 'C.UTF-8']
+locales = ['C', 'C.UTF-8']
 
 # Each entry in `all_tests` is an array of one or two elements. The first
 # element is the test name. The second is an optional timeout if the default
@@ -118,7 +118,7 @@ foreach testspec : all_tests
     endforeach
 
     # shcomp tests
-    lang_var = 'LANG='
+    lang_var = 'LANG=C.UTF-8'
     if not shcomp_tests_to_skip.contains(testname)
         test(testname + '/shcomp', ksh93_exe, timeout: timeout,
              args: [ test_driver, 'shcomp', testname],

--- a/src/cmd/ksh93/tests/util/preamble.sh
+++ b/src/cmd/ksh93/tests/util/preamble.sh
@@ -5,6 +5,16 @@ readonly test_file=${0##*/}
 readonly test_name=$1
 
 #
+# Make sure the unit test can't inadvertantly modify several critical env vars.
+#
+readonly FULL_PATH
+readonly ORIG_PATH
+readonly SAFE_PATH
+readonly TEST_DIR
+readonly TEST_SRC_DIR
+readonly BUILD_DIR
+
+#
 # Create some functions for reporting and counting errors.
 #
 integer error_count=0

--- a/src/cmd/ksh93/tests/util/run_test.sh
+++ b/src/cmd/ksh93/tests/util/run_test.sh
@@ -17,7 +17,7 @@ fi
 #
 # Setup the environment for the unit test.
 #
-export TEST_SRC_DIR=${0%/*/*}
+export TEST_SRC_DIR=${0%/*/*}  # capture the parent directory containing this script
 readonly test_name=$1
 readonly test_path=$TEST_SRC_DIR/$test_name.sh
 readonly test_script=$test_name.sh
@@ -25,7 +25,7 @@ export BUILD_DIR=$PWD
 
 #
 # Create a temp dir and make it the CWD for the unit test. It will be removed by the unit test
-# postscript it if we exit cleanly.
+# postscript if there are no test failures.
 #
 # The use of `mktemp -dt` isn't ideal as it has slightly different meaning on BSD and GNU. But for
 # our purposes that doesn't matter. It simply means the temp file name will contain the X's on a BSD
@@ -50,7 +50,8 @@ export PATH=$FULL_PATH
 
 #
 # Create a couple of named pipes (fifos) for the unit test to use as barriers rather than using
-# arbitrary sleeps.
+# arbitrary sleeps. The numeric suffix reflects the file-descriptor that will be open for
+# read-write on the fifo; e.g., `exec 9<>fifo9`.
 #
 mkfifo fifo9
 mkfifo fifo8
@@ -61,6 +62,18 @@ mkfifo fifo8
 mkdir $TEST_DIR/home
 export HOME=$TEST_DIR/home
 export HISTFILE=$TEST_DIR/sh_history
+
+#
+# Make sure any locale vars set by the user (or the continuous build environment) don't affect the
+# tests. The only var we don't unset or change is `LANG` because we expect `meson test` to set it.
+#
+unset LC_ALL
+unset LC_COLLATE
+unset LC_CTYPE
+unset LC_MESSAGES
+unset LC_MONETARY
+unset LC_NUMERIC
+unset LC_TIME
 
 #
 # Create the actual unit test script by concatenating the stock preamble and postscript to the unit

--- a/src/cmd/ksh93/tests/util/util.sh
+++ b/src/cmd/ksh93/tests/util/util.sh
@@ -5,6 +5,16 @@
 readonly test_name=${0##*/}
 
 #
+# Make sure the unit test can't inadvertantly modify several critical env vars.
+#
+readonly FULL_PATH
+readonly ORIG_PATH
+readonly SAFE_PATH
+readonly TEST_DIR
+readonly TEST_SRC_DIR
+readonly BUILD_DIR
+
+#
 # Create some functions for reporting and counting errors.
 #
 integer error_count=0


### PR DESCRIPTION
Don't let the user environment locale vars affect the ksh unit tests.

Protect against unit tests inadvertantly changing critical env vars.

The ksh unit tests had been testing the default locale in effect when
the tests were run. Explicitly test the "C" locale instead. Note that
this is different from "C.UTF-8".

Fixes #255