### PR TITLE
Disable code that causes error on start up

### DIFF
--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -1325,7 +1325,8 @@ Shell_t *sh_init(int argc, char *argv[], Shinit_f userinit) {
     shp->pwdfd = sh_diropenat(shp, AT_FDCWD, e_dot);
 #if O_SEARCH
     // This should _never_ happen, guaranteed by design and goat sacrifice.
-    if (shp->pwdfd < 0) errormsg(SH_DICT, ERROR_system(1), "Can't obtain directory fd.");
+    // If shell starts in a directory that it does not have access to, this will cause error.
+    // if (shp->pwdfd < 0) errormsg(SH_DICT, ERROR_system(1), "Can't obtain directory fd.");
 #endif
 
     // Initialize signal handling.


### PR DESCRIPTION
If ksh is started in a directory that is not accessible to it, it will
exit with an error. This code makes invalid assumption and should be
disabled.

Resolves: #567