### PR TITLE
Fix bug in sigalrm() setting shp->siginfo[SIGALRM]

### DIFF
--- a/src/cmd/ksh93/include/fault.h
+++ b/src/cmd/ksh93/include/fault.h
@@ -17,7 +17,9 @@
  *                    David Korn <dgkorn@gmail.com>                     *
  *                                                                      *
  ***********************************************************************/
-#ifndef SH_SIGBITS
+#ifndef FAULT_H_DEFINED
+#define FAULT_H_DEFINED
+
 //
 // UNIX shell
 // S. R. Bourne
@@ -97,6 +99,13 @@ struct checkpt {
 #endif
 };
 
+struct siginfo_ll {
+    siginfo_t info;
+    struct siginfo_ll *next;
+    struct siginfo_ll *last;
+};
+typedef struct siginfo_ll siginfo_ll_t;
+
 #if !_AST_no_spawnveg
 #define sh_pushcontext(shp, bp, n)                                                           \
     ((bp)->mode = (n), (bp)->olist = 0, (bp)->topfd = shp->topfd, (bp)->prev = shp->jmplist, \
@@ -111,10 +120,17 @@ struct checkpt {
 
 #define sh_popcontext(shp, bp) (shp->jmplist = (bp)->prev, errorpop(&((bp)->err)))
 
+// Bit of a chicken and egg problem here. If we've already included shell.h then this typedef
+// already exists and depending on the compiler defining it here may cause a warning or an error.
+#ifndef SHELL_H_DEFINED
+typedef struct Shell_s Shell_t;
+#endif
+
 typedef void (*sh_sigfun_t)(int);
 extern sh_sigfun_t sh_signal(int, sh_sigfun_t);
 extern void sh_fault(int, siginfo_t *, void *);
 extern void sh_setsiginfo(siginfo_t *);
+extern void set_trapinfo(Shell_t *shp, int sig, siginfo_t *info);
 extern void dump_backtrace(int max_frames, int skip_levels);
 #undef signal
 #define signal(a, b) sh_signal(a, (sh_sigfun_t)(b))
@@ -126,4 +142,4 @@ extern void timerdel(void *);
 
 extern const char e_alarm[];
 
-#endif  // !SH_SIGBITS
+#endif  // FAULT_H_DEFINED

--- a/src/cmd/ksh93/include/shell.h
+++ b/src/cmd/ksh93/include/shell.h
@@ -17,7 +17,9 @@
  *                    David Korn <dgkorn@gmail.com>                     *
  *                                                                      *
  ***********************************************************************/
-#ifndef SH_INTERACTIVE
+#ifndef SHELL_H_DEFINED
+#define SHELL_H_DEFINED
+
 //
 // David Korn
 // AT&T Labs
@@ -26,9 +28,16 @@
 //
 #define SH_VERSION 20120720
 
+// Bit of a chicken and egg problem here. If we've already included fault.h then this typedef
+// already exists and depending on the compiler defining it here may cause a warning or an error.
+#ifndef FAULT_H_DEFINED
+typedef struct Shell_s Shell_t;
+#endif
+
 #include <ast.h>
 #include <cdt.h>
 #include <stk.h>
+#include "fault.h"
 #ifdef _SH_PRIVATE
 #include "name.h"
 #else
@@ -56,8 +65,6 @@ typedef unsigned int Shopt_t_data_t;
 typedef struct {
     Shopt_t_data_t v[(256 / 8) / sizeof(Shopt_t_data_t)];
 } Shopt_t;
-
-typedef struct Shell_s Shell_t;
 
 #include <shcmd.h>
 
@@ -253,7 +260,7 @@ struct Shell_s {
     void *cdpathlist;
     char **argaddr;
     void *optlist;
-    void **siginfo;
+    siginfo_ll_t **siginfo;
 #if !_AST_no_spawnveg
     Spawnvex_t *vex;
     Spawnvex_t *vexp;
@@ -386,7 +393,7 @@ extern void *sh_waitnotify_20120720(Shwait_f, void *);
 //
 extern Shell_t sh;
 
-#include <shellapi.h>
+#include "shellapi.h"
 
 #ifndef _AST_INTERCEPT
 #if _lib_lseek64
@@ -455,4 +462,4 @@ extern Shell_t sh;
 #define SH_EXITMASK (SH_EXITSIG - 1)  // normal exit status bits
 #define SH_RUNPROG -1022              // needs to be negative and < 256
 
-#endif  // SH_INTERACTIVE
+#endif  // SHELL_H_DEFINED

--- a/src/cmd/ksh93/sh/timers.c
+++ b/src/cmd/ksh93/sh/timers.c
@@ -79,15 +79,11 @@ static_fn double setalarm(double t) {
 static_fn void sigalrm(int sig, siginfo_t *info, void *context) {
     Timer_t *tp, *tplast, *tpold, *tpnext;
     double now;
-    static double left;
+    static double left = 0;
     Shell_t *shp = sh_getinterp();
-    UNUSED(sig);
 
-    if (shp->st.trapcom[SIGALRM] && *shp->st.trapcom[SIGALRM]) {
-        shp->siginfo[SIGALRM] = malloc(sizeof(siginfo_t));
-        memcpy(shp->siginfo[SIGALRM], context, sizeof(siginfo_t));
-    }
-    left = 0;
+    set_trapinfo(shp, sig, info);
+
     if (time_state & SIGALRM_CALL)
         time_state &= ~SIGALRM_CALL;
     else if (alarm(0))


### PR DESCRIPTION
The `sigalrm()` function has two bugs. First, it's copying the `ucontext_t`
parameter when it should be copying the `siginfo_t` parameter. Second,
it's incorrect to assign a `siginfo_t*` to `shp->siginfo[SIGALRM]` since
that is supposed to be a `struct Siginfo*`.

I found this while looking at a core dump on OpenBSD that had sigalrm()
on the stack. I don't think this bug is the cause of the core dump but
it's wrong and could cause a fault. The crux of the problem is that
shp->siginfo[SIGALRM] is a linked list of `struct siginfo_ll` but
`sigalrm()` was treating it like single `siginfo_t` element.