### PR TITLE
Fix unit test handling of va_list taking functions

### DIFF
--- a/src/cmd/tests/sfio/tbadargs.c
+++ b/src/cmd/tests/sfio/tbadargs.c
@@ -21,7 +21,7 @@
 
 #include "sftest.h"
 
-int Code_line = 30; /* line number of CALL(sfclose(0)) */
+int Code_line = 42; /* line number of CALL(sfclose(0)) */
 
 #if defined(__LINE__)
 #define CALL(x) ((Code_line = __LINE__), (x))
@@ -31,11 +31,14 @@ int Code_line = 30; /* line number of CALL(sfclose(0)) */
 
 void handler(int sig) { terror("Bad argument handling on code line %d", Code_line); }
 
-tmain() {
+void main_varargs(int argc, char **argv, ...) {
+    va_list args;
+
     signal(SIGILL, handler);
     signal(SIGBUS, handler);
     signal(SIGSEGV, handler);
 
+    va_start(args, argv);
     CALL(sfclose(0));
     CALL(sfclrlock(0));
     CALL(sfopen(0, 0, 0));
@@ -56,7 +59,7 @@ tmain() {
     CALL(sfpool(0, 0, 0));
     CALL(sfpopen(0, 0, 0));
     CALL(sfprintf(0, 0));
-    CALL(sfvsprintf(0, 0, 0, 0));
+    CALL(sfvsprintf(0, 0, 0, args));
     CALL(sfsprintf(0, 0, 0));
     CALL(sfprints(0));
     CALL(sfpurge(0));
@@ -71,7 +74,7 @@ tmain() {
     CALL(sfreserve(0, 0, 0));
     CALL(sfresize(0, 0));
     CALL(sfscanf(0, 0));
-    CALL(sfvsscanf(0, 0, 0));
+    CALL(sfvsscanf(0, 0, args));
     CALL(sfsscanf(0, 0));
     CALL(sfseek(0, 0, 0));
     CALL(sfset(0, 0, 0));
@@ -89,6 +92,10 @@ tmain() {
     CALL(sfvscanf(0, 0, 0));
     CALL(sfwr(0, 0, 0, 0));
     CALL(sfwrite(0, 0, 0));
+    va_end(args);
+}
 
+tmain() {
+    main_varargs(argc, argv);
     texit(0);
 }

--- a/src/cmd/tests/sfio/tbadargs.c
+++ b/src/cmd/tests/sfio/tbadargs.c
@@ -38,7 +38,6 @@ void main_varargs(int argc, char **argv, ...) {
     signal(SIGBUS, handler);
     signal(SIGSEGV, handler);
 
-    va_start(args, argv);
     CALL(sfclose(0));
     CALL(sfclrlock(0));
     CALL(sfopen(0, 0, 0));
@@ -59,7 +58,6 @@ void main_varargs(int argc, char **argv, ...) {
     CALL(sfpool(0, 0, 0));
     CALL(sfpopen(0, 0, 0));
     CALL(sfprintf(0, 0));
-    CALL(sfvsprintf(0, 0, 0, args));
     CALL(sfsprintf(0, 0, 0));
     CALL(sfprints(0));
     CALL(sfpurge(0));
@@ -74,7 +72,6 @@ void main_varargs(int argc, char **argv, ...) {
     CALL(sfreserve(0, 0, 0));
     CALL(sfresize(0, 0));
     CALL(sfscanf(0, 0));
-    CALL(sfvsscanf(0, 0, args));
     CALL(sfsscanf(0, 0));
     CALL(sfseek(0, 0, 0));
     CALL(sfset(0, 0, 0));
@@ -88,10 +85,14 @@ void main_varargs(int argc, char **argv, ...) {
     CALL(sftell(0));
     CALL(sftmp(0));
     CALL(sfungetc(0, 0));
-    CALL(sfvprintf(0, 0, 0));
-    CALL(sfvscanf(0, 0, 0));
     CALL(sfwr(0, 0, 0, 0));
     CALL(sfwrite(0, 0, 0));
+
+    va_start(args, argv);
+    CALL(sfvprintf(0, 0, args));
+    CALL(sfvscanf(0, 0, args));
+    CALL(sfvsprintf(0, 0, 0, args));
+    CALL(sfvsscanf(0, 0, args));
     va_end(args);
 }
 


### PR DESCRIPTION
The unit test incorrectly assumes that 0 == NULL == va_list. That
happens to be true on x86 but is not necessarily true on other
architectures like ARM.

Fixes #558