### PR TITLE
Fix test failures on latest Ubuntu image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: required
-dist: trusty
-group: deprecated-2017Q4
 language: c
+
 env:
     global:
         # Travis currently only provides two cores per VM:

--- a/src/cmd/ksh93/tests/bracket.sh
+++ b/src/cmd/ksh93/tests/bracket.sh
@@ -305,15 +305,14 @@ done
 ) || log_error 'errors with {..}(...) patterns'
 [[ D290.2003.02.16.temp == D290.+(2003.02.16).temp* ]] || log_error 'pattern match bug with +(...)'
 rm -rf $file
-{
+touch -t 01020304.05 $file
 [[ -N $file ]] && log_error 'test -N $TEST_DIR/*: st_mtime>st_atime after creat'
-sleep 2
-print 'hello world'
+# Update only mtime to mimic the file was written
+touch -m -t 01020708.09 $file
 [[ -N $file ]] || log_error 'test -N $TEST_DIR/*: st_mtime<=st_atime after write'
-sleep 2
-read
+# Update only atime to mimic the file was read
+touch -a -t 01020809.10 $file
 [[ -N $file ]] && log_error 'test -N $TEST_DIR/*: st_mtime>st_atime after read'
-} > $file < $file
 if rm -rf "$file" && ln -s / "$file"
 then
     [[ -L "$file" ]] || log_error '-L not working'


### PR DESCRIPTION
It is a recommended filesystem optimization to disable atime updates on
reads. One of the bracket tests breaks due to this optimization. To
workaround this, we should use 'touch -a` to mimic the file was read.

Resolves: #227