### PR TITLE
Make dump_backtrace() more useful

### DIFF
--- a/config_ast.h.in
+++ b/config_ast.h.in
@@ -25,6 +25,7 @@
 // These are atypical platform symbols with respect to how they are
 // determined. They are either hardcoded or not determined via the usual
 // platform feature detection and naming conventions.
+#mesondefine DEBUG_BUILD
 #mesondefine MESON_BUILD
 #mesondefine HOSTTYPE
 #mesondefine BASH_MACHTYPE
@@ -342,3 +343,11 @@
 #define _ast_intmax_long 1
 #define _ast_intswap 7
 #define _ast_fltmax_t long double
+
+#if DEBUG_BUILD
+// If we're doing a debug build don't have any static (module private) functions.
+// This is needed on most platforms for dladdr() to give us an accurate backtrace.
+#define static_fn
+#else
+#define static_fn static
+#endif

--- a/meson.build
+++ b/meson.build
@@ -86,6 +86,21 @@ if system == 'darwin'
     feature_data.set('_DARWIN_C_SOURCE', 1)
 endif
 
+# We need symbols in the program to be visible to `dladdr()` and related
+# functions. This is necessary to be able to resolve addresses in the program
+# to the appropriate function. Otherwise only symbols in dynamically loaded
+# libraries are visible.
+if get_option('buildtype') == 'debug'
+    feature_data.set('DEBUG_BUILD', 1)
+    add_global_arguments('-fno-inline', language: 'c')
+    # This should be `if cc.has_link_argument()` but that isn't available
+    # until Meson 0.46 or newer and we can't count on that yet. And in
+    # practice this test works fine but can result in a meson warning.
+    if cc.has_argument('-Wl,-E')
+        add_global_link_arguments('-Wl,-E', language: 'c')
+    endif
+endif
+
 hosttype_cmd=run_command('bin/hosttype')
 hosttype=hosttype_cmd.stdout().strip()
 feature_data.set_quoted('HOSTTYPE', hosttype)

--- a/src/cmd/ksh93/include/fault.h
+++ b/src/cmd/ksh93/include/fault.h
@@ -115,6 +115,7 @@ typedef void (*sh_sigfun_t)(int);
 extern sh_sigfun_t sh_signal(int, sh_sigfun_t);
 extern void sh_fault(int, siginfo_t *, void *);
 extern void sh_setsiginfo(siginfo_t *);
+extern void dump_backtrace(int max_frames, int skip_levels);
 #undef signal
 #define signal(a, b) sh_signal(a, (sh_sigfun_t)(b))
 


### PR DESCRIPTION
This causes more function names to be visible to the `dladdr()` function
on GNU Linux and other systems.

Fixes #460 

P.S., The changes I made to *nvinit.c* are to demonstrate what needs to be done to all the code for this to be truly useful. If this is deemed acceptable I'll make the same mechanical transformation to the other ksh modules.