### PR TITLE
Abort if sh_iovalidfd() function fails

### DIFF
--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -427,7 +427,11 @@ static_fn int path_opentype(Shell_t *shp, const char *name, Pathcomp_t *pp, int 
             }
         }
     } while (fd < 0 && pp);
-    sh_iovalidfd(shp, fd);
+
+    if (fd >= 0) {
+        if (!sh_iovalidfd(shp, fd)) abort();
+    }
+
     if (fd >= 0 && (fd = sh_iomovefd(shp, fd)) > 0) {
         fcntl(fd, F_SETFD, FD_CLOEXEC);
         shp->fdstatus[fd] |= IOCLEX;

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -608,7 +608,9 @@ Sfio_t *sh_subshell(Shell_t *shp, Shnode_t *t, volatile int flags, int comsub) {
                     ((struct checkpt *)shp->jmplist)->mode = SH_JMPERREXIT;
                     errormsg(SH_DICT, ERROR_system(1), e_toomany);
                 }
-                if (fd >= shp->gd->lim.open_max) sh_iovalidfd(shp, fd);
+                if (fd >= shp->gd->lim.open_max) {
+                    if (!sh_iovalidfd(shp, fd)) abort();
+                }
                 shp->sftable[fd] = iop;
                 fcntl(fd, F_SETFD, FD_CLOEXEC);
                 shp->fdstatus[fd] = (shp->fdstatus[1] | IOCLEX);

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -108,7 +108,7 @@ static int subpipe[3], subdup, tsetio, usepipe;
 static_fn bool iousepipe(Shell_t *shp) {
     int i, err = errno;
     int fd = sffileno(sfstdout);
-    sh_iovalidfd(shp, fd);
+    if (!sh_iovalidfd(shp, fd)) abort();
     if (usepipe) {
         usepipe++;
         sh_iounpipe(shp);
@@ -121,7 +121,7 @@ static_fn bool iousepipe(Shell_t *shp) {
         return true;
     }
     subpipe[2] = sh_fcntl(fd, F_DUPFD_CLOEXEC, 10);
-    sh_iovalidfd(shp, subpipe[2]);
+    if (!sh_iovalidfd(shp, subpipe[2])) abort();
     shp->fdstatus[subpipe[2]] = shp->fdstatus[1];
     while (close(fd) < 0 && errno == EINTR) errno = err;
     fcntl(subpipe[1], F_DUPFD, fd);


### PR DESCRIPTION
This function fails if an invalid fd is passed to it. Ksh should abort
on such conditions.

Resolves: #595