### PR TITLE
Do not set pipefail option in backticks substitution

### DIFF
--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -434,7 +434,6 @@ Sfio_t *sh_subshell(Shell_t *shp, Shnode_t *t, volatile int flags, int comsub) {
     struct sh_scoped savst;
     struct dolnod *argsav = 0;
     int argcnt;
-    bool pipefail = false;
 #ifdef SPAWN_cwd
     Spawnvex_t *vp;
 #endif
@@ -489,9 +488,6 @@ Sfio_t *sh_subshell(Shell_t *shp, Shnode_t *t, volatile int flags, int comsub) {
     if (!shp->subshare) sp->pathlist = path_dup((Pathcomp_t *)shp->pathlist);
     if (comsub) {
         shp->comsub = comsub;
-        if (comsub == 1 && !(pipefail = sh_isoption(shp, SH_PIPEFAIL))) {
-            sh_onoption(shp, SH_PIPEFAIL);
-        }
     }
     sp->shpwdfd = -1;
     if (!comsub || !shp->subshare) {
@@ -596,9 +592,8 @@ Sfio_t *sh_subshell(Shell_t *shp, Shnode_t *t, volatile int flags, int comsub) {
                 shp->exitval = c;
                 if (shp->pipepid == shp->spid) shp->spid = 0;
                 shp->pipepid = 0;
-            } else if (comsub == 1 && !pipefail) {
-                sh_offoption(shp, SH_PIPEFAIL);
             }
+
             // Move tmp file to iop and restore sfstdout.
             iop = sfswap(sfstdout, NULL);
             if (!iop) {

--- a/src/cmd/ksh93/tests/basic.sh
+++ b/src/cmd/ksh93/tests/basic.sh
@@ -663,3 +663,7 @@ $SHELL -c 'kill -0 123456789123456789123456789' 2> /dev/null && log_error 'kill 
 $SHELL -xc '$(LD_LIBRARY_PATH=$LD_LIBRARY_PATH exec $SHELL -c :)' > /dev/null 2>&1  || log_error "ksh -xc '(name=value exec ksh)' fails with err=$?"
 
 $SHELL 2> /dev/null -c $'for i;\ndo :;done' || log_error 'for i ; <newline> not vaid'
+
+set +o pipefail
+foo=`false | true`
+[[ $? -eq 0 ]] || log_error "Incorrect exit status from command substitution"


### PR DESCRIPTION
This is a backward incompatible change in ksh93v- release.
Backticks substitution should not set pipefail option.    

Resolves: #589
