### PR TITLE
Solve the definition of LIBICONV_PLUG

### DIFF
--- a/config_ast.h.in
+++ b/config_ast.h.in
@@ -41,6 +41,7 @@
 #mesondefine ALIGN_BOUND
 #mesondefine ALIGN_BOUND1
 #mesondefine ALIGN_BOUND2
+#mesondefine LIBICONV_PLUG
 
 #mesondefine _ast_sizeof_int
 #mesondefine _ast_sizeof_long

--- a/features/meson.build
+++ b/features/meson.build
@@ -39,6 +39,13 @@ libexecinfo_dep = cc.find_library('execinfo', required: false, dirs: lib_dirs)
 # On some systems (e.g., OpenBSD) `iconv()` is in libiconv.
 libiconv_dep = cc.find_library('iconv', required: false, dirs: lib_dirs)
 
+# Under Cygwin the iconv shared library exports the symbols we need with a
+# `lib` prefix. So we don't want the LIBICONV_PLUG behavior on that platform.
+# On others we either want this or it's a no-op.
+if not (system == 'cygwin' or system == 'openbsd')
+    feature_data.set('LIBICONV_PLUG', 1)
+endif
+
 # On Cygwin the message catalog functions (e.g., `catopen()`) are in this
 # library.
 libcatgets_dep = cc.find_library('catgets', required: false, dirs: lib_dirs)

--- a/src/lib/libast/include/ast_iconv.h
+++ b/src/lib/libast/include/ast_iconv.h
@@ -6,12 +6,6 @@
 
 #include "ccode.h"
 
-#if !defined(__CYGWIN__) && !defined(__OpenBSD__)
-// Under Cygwin the iconv shared library exports the symbols we need with a
-// `lib` prefix. So we don't want the LIBICONV_PLUG behavior on that platform.
-// On others we either want this or it's a no-op.
-#define LIBICONV_PLUG 1  // prefer more recent GNU libiconv
-#endif
 #include <iconv.h>  // the native iconv.h
 
 #define ICONV_VERSION 20121001L


### PR DESCRIPTION
The way LIBICONV_PLUG is defined must go through feature detection, thus it must first land in config_ast.h.
This way, <iconv.h> can be included normally, provided that the source file first includes "config_ast.h".

This is already the case in all C source files.

This solves issue #280 in a more robust manner.
