### PR TITLE
Build with coshell support disabled by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -76,6 +76,10 @@ shared_c_args = [
     '-D_AST_no_spawnveg=1',
 ]
 
+if get_option('build-api-tests') == true
+    shared_c_args += [ '-DSHOPT_COSHELL' ]
+endif
+
 ptr_size = cc.sizeof('void*')
 int_size = cc.sizeof('int')
 long_size = cc.sizeof('long')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,6 +17,10 @@ option('read-timeout', type : 'string', value : '0')
 #
 option('audit-file', type : 'string', value : '/etc/ksh_audit')
 
+# To build with coshell support enabled:
+#   meson -Dcoshell
+option('coshell', type : 'boolean', value : false)
+
 # To disable building api tests, set build-api-tests option to false:
 #   meson -Dbuild-api-tests=false
 option('build-api-tests', type : 'boolean', value : true)

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -835,9 +835,9 @@ int job_walk(Shell_t *shp, Sfio_t *file, int (*fun)(struct process *, int), int 
     by_number = 0;
     job_lock();
     pw = job.pwlist;
-#if SHOPT_COSHELL
+
     job_waitsafe(SIGCHLD, (siginfo_t *)0, (void *)0);
-#endif  // SHOPT_COSHELL
+
     if (jobs == NULL) {
         // Do all jobs.
         for (; pw; pw = px) {


### PR DESCRIPTION
Since the coshell server was removed there should be no need for coshell
support in ksh. So build with it disabled by default but make it easy to
turn on if needed.

Resolve #619