### PR TITLE
Remove support for SHOPT_ACCT and SHOPT_ACCTFILE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ None at this time.
   experimental and undocumented this should not break any existing users of
   `ksh` built with this feature enabled. (issue #234)
 - <> operator now redirects standard input by default (issue #75).
+- Support for the build time SHOPT_ACCTFILE symbol and code has been removed
+  (issue #210).
 
 ## Notable fixes and improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ None at this time.
 
 ## Other significant changes
 
+- Code hidden behind the SHOPT_ACCT and SHOPT_ACCTFILE build time symbols
+  has been removed. The features are not enabled by default and I am not aware
+  of any distro which enables them. Furthermore, they are huge security holes
+  and should never be enabled.
 - The suid_exec program has been removed (issue #366).
 - The code has been restyled according to new guidelines (issue #125).
 - Many features which used to be optionally included at build time are now

--- a/src/cmd/ksh93/include/path.h
+++ b/src/cmd/ksh93/include/path.h
@@ -126,11 +126,4 @@ extern const char is_function[];
 extern const char is_ufunction[];
 extern const char e_prohibited[];
 
-#if SHOPT_ACCT
-extern void sh_accinit(void);
-extern void sh_accbegin(const char *);
-extern void sh_accend(void);
-extern void sh_accsusp(void);
-#endif  // SHOPT_ACCT
-
 #endif  // !PATH_OFFSET

--- a/src/cmd/ksh93/sh/fault.c
+++ b/src/cmd/ksh93/sh/fault.c
@@ -603,9 +603,6 @@ void sh_done(void *ptr, int sig) {
     }
     if (shp->var_tree) nv_scan(shp->var_tree, array_notify, (void *)0, NV_ARRAY, NV_ARRAY);
     sh_freeup(shp);
-#if SHOPT_ACCT
-    sh_accend();
-#endif  // SHOPT_ACCT
     if (mbwide() || sh_isoption(shp, SH_EMACS) || sh_isoption(shp, SH_VI) ||
         sh_isoption(shp, SH_GMACS))
         tty_cooked(-1);

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -70,10 +70,6 @@ char e_version[] =
 #define ATTRS 1
     "J"
 #endif
-#if SHOPT_ACCT
-#define ATTRS 1
-    "L"
-#endif
 #if SHOPT_REGRESS
 #define ATTRS 1
     "R"

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -325,10 +325,6 @@ int sh_main(int ac, char *av[], Shinit_f userinit) {
             }
             error_info.id = name;
             shp->comdiv--;
-#if SHOPT_ACCT
-            sh_accinit();
-            if (fdin != 0) sh_accbegin(error_info.id);
-#endif  // SHOPT_ACCT
         }
     } else {
         fdin = shp->infd;

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -2789,9 +2789,6 @@ pid_t _sh_fork(Shell_t *shp, pid_t parent, int flags, int *jobid) {
     sh_onstate(shp, SH_FORKED);
     sh_onstate(shp, SH_NOLOG);
     if (shp->fn_reset) shp->fn_depth = shp->fn_reset = 0;
-#if SHOPT_ACCT
-    sh_accsusp();
-#endif  // SHOPT_ACCT
     // Reset remaining signals to parent except for those `lost' by trap.
     if (!(flags & FSHOWME)) sh_sigreset(shp, 2);
     shp->subshell = 0;


### PR DESCRIPTION
These two features are not enabled by default, are not enabled in any distro I have access to, and are huge security holes. No sane distro  would ever enable these features so remove them.