### PR TITLE
sched_yield rather than sleep

### DIFF
--- a/src/cmd/tests/aso/meson.build
+++ b/src/cmd/tests/aso/meson.build
@@ -11,5 +11,5 @@ foreach file: aso_test_files
                              install: false)
     # TODO: Figure out how to make these tests more efficient so we don't need such an absurdly long
     # timeout in order to keep these tests from timing out on OpenBSD. See issue #483.
-    test('API/' + file, aso_test_target, timeout: 300)
+    test('API/' + file, aso_test_target)
 endforeach

--- a/src/cmd/tests/aso/tlock.c
+++ b/src/cmd/tests/aso/tlock.c
@@ -19,6 +19,8 @@
  ***********************************************************************/
 #include "config_ast.h"  // IWYU pragma: keep
 
+#include <sched.h>
+
 #include "terror.h"
 
 /* Test concurrency locking based on Atomic Scalar Operations
@@ -66,7 +68,7 @@ int lockobj(void *lck, ssize_t size, int locking) {
         return 0;
     }
 
-    for (k = 0;; ++k, usleep(100)) /* locking a slot */
+    for (k = 0;; ++k, sched_yield()) /* locking a slot */
     {
         if (size == sizeof(char))
             aso = asocaschar(lck, 0, Pnum);
@@ -83,7 +85,7 @@ int lockobj(void *lck, ssize_t size, int locking) {
             twarn("Process %3d(pid=%d): locking loop %d blocked by %d", Pnum, Pid[Pnum], k, aso);
     }
 
-    for (k = 0; k < 2; ++k, usleep(100)) /* make sure that lock is good */
+    for (k = 0; k < 2; ++k, sched_yield()) /* make sure that lock is good */
     {
         if (size == sizeof(char))
             lckv = *((char *)lck);
@@ -154,7 +156,7 @@ tmain() {
             continue;
         } else /* child process */
         {
-            for (;; usleep(1000)) /* wait until all are alive */
+            for (;; sched_yield()) /* wait until all are alive */
                 if (*Nproc == N_PROC) break;
             workload(k); /* now start working concurrently */
             texit(0);

--- a/src/cmd/tests/cdt/meson.build
+++ b/src/cmd/tests/cdt/meson.build
@@ -17,5 +17,5 @@ foreach file: cdt_test_files
                              install: false)
     # TODO: Figure out how to make these tests more efficient so we don't need such an absurdly long
     # timeout in order to keep these tests from timing out on OpenBSD. See issue #483.
-    test('API/' + file, aso_test_target, timeout: 300)
+    test('API/' + file, aso_test_target)
 endforeach

--- a/src/cmd/tests/cdt/trehash.c
+++ b/src/cmd/tests/cdt/trehash.c
@@ -19,9 +19,10 @@
  ***********************************************************************/
 #include "config_ast.h"  // IWYU pragma: keep
 
-#include "dttest.h"
-
 #include <sys/mman.h>
+#include <sched.h>
+
+#include "dttest.h"
 
 /* Test concurrency usage of the method Dtrhset.
 **
@@ -130,7 +131,7 @@ static void workload(Dt_t *dt, Proc_t *proc, int p) {
     /* insert objects in 'p' */
     asoincint(&State->insert);                  /* signaling that we are ready to go */
     while (asogetint(&State->insert) != N_PROC) /* wait until all processes are set */
-        usleep(100);
+        sched_yield();
     for (k = 0; k < proc->objn; ++k) {
         if (k && k % PROGRESS == 0) tinfo("\tProcess %d(%d): insertion passing %d", p, pid, k);
 
@@ -158,12 +159,12 @@ static void workload(Dt_t *dt, Proc_t *proc, int p) {
     tinfo("Process %d(%d): insertion done", p, pid);
     asoincint(&State->idone);            /* signaling that this workload has been inserted */
     while (asogetint(&State->idone) > 0) /* wait until parent signal ok to continue */
-        usleep(100);
+        sched_yield();
 
     /* delete objects in 'p' and also in "foe" of p */
     asoincint(&State->delete);                  /* signaling that we are ready to delete */
     while (asogetint(&State->delete) != N_PROC) /* wait until all processes are set */
-        usleep(100);
+        sched_yield();
     for (k = 0; k < proc->objn; ++k) {
         if (k && k % PROGRESS == 0) tinfo("\tProcess %d(%d): deletion passing %d", p, pid, k);
 

--- a/src/cmd/tests/cdt/tsafehash.c
+++ b/src/cmd/tests/cdt/tsafehash.c
@@ -19,9 +19,10 @@
  ***********************************************************************/
 #include "config_ast.h"  // IWYU pragma: keep
 
-#include "dttest.h"
-
+#include <sched.h>
 #include <sys/mman.h>
+
+#include "dttest.h"
 
 /* Test concurrency usage of the method Dtrhset.
 **
@@ -130,7 +131,7 @@ static void workload(Dt_t *dt, Proc_t *proc, int p) {
     /* insert objects in 'p' */
     asoincint(&State->insert);                  /* signaling that we are ready to go */
     while (asogetint(&State->insert) != N_PROC) /* wait until all processes are set */
-        usleep(100);
+        sched_yield();
     for (k = 0; k < proc->objn; ++k) {
         if (k && k % PROGRESS == 0) tinfo("\tProcess %d(%d): insertion passing %d", p, pid, k);
 
@@ -158,12 +159,12 @@ static void workload(Dt_t *dt, Proc_t *proc, int p) {
     tinfo("Process %d(%d): insertion done", p, pid);
     asoincint(&State->idone);            /* signaling that this workload has been inserted */
     while (asogetint(&State->idone) > 0) /* wait until parent signal ok to continue */
-        usleep(100);
+        sched_yield();
 
     /* delete objects in 'p' and also in "foe" of p */
     asoincint(&State->delete);                  /* signaling that we are ready to delete */
     while (asogetint(&State->delete) != N_PROC) /* wait until all processes are set */
-        usleep(100);
+        sched_yield();
     for (k = 0; k < proc->objn; ++k) {
         if (k && k % PROGRESS == 0) tinfo("\tProcess %d(%d): deletion passing %d", p, pid, k);
 

--- a/src/cmd/tests/cdt/tsafetree.c
+++ b/src/cmd/tests/cdt/tsafetree.c
@@ -19,9 +19,10 @@
  ***********************************************************************/
 #include "config_ast.h"  // IWYU pragma: keep
 
-#include "dttest.h"
-
+#include <sched.h>
 #include <sys/mman.h>
+
+#include "dttest.h"
 
 /* Test concurrency usage of the method Dtrhset.
 **
@@ -131,7 +132,7 @@ static void workload(Dt_t *dt, Proc_t *proc, int p) {
     /* insert objects in 'p' */
     asoincint(&State->insert);                  /* signaling that we are ready to go */
     while (asogetint(&State->insert) != N_PROC) /* wait until all processes are set */
-        usleep(100);
+        sched_yield();
     for (k = 0; k < proc->objn; ++k) {
         if (k && k % PROGRESS == 0) tinfo("\tProcess %d(%d): insertion passing %d", p, pid, k);
 
@@ -159,12 +160,12 @@ static void workload(Dt_t *dt, Proc_t *proc, int p) {
     tinfo("Process %d(%d): insertion done", p, pid);
     asoincint(&State->idone);            /* signaling that this workload has been inserted */
     while (asogetint(&State->idone) > 0) /* wait until parent signal ok to continue */
-        usleep(100);
+        sched_yield();
 
     /* delete objects in 'p' and also in "foe" of p */
     asoincint(&State->delete);                  /* signaling that we are ready to delete */
     while (asogetint(&State->delete) != N_PROC) /* wait until all processes are set */
-        usleep(100);
+        sched_yield();
     for (k = 0; k < proc->objn; ++k) {
         if (k && k % PROGRESS == 0) tinfo("\tProcess %d(%d): deletion passing %d", p, pid, k);
 


### PR DESCRIPTION
Several unit tests utilize very short duration sleeps (e.g., 100 usec)
while waiting for something to happen. The problem with this is that
on some platforms the minimum sleep interval might be 1, 10, even
100 msec. Which means the test can take one or two orders of magnitude
longer to run on those platforms compared to a platform where sleeps are
more granular. So instead of sleeping simply yield execution to another
runable thread.

This reduces the unit test run time for me from 49 minutes to 20 minutes
on OpenBSD in a virtual machine. And from 35 minutes to 16 minutes on
Cygwin.

Partial fix for #483
Partial fix for #546