### PR TITLE
Move detecting max signum to the build config phase

### DIFF
--- a/config_ast.h.in
+++ b/config_ast.h.in
@@ -74,6 +74,7 @@
 #mesondefine _stk_down
 #mesondefine isnanl
 #mesondefine const_const_fts_open
+#mesondefine MAX_SIGNUM
 
 // What follows are all the symbols that should be based on Meson feature
 // tests like `cc.has_header()` and `cc.find_library()`.

--- a/features/max_signum.c
+++ b/features/max_signum.c
@@ -1,0 +1,22 @@
+// This is used during the Meson config step to detect the largest signal number.
+#include <signal.h>
+#include <stdio.h>
+
+int main() {
+#ifdef _NSIG
+    printf("%d\n", _NSIG - 1);
+    return 0;
+#else  // _NSIG
+#ifdef NSIG
+    printf("%d\n", NSIG - 1);
+    return 0;
+#else  // NSIG
+#ifdef SIGRTMAX
+    printf("%d\n", SIGRTMAX);
+    return 0;
+#else  // SIGRTMAX
+    return 1;
+#endif  // SIGRTMAX
+#endif  // NSIG
+#endif  // _NSIG
+}

--- a/features/meson.build
+++ b/features/meson.build
@@ -108,6 +108,22 @@ socketpair_shutdown_feature_result = cc.run(
 feature_data.set10('_socketpair_shutdown_mode',
     socketpair_shutdown_feature_result.returncode() == 0)
 
+max_signum_feature_file = files('max_signum.c')
+max_signum_feature_result = cc.run(
+    max_signum_feature_file,
+    name: 'max signal number',
+    args: feature_test_args)
+if max_signum_feature_result.returncode() == 0
+    feature_data.set('MAX_SIGNUM', max_signum_feature_result.stdout().strip())
+else
+    warning('Could not reliably determine the max signal number.')
+    # Okay, we can't figure it out from the symbols provided by signal.h so
+    # use a big number and hope for the best. We're assuming no system has a
+    # signal number larger than 64.
+    feature_data.set('MAX_SIGNUM', '64')
+endif
+
+
 if cc.has_member('struct stat', 'st_mtim', prefix: '#include <sys/stat.h>',
                  args: feature_test_args)
     feature_data.set('STAT_ST_MTIM', 1)

--- a/src/cmd/ksh93/include/fault.h
+++ b/src/cmd/ksh93/include/fault.h
@@ -136,7 +136,7 @@ extern void dump_backtrace(int max_frames, int skip_levels);
 #define signal(a, b) sh_signal(a, (sh_sigfun_t)(b))
 
 extern void sh_done(void *, int);
-extern void sh_siginit(void *);
+extern void sh_siginit(Shell_t *shp);
 extern void *sh_timeradd(unsigned long, int, void (*)(void *), void *);
 extern void timerdel(void *);
 


### PR DESCRIPTION
The ksh code has been using a very opaque (i.e., hard to understand)
block of code to detect the max signal number. Replace that with a much
easier to understand build time feature detection.

AFAICT the run time calculation was correct. At least empirical testing
on a bunch of platforms (BSD and Linux) yield results identical to the
new mechanism. But I'm making this change anyway since a) there is no
point figuring out the answer every time ksh starts and b) it's much
clearer to do it using signal.h header symbols.

Partially resolves #663