### PR TITLE
Remove `_lib_sigvec`

### DIFF
--- a/config_ast.h.in
+++ b/config_ast.h.in
@@ -184,7 +184,6 @@
 #mesondefine _lib_setlocale
 #mesondefine _lib_setregid
 #mesondefine _lib_setreuid
-#mesondefine _lib_sigblock
 #mesondefine _lib_sigflag
 #mesondefine _lib_sigprocmask
 #mesondefine _lib_sigqueue

--- a/config_ast.h.in
+++ b/config_ast.h.in
@@ -71,7 +71,6 @@
 #mesondefine _pty_first
 #mesondefine _socketpair_shutdown_mode
 #mesondefine _std_remove
-#mesondefine _std_signal
 #mesondefine _stk_down
 #mesondefine isnanl
 #mesondefine const_const_fts_open
@@ -191,7 +190,6 @@
 #mesondefine _lib_sigqueue
 #mesondefine _lib_sigsetmask
 #mesondefine _lib_sigunblock
-#mesondefine _lib_sigvec
 #mesondefine _lib_socket
 #mesondefine _lib_socketpair
 #mesondefine _lib_spawn

--- a/src/cmd/ksh93/bltins/trap.c
+++ b/src/cmd/ksh93/bltins/trap.c
@@ -169,7 +169,7 @@ int b_trap(int argc, char *argv[], Shbltin_t *context) {
             } else if (clear) {
                 sh_sigclear(shp, sig);
                 if (sig == 0) shp->exittrap = 0;
-                if (dflag) signal(sig, (sh_sigfun_t)SIG_DFL);
+                if (dflag) sh_signal(sig, (sh_sigfun_t)SIG_DFL);
             } else {
                 if (sig >= shp->st.trapmax) shp->st.trapmax = sig + 1;
                 arg = shp->st.trapcom[sig];

--- a/src/cmd/ksh93/bltins/trap.c
+++ b/src/cmd/ksh93/bltins/trap.c
@@ -169,7 +169,7 @@ int b_trap(int argc, char *argv[], Shbltin_t *context) {
             } else if (clear) {
                 sh_sigclear(shp, sig);
                 if (sig == 0) shp->exittrap = 0;
-                if (dflag) signal(sig, SIG_DFL);
+                if (dflag) signal(sig, (sh_sigfun_t)SIG_DFL);
             } else {
                 if (sig >= shp->st.trapmax) shp->st.trapmax = sig + 1;
                 arg = shp->st.trapcom[sig];

--- a/src/cmd/ksh93/include/defs.h
+++ b/src/cmd/ksh93/include/defs.h
@@ -392,9 +392,6 @@ extern const Shtable_t shtab_siginfo[];
         if (s) sigaddset(&ss, (s));  \
         sigprocmask(action, &ss, 0); \
     } while (0)
-#define sigrelease(s) sh_sigaction(s, SIG_UNBLOCK)
-#define sigblock(s) sh_sigaction(s, SIG_BLOCK)
-#define sig_begin() sh_sigaction(0, SIG_SETMASK)
 
 #ifndef CLD_EXITED
 #define CLD_EXITED 1

--- a/src/cmd/ksh93/include/fault.h
+++ b/src/cmd/ksh93/include/fault.h
@@ -25,6 +25,10 @@
 #ifndef _FAULT_H
 #define _FAULT_H 1
 
+#ifdef _AST_SIG_H
+#error You cannot include fault.h after sig.h
+#endif
+
 #include <setjmp.h>
 #include <signal.h>
 
@@ -126,14 +130,14 @@ typedef struct siginfo_ll siginfo_ll_t;
 typedef struct Shell_s Shell_t;
 #endif
 
-typedef void (*sh_sigfun_t)(int);
+typedef void (*sh_sigfun_t)(int, siginfo_t *, void *);
 extern sh_sigfun_t sh_signal(int, sh_sigfun_t);
 extern void sh_fault(int, siginfo_t *, void *);
 extern void sh_setsiginfo(siginfo_t *);
 extern void set_trapinfo(Shell_t *shp, int sig, siginfo_t *info);
 extern void dump_backtrace(int max_frames, int skip_levels);
 #undef signal
-#define signal(a, b) sh_signal(a, (sh_sigfun_t)(b))
+#define signal(a, b) sh_signal(a, b)
 
 extern void sh_done(void *, int);
 extern void sh_siginit(void *);

--- a/src/cmd/ksh93/include/fault.h
+++ b/src/cmd/ksh93/include/fault.h
@@ -137,7 +137,7 @@ extern void sh_setsiginfo(siginfo_t *);
 extern void set_trapinfo(Shell_t *shp, int sig, siginfo_t *info);
 extern void dump_backtrace(int max_frames, int skip_levels);
 #undef signal
-#define signal(a, b) sh_signal(a, b)
+#define signal(a, b) ERROR("use sh_signal() not signal()")
 
 extern void sh_done(void *, int);
 extern void sh_siginit(void *);

--- a/src/cmd/ksh93/sh/fault.c
+++ b/src/cmd/ksh93/sh/fault.c
@@ -158,7 +158,7 @@ void sh_fault(int sig, siginfo_t *info, void *context) {
 
     if (sig == SIGABRT) {
         sh_signal(sig, (sh_sigfun_t)(SIG_DFL));
-        sigrelease(sig);
+        sh_sigaction(sig, SIG_UNBLOCK);
         kill(getpid(), sig);
     }
     if (sig == SIGSEGV) {
@@ -166,7 +166,7 @@ void sh_fault(int sig, siginfo_t *info, void *context) {
         // The preceding call should call `abort()` which means this shouldn't be reached but
         // be paranoid.
         sh_signal(sig, (sh_sigfun_t)(SIG_DFL));
-        sigrelease(sig);
+        sh_sigaction(sig, SIG_UNBLOCK);
         kill(getpid(), sig);
     }
     if (sig == SIGCHLD) sfprintf(sfstdout, "childsig\n");
@@ -176,7 +176,7 @@ void sh_fault(int sig, siginfo_t *info, void *context) {
     trap = shp->st.trapcom[sig];
     if (sig == SIGBUS) {
         sh_signal(sig, (sh_sigfun_t)(SIG_DFL));
-        sigrelease(sig);
+        sh_sigaction(sig, SIG_UNBLOCK);
         kill(getpid(), sig);
     }
     if (shp->savesig) {
@@ -203,7 +203,7 @@ void sh_fault(int sig, siginfo_t *info, void *context) {
                 goto done;
             }
             shp->lastsig = sig;
-            sigrelease(sig);
+            sh_sigaction(sig, SIG_UNBLOCK);
             if (pp->mode != SH_JMPSUB) {
                 if (pp->mode < SH_JMPSUB) {
                     pp->mode = shp->subshell ? SH_JMPSUB : SH_JMPFUN;
@@ -238,7 +238,7 @@ void sh_fault(int sig, siginfo_t *info, void *context) {
         if (sig == SIGTSTP) {
             shp->trapnote |= SH_SIGTSTP;
             if (pp->mode == SH_JMPCMD && sh_isstate(shp, SH_STOPOK)) {
-                sigrelease(sig);
+                sh_sigaction(sig, SIG_UNBLOCK);
                 sh_exit(shp, SH_EXITSIG);
                 goto done;
             }
@@ -251,7 +251,7 @@ void sh_fault(int sig, siginfo_t *info, void *context) {
     if (sig < shp->gd->sigmax) shp->sigflag[sig] |= flag;
     if (pp->mode == SH_JMPCMD && sh_isstate(shp, SH_STOPOK)) {
         if (action < 0) goto done;
-        sigrelease(sig);
+        sh_sigaction(sig, SIG_UNBLOCK);
         sh_exit(shp, SH_EXITSIG);
     }
 
@@ -266,7 +266,9 @@ void sh_siginit(void *ptr) {
     Shell_t *shp = (Shell_t *)ptr;
     int sig, n;
     const struct shtable2 *tp = shtab_signals;
-    sig_begin();
+
+    // Make sure no signals are blocked.
+    sh_sigaction(0, SIG_SETMASK);
 
     // Find the largest signal number in the table.
 #if defined(SIGRTMIN) && defined(SIGRTMAX)
@@ -615,7 +617,7 @@ void sh_done(void *ptr, int sig) {
             setrlimit(RLIMIT_CORE, &rlp);
         }
         sh_signal(sig, (sh_sigfun_t)(SIG_DFL));
-        sigrelease(sig);
+        sh_sigaction(sig, SIG_UNBLOCK);
         kill(getpid(), sig);
         pause();
     }
@@ -822,6 +824,6 @@ sh_sigfun_t sh_signal(int sig, sh_sigfun_t func) {
         sigdelset(&sigin.sa_mask, SIGSEGV);
     }
     sigaction(sig, &sigin, &sigout);
-    sigrelease(sig);
+    sh_sigaction(sig, SIG_UNBLOCK);
     return (sh_sigfun_t)sigout.sa_sigaction;
 }

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -2005,7 +2005,7 @@ static_fn void time_grace(void *handle) {
     }
     errormsg(SH_DICT, 0, e_timewarn);
     sh_onstate(shp, SH_GRACE);
-    sigrelease(SIGALRM);
+    sh_sigaction(SIGALRM, SIG_UNBLOCK);
     shp->trapnote |= SH_SIGTRAP;
 }
 

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -586,9 +586,9 @@ bool job_reap(int sig) {
 void job_init(Shell_t *shp, int lflag) {
     int ntry = 0;
     job.fd = JOBTTY;
-    signal(SIGCHLD, job_waitsafe);
+    sh_signal(SIGCHLD, job_waitsafe);
 #if defined(SIGCLD) && (SIGCLD != SIGCHLD)
-    signal(SIGCLD, job_waitsafe);
+    sh_signal(SIGCLD, job_waitsafe);
 #endif
     if (njob_savelist < NJOB_SAVELIST) init_savelist();
     if (!sh_isoption(shp, SH_INTERACTIVE)) return;
@@ -613,7 +613,7 @@ void job_init(Shell_t *shp, int lflag) {
     while ((job.mytgid = tcgetpgrp(JOBTTY)) != job.mypgid) {
         if (job.mytgid <= 0) return;
         // Stop this shell until continued.
-        signal(SIGTTIN, (sh_sigfun_t)(SIG_DFL));
+        sh_signal(SIGTTIN, (sh_sigfun_t)(SIG_DFL));
         kill(shp->gd->pid, SIGTTIN);
         // Resumes here after continue tries again.
         if (ntry++ > IOMAXTRY) {
@@ -662,12 +662,12 @@ void job_init(Shell_t *shp, int lflag) {
     sigflag(SIGCHLD, SA_NOCLDSTOP | SA_NOCLDWAIT, 0);
 #endif  // SA_NOCLDSTOP || SA_NOCLDWAIT
 #endif  // 0
-    signal(SIGTTIN, (sh_sigfun_t)(SIG_IGN));
-    signal(SIGTTOU, (sh_sigfun_t)(SIG_IGN));
+    sh_signal(SIGTTIN, (sh_sigfun_t)(SIG_IGN));
+    sh_signal(SIGTTOU, (sh_sigfun_t)(SIG_IGN));
     shp->sigflag[SIGTTIN] = SH_SIGOFF;
     shp->sigflag[SIGTTOU] = SH_SIGOFF;
     // The shell now handles ^Z.
-    signal(SIGTSTP, sh_fault);
+    sh_signal(SIGTSTP, sh_fault);
     tcsetpgrp(JOBTTY, shp->gd->pid);
 #ifdef CNSUSP
     // Set the switch character.

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -168,10 +168,10 @@ int sh_main(int ac, char *av[], Shinit_f userinit) {
         }
         if (sh_isoption(shp, SH_INTERACTIVE)) {
 #ifdef SIGXCPU
-            signal(SIGXCPU, (sh_sigfun_t)(SIG_DFL));
+            sh_signal(SIGXCPU, (sh_sigfun_t)(SIG_DFL));
 #endif  // SIGXCPU
 #ifdef SIGXFSZ
-            signal(SIGXFSZ, (sh_sigfun_t)(SIG_DFL));
+            sh_signal(SIGXFSZ, (sh_sigfun_t)(SIG_DFL));
 #endif  // SIGXFSZ
             sh_onoption(shp, SH_MONITOR);
         }

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -121,9 +121,9 @@ int sh_main(int ac, char *av[], Shinit_f userinit) {
     char *command;
 
     // Make sure we weren't started with several critical signals blocked from delivery.
-    sigrelease(SIGALRM);
-    sigrelease(SIGCHLD);
-    sigrelease(SIGHUP);
+    sh_sigaction(SIGALRM, SIG_UNBLOCK);
+    sh_sigaction(SIGCHLD, SIG_UNBLOCK);
+    sh_sigaction(SIGHUP, SIG_UNBLOCK);
 
     fixargs(av, 0);
     shp = sh_init(ac, av, userinit);

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -77,16 +77,6 @@ static struct stat lastmail;
 static time_t mailtime;
 static char beenhere = 0;
 
-#if _lib_sigvec
-void clearsigmask(int sig) {
-    struct sigvec vec;
-    if (sigvec(sig, NULL, &vec) >= 0 && vec.sv_mask) {
-        vec.sv_mask = 0;
-        sigvec(sig, &vec, NULL);
-    }
-}
-#endif  // _lib_sigvec
-
 #ifdef PATH_BFPATH
 #define PATHCOMP NULL
 #else
@@ -130,12 +120,10 @@ int sh_main(int ac, char *av[], Shinit_f userinit) {
     bool rshflag; /* set for restricted shell */
     char *command;
 
-#if _lib_sigvec
-    // This is to clear mask that may be left on by rlogin.
-    clearsigmask(SIGALRM);
-    clearsigmask(SIGHUP);
-    clearsigmask(SIGCHLD);
-#endif  // _lib_sigvec
+    // Make sure we weren't started with several critical signals blocked from delivery.
+    sigrelease(SIGALRM);
+    sigrelease(SIGCHLD);
+    sigrelease(SIGHUP);
 
     fixargs(av, 0);
     shp = sh_init(ac, av, userinit);
@@ -180,10 +168,10 @@ int sh_main(int ac, char *av[], Shinit_f userinit) {
         }
         if (sh_isoption(shp, SH_INTERACTIVE)) {
 #ifdef SIGXCPU
-            signal(SIGXCPU, SIG_DFL);
+            signal(SIGXCPU, (sh_sigfun_t)(SIG_DFL));
 #endif  // SIGXCPU
 #ifdef SIGXFSZ
-            signal(SIGXFSZ, SIG_DFL);
+            signal(SIGXFSZ, (sh_sigfun_t)(SIG_DFL));
 #endif  // SIGXFSZ
             sh_onoption(shp, SH_MONITOR);
         }

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -111,8 +111,8 @@ static_fn pid_t _spawnveg(Shell_t *shp, const char *path, char *const argv[], ch
 
 #ifdef SIGTSTP
     if (job.jobcontrol) {
-        signal(SIGTTIN, SIG_DFL);
-        signal(SIGTTOU, SIG_DFL);
+        sh_signal(SIGTTIN, SIG_DFL);
+        sh_signal(SIGTTOU, SIG_DFL);
     }
 #endif  // SIGTSTP
 
@@ -131,8 +131,8 @@ static_fn pid_t _spawnveg(Shell_t *shp, const char *path, char *const argv[], ch
 
 #ifdef SIGTSTP
     if (job.jobcontrol) {
-        signal(SIGTTIN, SIG_IGN);
-        signal(SIGTTOU, SIG_IGN);
+        sh_signal(SIGTTIN, SIG_IGN);
+        sh_signal(SIGTTOU, SIG_IGN);
     }
 #endif  // SIGTSTP
 

--- a/src/cmd/ksh93/sh/timers.c
+++ b/src/cmd/ksh93/sh/timers.c
@@ -29,7 +29,6 @@
 
 #include "error.h"
 #include "fault.h"
-#include "sig.h"
 
 typedef struct _timer {
     double wakeup;
@@ -149,22 +148,22 @@ static_fn void sigalrm(int sig, siginfo_t *info, void *context) {
         }
     }
     if (!tpmin) {
-        signal(SIGALRM, (sh.sigflag[SIGALRM] & SH_SIGFAULT) ? (sh_sigfun_t)sh_fault : SIG_DFL);
+        signal(SIGALRM, (sh.sigflag[SIGALRM] & SH_SIGFAULT) ? sh_fault : (sh_sigfun_t)(SIG_DFL));
     }
     time_state &= ~IN_SIGALRM;
     errno = EINTR;
 }
 
 static_fn void oldalrm(void *handle) {
-    Handler_t fn = *(Handler_t *)handle;
+    sh_sigfun_t fn = *(sh_sigfun_t *)handle;
     free(handle);
-    (*fn)(SIGALRM);
+    (*fn)(SIGALRM, NULL, NULL);
 }
 
 void *sh_timeradd(unsigned long msec, int flags, void (*action)(void *), void *handle) {
     Timer_t *tp;
     double t;
-    Handler_t fn;
+    sh_sigfun_t fn;
 
     t = ((double)msec) / 1000.;
     if (t <= 0 || !action) return NULL;
@@ -183,9 +182,9 @@ void *sh_timeradd(unsigned long msec, int flags, void (*action)(void *), void *h
     tptop = tp;
     if (!tpmin || tp->wakeup < tpmin->wakeup) {
         tpmin = tp;
-        fn = (Handler_t)signal(SIGALRM, sigalrm);
-        if ((t = setalarm(t)) > 0 && fn && fn != (Handler_t)sigalrm) {
-            Handler_t *hp = (Handler_t *)malloc(sizeof(Handler_t));
+        fn = signal(SIGALRM, sigalrm);
+        if ((t = setalarm(t)) > 0 && fn && fn != sigalrm) {
+            sh_sigfun_t *hp = malloc(sizeof(sh_sigfun_t));
             if (hp) {
                 *hp = fn;
                 sh_timeradd((long)(1000 * t), 0, oldalrm, (void *)hp);
@@ -217,6 +216,6 @@ void timerdel(void *handle) {
             tpmin = 0;
             setalarm((double)0);
         }
-        signal(SIGALRM, (sh.sigflag[SIGALRM] & SH_SIGFAULT) ? (sh_sigfun_t)sh_fault : SIG_DFL);
+        signal(SIGALRM, (sh.sigflag[SIGALRM] & SH_SIGFAULT) ? sh_fault : (sh_sigfun_t)(SIG_DFL));
     }
 }

--- a/src/cmd/ksh93/sh/timers.c
+++ b/src/cmd/ksh93/sh/timers.c
@@ -97,7 +97,7 @@ static_fn void sigalrm(int sig, siginfo_t *info, void *context) {
         return;
     }
     time_state |= IN_SIGALRM;
-    sigrelease(SIGALRM);
+    sh_sigaction(SIGALRM, SIG_UNBLOCK);
     while (1) {
         now = getnow();
         tpold = tpmin = 0;

--- a/src/cmd/ksh93/sh/timers.c
+++ b/src/cmd/ksh93/sh/timers.c
@@ -127,7 +127,7 @@ static_fn void sigalrm(int sig, siginfo_t *info, void *context) {
             if (!tpmin || tpmin->wakeup > tp->wakeup) tpmin = tp;
         }
         if (tpmin && (left == 0 || (tp && tpmin->wakeup < (now + left)))) {
-            if (left == 0) signal(SIGALRM, sigalrm);
+            if (left == 0) sh_signal(SIGALRM, sigalrm);
             left = setalarm(tpmin->wakeup - now);
             if (left && (now + left) < tpmin->wakeup) {
                 setalarm(left);
@@ -148,7 +148,7 @@ static_fn void sigalrm(int sig, siginfo_t *info, void *context) {
         }
     }
     if (!tpmin) {
-        signal(SIGALRM, (sh.sigflag[SIGALRM] & SH_SIGFAULT) ? sh_fault : (sh_sigfun_t)(SIG_DFL));
+        sh_signal(SIGALRM, (sh.sigflag[SIGALRM] & SH_SIGFAULT) ? sh_fault : (sh_sigfun_t)(SIG_DFL));
     }
     time_state &= ~IN_SIGALRM;
     errno = EINTR;
@@ -182,7 +182,7 @@ void *sh_timeradd(unsigned long msec, int flags, void (*action)(void *), void *h
     tptop = tp;
     if (!tpmin || tp->wakeup < tpmin->wakeup) {
         tpmin = tp;
-        fn = signal(SIGALRM, sigalrm);
+        fn = sh_signal(SIGALRM, sigalrm);
         if ((t = setalarm(t)) > 0 && fn && fn != sigalrm) {
             sh_sigfun_t *hp = malloc(sizeof(sh_sigfun_t));
             if (hp) {
@@ -216,6 +216,6 @@ void timerdel(void *handle) {
             tpmin = 0;
             setalarm((double)0);
         }
-        signal(SIGALRM, (sh.sigflag[SIGALRM] & SH_SIGFAULT) ? sh_fault : (sh_sigfun_t)(SIG_DFL));
+        sh_signal(SIGALRM, (sh.sigflag[SIGALRM] & SH_SIGFAULT) ? sh_fault : (sh_sigfun_t)(SIG_DFL));
     }
 }

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1618,8 +1618,8 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                     if (jmpval) goto done;
                     if ((type & FINT) && !sh_isstate(shp, SH_MONITOR)) {
                         // Default std input for &.
-                        signal(SIGINT, (sh_sigfun_t)(SIG_IGN));
-                        signal(SIGQUIT, (sh_sigfun_t)(SIG_IGN));
+                        sh_signal(SIGINT, (sh_sigfun_t)(SIG_IGN));
+                        sh_signal(SIGQUIT, (sh_sigfun_t)(SIG_IGN));
                         shp->sigflag[SIGINT] = SH_SIGOFF;
                         shp->sigflag[SIGQUIT] = SH_SIGOFF;
                         if (!shp->st.ioset) {
@@ -2797,9 +2797,9 @@ pid_t _sh_fork(Shell_t *shp, pid_t parent, int flags, int *jobid) {
     }
 #ifdef SIGTSTP
     if (job.jobcontrol) {
-        signal(SIGTTIN, (sh_sigfun_t)(SIG_DFL));
-        signal(SIGTTOU, (sh_sigfun_t)(SIG_DFL));
-        signal(SIGTSTP, (sh_sigfun_t)(SIG_DFL));
+        sh_signal(SIGTTIN, (sh_sigfun_t)(SIG_DFL));
+        sh_signal(SIGTTOU, (sh_sigfun_t)(SIG_DFL));
+        sh_signal(SIGTSTP, (sh_sigfun_t)(SIG_DFL));
     }
 #endif  // SIGTSTP
     job.jobcontrol = 0;
@@ -3084,7 +3084,7 @@ static_fn void sigreset(Shell_t *shp, int mode) {
         if (sig == SIGCHLD) continue;
         if (shp->sigflag[sig] & SH_SIGOFF) return;
         trap = shp->st.trapcom[sig];
-        if (trap && *trap == 0) signal(sig, mode ? (sh_sigfun_t)sh_fault : SIG_IGN);
+        if (trap && *trap == 0) sh_signal(sig, mode ? (sh_sigfun_t)sh_fault : SIG_IGN);
     }
 }
 
@@ -3111,8 +3111,8 @@ static_fn pid_t sh_ntfork(Shell_t *shp, const Shnode_t *t, char *argv[], int *jo
     jmpval = sigsetjmp(buffp->buff, 0);
     if (jmpval == 0) {
         if ((otype & FINT) && !sh_isstate(shp, SH_MONITOR)) {
-            signal(SIGQUIT, SIG_IGN);
-            signal(SIGINT, SIG_IGN);
+            sh_signal(SIGQUIT, SIG_IGN);
+            sh_signal(SIGINT, SIG_IGN);
         }
         spawnpid = -1;
         if (t->com.comio) {

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1618,8 +1618,8 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                     if (jmpval) goto done;
                     if ((type & FINT) && !sh_isstate(shp, SH_MONITOR)) {
                         // Default std input for &.
-                        signal(SIGINT, SIG_IGN);
-                        signal(SIGQUIT, SIG_IGN);
+                        signal(SIGINT, (sh_sigfun_t)(SIG_IGN));
+                        signal(SIGQUIT, (sh_sigfun_t)(SIG_IGN));
                         shp->sigflag[SIGINT] = SH_SIGOFF;
                         shp->sigflag[SIGQUIT] = SH_SIGOFF;
                         if (!shp->st.ioset) {
@@ -2797,9 +2797,9 @@ pid_t _sh_fork(Shell_t *shp, pid_t parent, int flags, int *jobid) {
     }
 #ifdef SIGTSTP
     if (job.jobcontrol) {
-        signal(SIGTTIN, SIG_DFL);
-        signal(SIGTTOU, SIG_DFL);
-        signal(SIGTSTP, SIG_DFL);
+        signal(SIGTTIN, (sh_sigfun_t)(SIG_DFL));
+        signal(SIGTTOU, (sh_sigfun_t)(SIG_DFL));
+        signal(SIGTSTP, (sh_sigfun_t)(SIG_DFL));
     }
 #endif  // SIGTSTP
     job.jobcontrol = 0;

--- a/src/lib/libast/comp/sigunblock.c
+++ b/src/lib/libast/comp/sigunblock.c
@@ -34,9 +34,11 @@ int sigunblock(int s) {
     if (s) {
         sigaddset(&mask, s);
         op = SIG_UNBLOCK;
-    } else
+    } else {
         op = SIG_SETMASK;
-    return (sigprocmask(op, &mask, NULL));
+    }
+
+    return sigprocmask(op, &mask, NULL);
 }
 
 #endif  // !_lib_sigunblock

--- a/src/lib/libast/include/sig.h
+++ b/src/lib/libast/include/sig.h
@@ -1,14 +1,16 @@
 /* : : generated from sig.sh by iffe version 2013-11-14 : : */
-#ifndef _def_sig_features
-#define _def_sig_features 1
+#ifndef _AST_SIG_H
+#define _AST_SIG_H 1
+
+#ifdef _FAULT_H
+#error You cannot include sig.h after fault.h
+#endif
 
 #define sig_info _sig_info_
 
 #include <signal.h>
 
 typedef void (*Sig_handler_t)(int);
-
-#define Handler_t Sig_handler_t
 
 #define SIG_REG_PENDING (-1)
 #define SIG_REG_POP 0
@@ -26,9 +28,9 @@ typedef struct {
 
 extern Sig_info_t sig_info;
 
+Sig_handler_t ast_signal(int sig, Sig_handler_t sigfun);
 extern int sigflag(int, int, int);
-
 extern int sigcritical(int);
 extern int sigunblock(int);
 
-#endif
+#endif  // _AST_SIG_H

--- a/src/lib/libast/misc/meson.build
+++ b/src/lib/libast/misc/meson.build
@@ -7,7 +7,7 @@ libast_files += [
     'misc/optget.c', 'misc/optjoin.c', 'misc/procclose.c', 'misc/procfree.c',
     'misc/procopen.c', 'misc/procrun.c', 'misc/recfmt.c', 'misc/reclen.c',
     'misc/recstr.c', 'misc/setenviron.c', 'misc/sigcrit.c', 'misc/sigdata.c',
-    'misc/signal.c', 'misc/stack.c', 'misc/state.c',
+    'misc/stack.c', 'misc/state.c',
     'misc/stk.c', 'misc/systrace.c', 'misc/translate.c', 'misc/univdata.c',
     'misc/fts.c', 'misc/vmbusy.c'
 ]

--- a/src/lib/libast/misc/procopen.c
+++ b/src/lib/libast/misc/procopen.c
@@ -105,7 +105,7 @@ typedef struct Mod_s {
             Fd_t child;
         } fd;
 
-        Handler_t handler;
+        Sig_handler_t handler;
 
     } arg;
 
@@ -671,7 +671,7 @@ Proc_t *procopen(const char *cmd, char **argv, char **envv, long *modv, int flag
         if (procfd >= 0) {
 #ifdef SIGPIPE
             if ((flags & (PROC_WRITE | PROC_IGNORE)) == (PROC_WRITE | PROC_IGNORE)) {
-                Handler_t handler;
+                Sig_handler_t handler;
 
                 if ((handler = signal(SIGPIPE, ignoresig)) != SIG_DFL && handler != ignoresig)
                     signal(SIGPIPE, handler);


### PR DESCRIPTION
Remove the `_lib_sigvec` feature symbol as `sigvec()` is an ancient,
obsolete, function that has been replaced by `sigaction()`.  It's also
not needed because libast already provides `sigunblock()` which does
what ksh needs.

Also  remove the signal.c module as the function it defines isn't
actually used or needed.

Resolves #630