### PR TITLE
Fix `wchar` unit test on FreeBSD

### DIFF
--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -118,10 +118,7 @@ foreach testspec : all_tests
     timeout = (testspec.length() == 2) ? testspec[1] : default_timeout
     foreach locale : locales
         lang_var = 'LANG=' + locale
-        if locale != ''
-            locale = '/' + locale
-        endif
-        test(testname + locale, ksh93_exe, timeout: timeout,
+        test(testname + '/' + locale, ksh93_exe, timeout: timeout,
              args: [test_driver, testname],
              env: [shell_var, lang_var, ld_library_path, libsample_path])
     endforeach

--- a/src/cmd/ksh93/tests/wchar.sh
+++ b/src/cmd/ksh93/tests/wchar.sh
@@ -21,7 +21,13 @@
 # Tests for \u[...] and \w[...] input and output
 #
 
-locales="en_US.UTF-8 en_US.utf8 en_US.ISO-8859-15 en_US.iso885915 zh_CN.GB18030 zh_CN.gb18030"
+locales="en_US.UTF-8 en_US.utf8 en_US.ISO-8859-15 en_US.iso885915"
+# On FreeBSD 11.1 the native locale subsystem cannot convert the Euro currency symbol from UTF-8 to
+# GB1803. See https://github.com/att/ast/issues/577#issuecomment-396113061.
+if [[ $OS_NAME != "FreeBSD" ]]
+then
+    locales="$locales zh_CN.GB18030 zh_CN.gb18030"
+fi
 supported="C.UTF-8"
 locale -a > locale.txt
 


### PR DESCRIPTION
Part of resolving #577