### PR TITLE
Don't declare strlcat() unconditionally

### DIFF
--- a/config_ast.h.in
+++ b/config_ast.h.in
@@ -201,7 +201,6 @@
 #mesondefine _lib_statvfs64
 #mesondefine _lib_stracmp
 #mesondefine _lib_strlcat
-#mesondefine _lib_strlcpy
 #mesondefine _lib_strnacmp
 #mesondefine _lib_strsignal
 #mesondefine _lib_sync

--- a/features/meson.build
+++ b/features/meson.build
@@ -84,6 +84,8 @@ if not cc.has_function('isnanl', prefix: '#include <math.h>', args: feature_test
     feature_data.set('isnanl', 'isnan')
 endif
 
+feature_data.set10('_lib_strlcat',
+    cc.has_function('strlcat', prefix: '#include <string.h>', args: feature_test_args))
 feature_data.set10('_lib_utimensat',
     cc.has_function('utimensat', prefix: '#include <sys/stat.h>', args: feature_test_args))
 feature_data.set10('_lib_sysinfo',

--- a/src/cmd/tests/terror.h
+++ b/src/cmd/tests/terror.h
@@ -51,7 +51,6 @@
 #define TIMEOUT 0 /* timeout in minutes */
 #endif
 
-extern int sprintf (char *, const char *, ...);
 extern void tsterror (char *, ...);
 extern void tstinfo (char *, ...);
 extern void tstwarn (char *, ...);

--- a/src/lib/libast/include/ast_sys.h
+++ b/src/lib/libast/include/ast_sys.h
@@ -113,8 +113,10 @@ extern char *gettxt(const char *, const char *);
 extern void *memalign(size_t, size_t);
 extern void *pvalloc(size_t);
 extern char *resolvepath(const char *, char *, size_t);
+#if !_lib_strlcat
 extern size_t strlcat(char *, const char *, size_t);
 extern size_t strlcpy(char *, const char *, size_t);
+#endif
 extern void swab(const void *, void *, ssize_t);
 
 #include <stdarg.h>

--- a/src/lib/libast/string/strlcat.c
+++ b/src/lib/libast/string/strlcat.c
@@ -24,11 +24,7 @@
  */
 #include "config_ast.h"  // IWYU pragma: keep
 
-#define strlcat ______strlcat
-
 #include <ast.h>
-
-#undef strlcat
 
 #if _lib_strlcat
 

--- a/src/lib/libast/string/strlcpy.c
+++ b/src/lib/libast/string/strlcpy.c
@@ -24,13 +24,9 @@
  */
 #include "config_ast.h"  // IWYU pragma: keep
 
-#define strlcpy ______strlcpy
-
 #include <ast.h>
 
-#undef strlcpy
-
-#if _lib_strlcpy
+#if _lib_strlcat
 
 NoN(strlcpy)
 


### PR DESCRIPTION
Recent changes cause the unconditional declarations of `sprintf()`,
`strlcat()` and `strlcpy()` to be used (in a few files) after the relevant
system header that declares them has been imported. On macOS this causes
compilation errors due to differing declarations. So check if the system
provides those functions and only declare them if it doesn't.