### PR TITLE
Fix a use after free issue while unseting arrays

### DIFF
--- a/src/cmd/ksh93/sh/array.c
+++ b/src/cmd/ksh93/sh/array.c
@@ -501,7 +501,10 @@ static_fn void array_putval(Namval_t *np, const char *string, int flags, Namfun_
                     if (mp != np) {
                         array_clrbit(aq->bits, aq->cur, ARRAY_CHILD);
                         aq->val[aq->cur].cp = 0;
-                        if (!xfree) nv_delete(mp, ap->table, 0);
+                        // TODO: NV_NOFREE was added here as a workaround for a use after free bug
+                        // If it creates a big memory leak we should investigate another solution for it
+                        // https://github.com/att/ast/issues/398
+                        if (!xfree) nv_delete(mp, ap->table, NV_NOFREE);
                     }
                     if (!array_covered(np, (struct index_array *)ap)) {
                         if (array_elem(ap)) ap->nelem--;


### PR DESCRIPTION
There is a use after free issue that may occur while unseting elements
of an array. This patch works around it.

Related: #398