### PR TITLE
Building api tests should be configurable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -123,5 +123,10 @@ subdir('src/lib/libcmd')
 subdir('src/lib/libdll')
 subdir('src/lib/libcoshell')
 subdir('src/cmd/builtin')
-subdir('src/cmd/tests')
+
+# Check if api tests should be built
+if get_option('build-api-tests') == true
+    subdir('src/cmd/tests')
+endif
+
 subdir('src/cmd/ksh93')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,3 +16,7 @@ option('read-timeout', type : 'string', value : '0')
 # the default pathname for recording shell auditable events.
 #
 option('audit-file', type : 'string', value : '/etc/ksh_audit')
+
+# To disable building api tests, set build-api-tests option to false:
+#   meson -Dbuild-api-tests=false
+option('build-api-tests', type : 'boolean', value : true)


### PR DESCRIPTION
Not everyone would like to build api tests, so building these tests
should be configurable.

Related: #558