### PR TITLE
Fix timezone name determination

### DIFF
--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -189,8 +189,7 @@ static void tmlocal(void) {
         else if (e)
             environ[0] = e;
     }
-    local.standard = strdup(tzname[0]);
-    local.daylight = strdup(tzname[1]);
+
     tmlocale();
 
     /*
@@ -230,8 +229,8 @@ static void tmlocal(void) {
          * POSIX
          */
 
-        if (!local.standard) local.standard = strdup(tzname[0]);
-        if (!local.daylight) local.daylight = strdup(tzname[1]);
+        local.standard = strdup(tzname[0]);
+        local.daylight = strdup(tzname[1]);
     } else if ((s = getenv("TZNAME")) && *s && (s = strdup(s))) {
         /*
          * BSD


### PR DESCRIPTION
On FreeBSD calling `tzset()` does not guarantee the `tzname` array will
be correctly populated. On most systems that works but on FreeBSD you
have to call `localtime()` or a related function (e.g., `ctime()`).

This change also eliminates a potential, very small, memory leak due to
the `strdup()`'ed tznames not being freed.

Partial fix for #577