### PR TITLE
Fix invalid pointer dereference

### DIFF
--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -928,8 +928,9 @@ static_fn char **genvalue(char **argv, const char *prefix, int n, struct Walk *w
                 if (outfile && wp->indent < 0 && (wp->flags & NV_COMVAR)) sfputc(outfile, ';');
                 wp->flags |= NV_COMVAR;
                 if (argv[1]) {
-                    ssize_t r = (cp - argv[0]) + strlen(cp);
-                    if (argv[1][r] == '.' && strncmp(argv[0], argv[1], r) == 0) {
+                    ssize_t r0 = (cp - argv[0]) + strlen(cp);
+                    ssize_t r1 = strlen(argv[1]);
+                    if (r0 <= r1 && argv[1][r0] == '.' && strncmp(argv[0], argv[1], r0) == 0) {
                         wp->flags &= ~NV_COMVAR;
                     }
                 }

--- a/src/cmd/ksh93/tests/arrays.sh
+++ b/src/cmd/ksh93/tests/arrays.sh
@@ -723,9 +723,9 @@ x=$(
 ) 2> /dev/null
 [[ $x == "$exp" ]] || log_error 'setting element 1 of array to compound variable failed'
 
-#test for cloning a very large index array - can core dump
+# Test for cloning a very large index array.
 (
-    trap 'x=$?;exit $(( $x!=0 ))' EXIT
+    trap 'x=$?; exit $(( $x != 0 ))' EXIT
     $SHELL <<- \EOF
     (
         print '('
@@ -747,7 +747,7 @@ x=$(
     v=$(typeset -p hugecpv)
     [[ ${v/hugecpv/hugecpv2} == "$(typeset -p hugecpv2)" ]]
 EOF
-) 2> /dev/null || log_error 'copying a large array fails'
+) || log_error 'copying a large array fails'
 
 unset foo
 typeset -a foo


### PR DESCRIPTION
The `genvalue()` function can incorrectly access an address past the end
of a string pointing to a var name. This is usually harmless. But if the
string ends on a page boundary and the next page is not mapped then a
SIGSEGV occurs.

Partial fix for #483