### PR TITLE
Fix a use after free issue caused by _nv_unset function

### DIFF
--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -2200,16 +2200,7 @@ void _nv_unset(Namval_t *np, int flags) {
                 }
                 dtclose(rp->sdict);
             }
-            if (flags & NV_TABLE) {
-                // Drop all references and close the stream.
-                // Note that stkclose() calls sfclose() which frees the stream.
-                // TODO: What should we do if `stkclose()` reports an error (by returning -1)?
-                while (stkclose(slp->slptr) > 0) {
-                    ;  // empty loop
-                }
-            } else {
-                sfclose(slp->slptr);
-            }
+            stakdelete(slp->slptr);
             free(np->nvalue.ip);
             np->nvalue.ip = 0;
         }


### PR DESCRIPTION
_nv_unset function runs stkclose() on a stack in a while loop until
it's reference count is less than one and it can free the stack. But
the same stack is getting free'd by sh_freeup() function later. This
may cause a crash due to memory corruption. In ksh93u+ release,
stakdelete() macro was used to close the stack. This macro calls
stkclose() function and it decreases reference count for the stack by
only one. It should be later free'd by sh_freeup() function.

Related: #398