### PR TITLE
Make unit test `subshell` more predictable

### DIFF
--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -21,6 +21,17 @@
 builtin getconf
 bincat=$(PATH=$(getconf PATH) whence -p cat)
 
+# Some platforms have an extremely large default value for the number of open files. For example,
+# FreeBSD 11.1 has a default of 44685. This test fails with such a large value. Every other platform
+# has a limit an order of magnitude smaller. So limit the allowable values to something more
+# reasonable.
+#
+# TBD is why such a large default limit causes the test to fail.
+#
+# TODO: Figure out why this test seems to depend on `ulimit` being a builtin without explicitly
+# invoking the builtin via `builtin ulimit`.
+ulimit -n 512
+
 z=()
 z.foo=( [one]=hello [two]=(x=3 y=4) [three]=hi)
 z.bar[0]=hello


### PR DESCRIPTION
Some platforms, such as FreeBSD, have a unusually large limit on the number
of open file descriptors. In the case of FreeBSD 11.1 it is 44685. That
causes this test to fail (for unknown reasons). So limit the max file
descriptor number to something more reasonable and comparable to all the
other platforms.

TBD is why such a huge default file descriptor limit causes this test to
fail.

Partial fix for #577