### PR TITLE
Lint cleanups in jobs.c

### DIFF
--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -60,20 +60,8 @@
 #include "terminal.h"
 #include "variables.h"
 
-#if !defined(WCONTINUED) || !defined(WIFCONTINUED) || defined(__APPLE__)
-#undef WCONTINUED
-#define WCONTINUED 0
-#undef WIFCONTINUED
-#define WIFCONTINUED(wstat) (0)
-#endif
-
 #define NJOB_SAVELIST 4
 
-//
-// Temporary hack to get W* macros to work.
-//
-#undef wait
-#define wait ______wait
 //
 // This struct saves a link list of processes that have non-zero exit status,
 // have had $! saved, but haven't been waited for.


### PR DESCRIPTION
Oclint was pointing out that on macOS WIFCONTINUED() is a constant.
There is absolutely no reason for defining a private implementation in
that fashion as the macOS provided version works just fine. Too, it
should be available on every platform we support. Too, if this was
really needed it would also be needed for WIFSTOPPED.