### PR TITLE
Restore definition of subshell_table_unset

### DIFF
--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -2200,16 +2200,7 @@ void _nv_unset(Namval_t *np, int flags) {
                 }
                 dtclose(rp->sdict);
             }
-            if (flags & NV_TABLE) {
-                // Drop all references and close the stream.
-                // Note that stkclose() calls sfclose() which frees the stream.
-                // TODO: What should we do if `stkclose()` reports an error (by returning -1)?
-                while (stkclose(slp->slptr) > 0) {
-                    ;  // empty loop
-                }
-            } else {
-                sfclose(slp->slptr);
-            }
+            stakdelete(slp->slptr);
             free(np->nvalue.ip);
             np->nvalue.ip = 0;
         }


### PR DESCRIPTION
This function was causing lot of use after free crashes, so I have
restored it back to it's definition from ksh93u+ release.

Related: #398