### PR TITLE
Enable all pty tests, disable /etc/ksh.kshrc, avoid seq(1)

### DIFF
--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -64,7 +64,9 @@ function tst
     done
 }
 
-export PS1=':test-!: ' PS2='> ' PS4=': ' ENV= EXINIT= HISTFILE= TERM=dumb VISUAL=vi LC_ALL=C
+# ENV begins with /./ to disable /etc/ksh.kshrc.
+export PS1=':test-!: ' PS2='> ' PS4=': ' ENV=/./dev/null EXINIT= HISTFILE=
+export TERM=dumb VISUAL=vi LC_ALL=C
 
 if ! pty $bintrue < /dev/null
 then
@@ -448,7 +450,7 @@ L process/terminal group exercise
 
 # Make sure any LESS env var the user might have set doesn't interfere.
 w unset LESS
-w for i in $(seq 100); do echo seq-$i; done | less
+w printf 'seq-%s\n' {1..100} | less
 u :$|:\E|lines
 c j
 u seq-24


### PR DESCRIPTION
Disable /etc/ksh.kshrc so it can't change PS1 or other environment
variables; such changes can break the tests.  Switch from `seq 100` to
`{1..100}` because OpenBSD has no seq(1) command.  Remove TODO
comments and enable tests in pty.sh.  Some tests use stty(1); these
should work even if stty(1) is not a builtin.

This enables the test for https://github.com/att/ast/issues/375