### PR TITLE
Export variables defined with ${:=} after 'set -a'

### DIFF
--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -1025,6 +1025,7 @@ static bool varsub(Mac_t *mp) {
     char *idx = 0;
     int var = 1, addsub = 0, oldpat = mp->pattern, idnum = 0, flag = 0, d;
     Stk_t *stkp = mp->shp->stk;
+    Shell_t *shp = sh_getinterp();
 
 retry1:
     mp->zeros = 0;
@@ -1788,6 +1789,7 @@ retry2:
             if (np) {
                 if (mp->shp->subshell) np = sh_assignok(np, 1);
                 nv_putval(np, argp, 0);
+                if (sh_isoption(shp, SH_ALLEXPORT)) nv_onattr(np, NV_EXPORT);
                 v = nv_getval(np);
                 nulflg = 0;
                 stkseek(stkp, offset);

--- a/src/cmd/ksh93/tests/attributes.sh
+++ b/src/cmd/ksh93/tests/attributes.sh
@@ -574,3 +574,11 @@ do
     read -r -N6 var
     [[ $var == dHdvdG93 ]] &&  ((i !=2)) && log_error 'loop optimization bug with typeset -b variables'
 done <<< 'twotowthreetfourro'
+
+# https://github.com/att/ast/issues/537
+unset foo bar
+# Export each variable that gets assigned
+set -a
+foo=${bar:=baz}
+env | grep -q bar || log_error 'Variable bar should be exported'
+set +a


### PR DESCRIPTION
After 'set -a', variables defined with ${parameter :=word} style of expansion should be exported.

Resolves: #537
