### PR TITLE
Use non-zero delay in sigchld test

### DIFF
--- a/src/cmd/ksh93/tests/sigchld.sh
+++ b/src/cmd/ksh93/tests/sigchld.sh
@@ -18,7 +18,7 @@
 #                                                                      #
 ########################################################################
 
-float DELAY=${1:-0.2}
+float DELAY=0.2
 integer FOREGROUND=10 BACKGROUND=2
 
 s=$($SHELL -c '


### PR DESCRIPTION
This test was specified as time sensitive in the legacy test script and
should be run with a non-zero delay. Since we have changed how test
cases are run, '$1' now contains test name. We should always use the
default timeout of 0.2 seconds in this script.

Resolves: #512