### PR TITLE
Disable case modification in parameter substitution

### DIFF
--- a/src/cmd/ksh93/data/lexstates.c
+++ b/src/cmd/ksh93/data/lexstates.c
@@ -189,12 +189,12 @@ static const char sh_lexstate7[256] = {
     S_ERR,  S_ERR,  S_ERR,  S_ERR,   S_ERR, S_ERR,  S_ERR,  S_ERR,
 
     S_ERR,  S_ERR,  S_ERR,  S_MOD2,  S_ERR, S_MOD2, S_ERR,  S_ERR,  S_ERR, S_ERR, S_MOD1, S_MOD1,
-    S_MOD2, S_MOD1, S_DOT,  S_MOD2,  0,     0,      0,      0,      0,     0,     0,      0,
+    S_ERR, S_MOD1, S_DOT,  S_MOD2,  0,     0,      0,      0,      0,     0,     0,      0,
     0,      0,      S_MOD1, S_ERR,   S_ERR, S_MOD1, S_ERR,  S_MOD1,
 
     0,      0,      0,      0,       0,     0,      0,      0,      0,     0,     0,      0,
     0,      0,      0,      0,       0,     0,      0,      0,      0,     0,     0,      0,
-    0,      0,      0,      S_BRACT, S_ESC, S_ERR,  S_MOD2, 0,
+    0,      0,      0,      S_BRACT, S_ESC, S_ERR,  S_ERR, 0,
 
     S_ERR,  0,      0,      0,       0,     0,      0,      0,      0,     0,     0,      0,
     0,      0,      0,      0,       0,     0,      0,      0,      0,     0,     0,      0,

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -1687,8 +1687,15 @@ retry2:
                 }
             }
             if (vsize) {
+#if 0
                 if (c == ',' || c == '^') offset = stktell(stkp);
+#endif
                 mac_copy(mp, v, vsize > 0 ? vsize : strlen(v));
+#if 0
+                // This code supports case modification in parameter substitution.
+                // It was not available in ksh-20120801. We should consider removing
+                // it altogether.
+                // https://github.com/att/ast/issues/417
                 if (c == ',' || c == '^') {
                     v = stkptr(stkp, offset);
                     if (type) {
@@ -1698,6 +1705,7 @@ retry2:
                         *v = (c == '^' ? toupper(*v) : tolower(*v));
                     }
                 }
+#endif
             }
             if (addsub) {
                 mp->shp->instance++;


### PR DESCRIPTION
It seems this feature is inspired bash and it is a backward incompatible
with the last stable release. We should keep it disabled in the next
release.

Related: #417