### PR TITLE
fix or skip some tests in OpenBSD

### DIFF
--- a/src/cmd/ksh93/tests/sh_match.sh
+++ b/src/cmd/ksh93/tests/sh_match.sh
@@ -52,10 +52,11 @@ function test_xmlfragment1
     typeset -r testscript='test1_script.sh'
 
     cat >"${testscript}" <<-TEST1SCRIPT
-	# memory safeguards to prevent out-of-control memory consumption
-	ulimit -M \$(( 1024 * 1024 ))
-	ulimit -v \$(( 1024 * 1024 ))
-	ulimit -d \$(( 1024 * 1024 ))
+	# Put safeguards to prevent out-of-control memory consumption.
+	# Ignore "read only" error if a limit is not supported.
+	ulimit -M \$(( 1024 * 1024 )) 2>/dev/null
+	ulimit -v \$(( 1024 * 1024 )) 2>/dev/null
+	ulimit -d \$(( 1024 * 1024 )) 2>/dev/null
 
 	# input text
 	xmltext="\$( < "\$1" )"


### PR DESCRIPTION
I reported in #483 that some tests fail in OpenBSD, because of differences between OpenBSD and other systems. These commits edit the tests sh_match.sh, signal.sh, and variables.sh to give "OK" on OpenBSD.

The remaining tests that "FAIL" are these:

- pty.sh might be ksh's bug.
- arith.sh, comvario.sh, treemove.sh fail because of OpenBSD's bug in strtold().
- coprocess.sh, sigchld.sh are often "OK" but have a chance to "FAIL".