### PR TITLE
Mark statements not reached

### DIFF
--- a/src/cmd/ksh93/bltins/alarm.c
+++ b/src/cmd/ksh93/bltins/alarm.c
@@ -259,7 +259,10 @@ int b_alarm(int argc, char *argv[], Shbltin_t *context) {
     if (!nv_isnull(np)) nv_unset(np);
     nv_setattr(np, NV_DOUBLE);
     tp = newof(NULL, struct tevent, 1, 0);
-    if (!tp) errormsg(SH_DICT, ERROR_exit(1), e_nospace);
+    if (!tp) {
+        errormsg(SH_DICT, ERROR_exit(1), e_nospace);
+        __builtin_unreachable();
+    }
     tp->fun.disc = &alarmdisc;
     tp->flags = rflag;
     tp->node = np;

--- a/src/cmd/ksh93/bltins/cd_pwd.c
+++ b/src/cmd/ksh93/bltins/cd_pwd.c
@@ -99,7 +99,11 @@ int b_cd(int argc, char *argv[], Shbltin_t *context) {
     int newdirfd;
     Namval_t *opwdnod, *pwdnod;
 
-    if (sh_isoption(shp, SH_RESTRICTED)) errormsg(SH_DICT, ERROR_exit(1), e_restricted + 4);
+    if (sh_isoption(shp, SH_RESTRICTED)) {
+        errormsg(SH_DICT, ERROR_exit(1), e_restricted + 4);
+        __builtin_unreachable();
+    }
+
     while ((rval = optget(argv, sh_optcd))) {
         switch (rval) {
             case 'f': {
@@ -151,7 +155,10 @@ int b_cd(int argc, char *argv[], Shbltin_t *context) {
         dir = sh_scoped(shp, opwdnod)->nvalue.sp;
     }
 
-    if (!dir || *dir == 0) errormsg(SH_DICT, ERROR_exit(1), argc == 2 ? e_subst + 4 : e_direct);
+    if (!dir || *dir == 0) {
+        errormsg(SH_DICT, ERROR_exit(1), argc == 2 ? e_subst + 4 : e_direct);
+        __builtin_unreachable();
+    }
     if (xattr) {
         if (!shp->strbuf2) shp->strbuf2 = sfstropen();
         j = sfprintf(shp->strbuf2, "%s", dir);

--- a/src/cmd/ksh93/bltins/cflow.c
+++ b/src/cmd/ksh93/bltins/cflow.c
@@ -107,7 +107,10 @@ int b_break(int n, char *argv[], Shbltin_t *context) {
 
     if (arg) {
         n = (int)strtol(arg, &arg, 10);
-        if (n <= 0 || *arg) errormsg(SH_DICT, ERROR_exit(1), e_nolabels, *argv);
+        if (n <= 0 || *arg) {
+            errormsg(SH_DICT, ERROR_exit(1), e_nolabels, *argv);
+            __builtin_unreachable();
+        }
     }
 
     if (shp->st.loopcnt) {

--- a/src/cmd/ksh93/bltins/hist.c
+++ b/src/cmd/ksh93/bltins/hist.c
@@ -154,6 +154,7 @@ int b_hist(int argc, char *argv[], Shbltin_t *context) {
         location = hist_find(hp, argv[1], hist_max(hp) - 1, 0, -1);
         if ((range[++flag] = location.hist_command) < 0) {
             errormsg(SH_DICT, ERROR_exit(1), e_found, argv[1]);
+            __builtin_unreachable();
         }
         argv++;
     }
@@ -180,8 +181,12 @@ int b_hist(int argc, char *argv[], Shbltin_t *context) {
     // Check for valid ranges.
     if (range[1] < index2 || range[0] >= flag) {
         errormsg(SH_DICT, ERROR_exit(1), e_badrange, range[0], range[1]);
+        __builtin_unreachable();
     }
-    if (edit && *edit == '-' && range[0] != range[1]) errormsg(SH_DICT, ERROR_exit(1), e_eneedsarg);
+    if (edit && *edit == '-' && range[0] != range[1]) {
+        errormsg(SH_DICT, ERROR_exit(1), e_eneedsarg);
+        __builtin_unreachable();
+    }
     // Now list commands from range[rflag] to range[1-rflag].
     incr = 1;
     flag = rflag > 0;
@@ -191,7 +196,10 @@ int b_hist(int argc, char *argv[], Shbltin_t *context) {
         arg = "\n\t";
     } else {
         fname = pathtmp(NULL, 0, 0, NULL);
-        if (!fname) errormsg(SH_DICT, ERROR_exit(1), e_create, "");
+        if (!fname) {
+            errormsg(SH_DICT, ERROR_exit(1), e_create, "");
+            __builtin_unreachable();
+        }
         fdo = open(fname, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR | O_CLOEXEC);
         if (fdo < 0) {
             errormsg(SH_DICT, ERROR_system(1), e_create, fname);
@@ -218,7 +226,10 @@ int b_hist(int argc, char *argv[], Shbltin_t *context) {
     if (!arg && !(arg = nv_getval(sh_scoped(shp, HISTEDIT))) &&
         !(arg = nv_getval(sh_scoped(shp, FCEDNOD)))) {
         arg = (char *)e_defedit;
-        if (*arg != '/') errormsg(SH_DICT, ERROR_exit(1), "ed not found set FCEDIT");
+        if (*arg != '/') {
+            errormsg(SH_DICT, ERROR_exit(1), "ed not found set FCEDIT");
+            __builtin_unreachable();
+        }
     }
     if (*arg != '-') {
         char *com[3];
@@ -243,6 +254,7 @@ int b_hist(int argc, char *argv[], Shbltin_t *context) {
         // Read in and run the command.
         if (shp->hist_depth++ > HIST_RECURSE) {
             errormsg(SH_DICT, ERROR_exit(1), e_toodeep, "history");
+            __builtin_unreachable();
         }
         sh_eval(shp, iop, 1);
         shp->hist_depth--;
@@ -279,6 +291,7 @@ static_fn void hist_subst(Shell_t *shp, const char *command, int fd, char *repla
     sp = sh_substitute(shp, string, replace, newp);
     if (sp == 0) {
         errormsg(SH_DICT, ERROR_exit(1), e_subst, command);
+        __builtin_unreachable();
     }
     *(newp - 1) = '=';
     sh_eval(shp, sfopen(NULL, sp, "s"), 1);

--- a/src/cmd/ksh93/bltins/misc.c
+++ b/src/cmd/ksh93/bltins/misc.c
@@ -129,6 +129,7 @@ int B_login(int argc, char *argv[], Shbltin_t *context) {
     pp = (struct checkpt *)shp->jmplist;
     if (sh_isoption(shp, SH_RESTRICTED)) {
         errormsg(SH_DICT, ERROR_exit(1), e_restricted, argv[0]);
+        __builtin_unreachable();
     } else {
         struct argnod *arg = shp->envlist;
         Namval_t *np;
@@ -247,7 +248,10 @@ int b_dot_cmd(int n, char *argv[], Shbltin_t *context) {
     argv += opt_info.index;
     script = *argv;
     if (error_info.errors || !script) errormsg(SH_DICT, ERROR_usage(2), "%s", optusage((char *)0));
-    if (shp->dot_depth + 1 > DOTMAX) errormsg(SH_DICT, ERROR_exit(1), e_toodeep, script);
+    if (shp->dot_depth + 1 > DOTMAX) {
+        errormsg(SH_DICT, ERROR_exit(1), e_toodeep, script);
+        __builtin_unreachable();
+    }
     np = shp->posix_fun;
     if (!np) {
         // Check for KornShell style function first.
@@ -259,6 +263,7 @@ int b_dot_cmd(int n, char *argv[], Shbltin_t *context) {
                     if (nv_isattr(np, NV_FPOSIX)) np = 0;
                 } else {
                     errormsg(SH_DICT, ERROR_exit(1), e_found, script);
+                    __builtin_unreachable();
                 }
             }
         } else {
@@ -368,6 +373,7 @@ int b_shift(int n, char *argv[], Shbltin_t *context) {
     n = ((arg = *argv) ? (int)sh_arith(shp, arg) : 1);
     if (n < 0 || shp->st.dolc < n) {
         errormsg(SH_DICT, ERROR_exit(1), e_number, arg);
+        __builtin_unreachable();
     } else {
         shp->st.dolv += n;
         shp->st.dolc -= n;
@@ -428,11 +434,17 @@ int b_bg(int n, char *argv[], Shbltin_t *context) {
     if (error_info.errors) errormsg(SH_DICT, ERROR_usage(2), "%s", optusage((char *)0));
     argv += opt_info.index;
     if (!sh_isoption(shp, SH_MONITOR) || !job.jobcontrol) {
-        if (sh_isstate(shp, SH_INTERACTIVE)) errormsg(SH_DICT, ERROR_exit(1), e_no_jctl);
+        if (sh_isstate(shp, SH_INTERACTIVE)) {
+            errormsg(SH_DICT, ERROR_exit(1), e_no_jctl);
+            __builtin_unreachable();
+        }
         return 1;
     }
     if (flag == 'd' && *argv == 0) argv = (char **)0;
-    if (job_walk(shp, sfstdout, job_switch, flag, argv)) errormsg(SH_DICT, ERROR_exit(1), e_no_job);
+    if (job_walk(shp, sfstdout, job_switch, flag, argv)) {
+        errormsg(SH_DICT, ERROR_exit(1), e_no_job);
+        __builtin_unreachable();
+    }
     return shp->exitval;
 }
 
@@ -470,7 +482,10 @@ int b_jobs(int n, char *argv[], Shbltin_t *context) {
     argv += opt_info.index;
     if (error_info.errors) errormsg(SH_DICT, ERROR_usage(2), "%s", optusage((char *)0));
     if (*argv == 0) argv = (char **)0;
-    if (job_walk(shp, sfstdout, job_list, flag, argv)) errormsg(SH_DICT, ERROR_exit(1), e_no_job);
+    if (job_walk(shp, sfstdout, job_list, flag, argv)) {
+        errormsg(SH_DICT, ERROR_exit(1), e_no_job);
+        __builtin_unreachable();
+    }
     job_wait((pid_t)0);
     return shp->exitval;
 }
@@ -503,11 +518,15 @@ int b_universe(int argc, char *argv[], Shbltin_t *context) {
     if (error_info.errors || argc > 1) errormsg(SH_DICT, ERROR_usage(2), "%s", optusage((char *)0));
     arg = argv[0];
     if (arg) {
-        if (!astconf("UNIVERSE", 0, arg)) errormsg(SH_DICT, ERROR_exit(1), e_badname, arg);
+        if (!astconf("UNIVERSE", 0, arg)) {
+            errormsg(SH_DICT, ERROR_exit(1), e_badname, arg);
+            __builtin_unreachable();
+        }
     } else {
         arg = astconf("UNIVERSE", 0, 0);
         if (!arg) {
             errormsg(SH_DICT, ERROR_exit(1), e_nouniverse);
+            __builtin_unreachable();
         } else {
             sfputr(sfstdout, arg, '\n');
         }

--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -541,7 +541,10 @@ static_fn ssize_t fmtbase64(Shell_t *shp, Sfio_t *iop, char *string, const char 
     static union types_t number;
 
     if (!np || nv_isnull(np)) {
-        if (sh_isoption(shp, SH_NOUNSET)) errormsg(SH_DICT, ERROR_exit(1), e_notset, string);
+        if (sh_isoption(shp, SH_NOUNSET)) {
+            errormsg(SH_DICT, ERROR_exit(1), e_notset, string);
+            __builtin_unreachable();
+        }
         return 0;
     }
     if (nv_isattr(np, NV_INTEGER) && !nv_isarray(np)) {
@@ -748,8 +751,10 @@ static_fn int extend(Sfio_t *sp, void *v, Sffmt_t *fe) {
                 break;
             }
             default: {
-                if (!strchr("DdXxoUu", format))
+                if (!strchr("DdXxoUu", format)) {
                     errormsg(SH_DICT, ERROR_exit(1), e_formspec, format);
+                    __builtin_unreachable();
+                }
                 fe->fmt = 'd';
                 value->ll = 0;
                 break;
@@ -935,7 +940,7 @@ static_fn int extend(Sfio_t *sp, void *v, Sffmt_t *fe) {
                 fe->fmt = 'd';
                 fe->size = sizeof(value->ll);
                 errormsg(SH_DICT, ERROR_exit(1), e_formspec, format);
-                break;
+                __builtin_unreachable();
             }
         }
 
@@ -986,13 +991,19 @@ static_fn int extend(Sfio_t *sp, void *v, Sffmt_t *fe) {
         }
         case 'P': {
             s = fmtmatch(value->s);
-            if (!s || *s == 0) errormsg(SH_DICT, ERROR_exit(1), e_badregexp, value->s);
+            if (!s || *s == 0) {
+                errormsg(SH_DICT, ERROR_exit(1), e_badregexp, value->s);
+                __builtin_unreachable();
+            }
             value->s = s;
             break;
         }
         case 'R': {
             s = fmtre(value->s);
-            if (!s || *s == 0) errormsg(SH_DICT, ERROR_exit(1), e_badregexp, value->s);
+            if (!s || *s == 0) {
+                errormsg(SH_DICT, ERROR_exit(1), e_badregexp, value->s);
+                __builtin_unreachable();
+            }
             value->s = s;
             break;
         }

--- a/src/cmd/ksh93/bltins/read.c
+++ b/src/cmd/ksh93/bltins/read.c
@@ -292,7 +292,10 @@ int b_read(int argc, char *argv[], Shbltin_t *context) {
             }
             case 'u': {
                 if (opt_info.arg[0] == 'p' && opt_info.arg[1] == 0) {
-                    if ((fd = shp->cpipe[0]) <= 0) errormsg(SH_DICT, ERROR_exit(1), e_query);
+                    if ((fd = shp->cpipe[0]) <= 0) {
+                        errormsg(SH_DICT, ERROR_exit(1), e_query);
+                        __builtin_unreachable();
+                    }
                     break;
                 }
                 fd = (int)strtol(opt_info.arg, &opt_info.arg, 10);
@@ -642,6 +645,7 @@ int sh_readline(Shell_t *shp, char **names, void *readfn, volatile int fd, int f
         c = sfvalue(iop) + 1;
         if (!sferror(iop) && sfgetc(iop) >= 0) {
             errormsg(SH_DICT, ERROR_exit(1), e_overlimit, "line length");
+            __builtin_unreachable();
         }
     }
     if (timeslot) timerdel(timeslot);

--- a/src/cmd/ksh93/bltins/sleep.c
+++ b/src/cmd/ksh93/bltins/sleep.c
@@ -117,14 +117,21 @@ int b_sleep(int argc, char *argv[], Shbltin_t *context) {
                     if (*last && (pp = sfprints("p%s", cp))) ns = tmxdate(pp, &last, now);
                 }
             }
-            if (*last) errormsg(SH_DICT, ERROR_exit(1), e_number, *argv);
+            if (*last) {
+                errormsg(SH_DICT, ERROR_exit(1), e_number, *argv);
+                __builtin_unreachable();
+            }
             d = ns - now;
             d /= TMX_RESOLUTION;
         }
     skip:
-        if (argv[1]) errormsg(SH_DICT, ERROR_exit(1), e_oneoperand);
+        if (argv[1]) {
+            errormsg(SH_DICT, ERROR_exit(1), e_oneoperand);
+            __builtin_unreachable();
+        }
     } else if (!sflag) {
         errormsg(SH_DICT, ERROR_exit(1), e_oneoperand);
+        __builtin_unreachable();
     }
     if (d > .10) {
         time(&tloc);

--- a/src/cmd/ksh93/bltins/test.c
+++ b/src/cmd/ksh93/bltins/test.c
@@ -141,7 +141,10 @@ int b_test(int argc, char *argv[], Shbltin_t *context) {
 
     if (c_eq(cp, '[')) {
         cp = argv[--argc];
-        if (!c_eq(cp, ']')) errormsg(SH_DICT, ERROR_exit(2), e_missing, "']'");
+        if (!c_eq(cp, ']')) {
+            errormsg(SH_DICT, ERROR_exit(2), e_missing, "']'");
+            __builtin_unreachable();
+        }
     }
 
     // According to POSIX, test builtin should return 1 if expression is missing
@@ -188,6 +191,7 @@ int b_test(int argc, char *argv[], Shbltin_t *context) {
                     goto done;
                 }
                 errormsg(SH_DICT, ERROR_exit(2), e_badop, cp);
+                __builtin_unreachable();
             }
             result = (test_binop(tdata.sh, op, argv[1], argv[3]) ^ (argc != 5));
             goto done;
@@ -258,6 +262,7 @@ static_fn int eval_expr(struct test *tp, int flag) {
         }
         if (flag == 0) break;
         errormsg(SH_DICT, ERROR_exit(2), e_badsyntax);
+        __builtin_unreachable();
     }
     return r;
 }
@@ -269,6 +274,7 @@ static_fn char *nxtarg(struct test *tp, int mt) {
             return 0;
         }
         errormsg(SH_DICT, ERROR_exit(2), e_argument);
+        __builtin_unreachable();
     }
     return tp->av[tp->ap++];
 }
@@ -283,7 +289,10 @@ static_fn int eval_e3(struct test *tp) {
     if (c_eq(arg, '(')) {
         op = eval_expr(tp, 1);
         cp = nxtarg(tp, 0);
-        if (!cp || !c_eq(cp, ')')) errormsg(SH_DICT, ERROR_exit(2), e_missing, "')'");
+        if (!cp || !c_eq(cp, ')')) {
+            errormsg(SH_DICT, ERROR_exit(2), e_missing, "')'");
+            __builtin_unreachable();
+        }
         return op;
     }
     cp = nxtarg(tp, 1);
@@ -302,8 +311,9 @@ static_fn int eval_e3(struct test *tp) {
         op = arg[1];
         if (!cp) {
             // For backward compatibility with new flags.
-            if (op == 0 || !strchr(test_opchars + 10, op)) return (1);
+            if (op == 0 || !strchr(test_opchars + 10, op)) return 1;
             errormsg(SH_DICT, ERROR_exit(2), e_argument);
+            __builtin_unreachable();
         }
         if (strchr(test_opchars, op)) return (test_unop(tp->sh, op, cp));
     }
@@ -315,7 +325,10 @@ static_fn int eval_e3(struct test *tp) {
 skip:
     op = sh_lookup(binop = cp, shtab_testops);
     if (!(op & TEST_BINOP)) cp = nxtarg(tp, 0);
-    if (!op) errormsg(SH_DICT, ERROR_exit(2), e_badop, binop);
+    if (!op) {
+        errormsg(SH_DICT, ERROR_exit(2), e_badop, binop);
+        __builtin_unreachable();
+    }
     if (op == TEST_AND || op == TEST_OR) tp->ap--;
     return test_binop(tp->sh, op, arg, cp);
 }
@@ -454,8 +467,7 @@ int test_unop(Shell_t *shp, int op, const char *arg) {
             static char a[3] = "-?";
             a[1] = op;
             errormsg(SH_DICT, ERROR_exit(2), e_badop, a);
-            // NOTREACHED
-            return 0;
+            __builtin_unreachable();
         }
     }
 }

--- a/src/cmd/ksh93/bltins/trap.c
+++ b/src/cmd/ksh93/bltins/trap.c
@@ -108,7 +108,10 @@ int b_trap(int argc, char *argv[], Shbltin_t *context) {
                     dflag = true;
                 }
             }
-            if (!argv[0]) errormsg(SH_DICT, ERROR_exit(1), e_condition);
+            if (!argv[0]) {
+                errormsg(SH_DICT, ERROR_exit(1), e_condition);
+                __builtin_unreachable();
+            }
         }
         while ((arg = *argv++)) {
             sig = sig_number(shp, arg);
@@ -238,6 +241,7 @@ int b_kill(int argc, char *argv[], Shbltin_t *context) {
                 if ((int)shp->sigval != shp->sigval) {
                     errormsg(SH_DICT, ERROR_exit(1), "%lld - too large for sizeof(integer)",
                              shp->sigval);
+                    __builtin_unreachable();
                 }
                 break;
             }
@@ -246,6 +250,7 @@ int b_kill(int argc, char *argv[], Shbltin_t *context) {
                 shp->sigval = opt_info.num;
                 if ((int)shp->sigval < 0) {
                     errormsg(SH_DICT, ERROR_exit(1), "%lld - Q must be unsigned", shp->sigval);
+                    __builtin_unreachable();
                 }
                 break;
             }
@@ -277,6 +282,7 @@ endopts:
                         shp->exitval = 2;
                         shp->sigval = 0;
                         errormsg(SH_DICT, ERROR_exit(1), e_nosignal, signame);
+                        __builtin_unreachable();
                     }
                     sfprintf(sfstdout, "%d\n", sig);
                 }
@@ -288,6 +294,7 @@ endopts:
         if ((sig = sig_number(shp, signame)) < 0 || sig >= shp->gd->sigmax) {
             shp->exitval = 2;
             errormsg(SH_DICT, ERROR_exit(1), e_nosignal, signame);
+            __builtin_unreachable();
         }
     }
     if (job_walk(shp, sfstdout, job_kill, sig | (flag & (Q_FLAG | QQ_FLAG)), argv)) {

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -199,6 +199,7 @@ int b_alias(int argc, char *argv[], Shbltin_t *context) {
                         argv++;
                     } else {
                         errormsg(SH_DICT, ERROR_exit(1), e_option, argv[1]);
+                        __builtin_unreachable();
                     }
                 }
             }
@@ -312,7 +313,10 @@ int b_typeset(int argc, char *argv[], Shbltin_t *context) {
             case 'Z':
             case 'R': {
                 if (tdata.argnum == 0) tdata.argnum = (int)opt_info.num;
-                if (tdata.argnum < 0) errormsg(SH_DICT, ERROR_exit(1), e_badfield, tdata.argnum);
+                if (tdata.argnum < 0) {
+                    errormsg(SH_DICT, ERROR_exit(1), e_badfield, tdata.argnum);
+                    __builtin_unreachable();
+                }
                 if (n == 'Z') {
                     flag |= NV_ZFILL;
                 } else {
@@ -324,6 +328,7 @@ int b_typeset(int argc, char *argv[], Shbltin_t *context) {
             case 'M': {
                 if ((tdata.wctname = opt_info.arg) && !nv_mapchar((Namval_t *)0, tdata.wctname)) {
                     errormsg(SH_DICT, ERROR_exit(1), e_unknownmap, tdata.wctname);
+                    __builtin_unreachable();
                 }
                 if (tdata.wctname && strcmp(tdata.wctname, e_tolower) == 0) {
                     flag |= NV_UTOL;
@@ -400,6 +405,7 @@ endargs:
 #if SHOPT_BASH
     if (local && context->shp->var_base == context->shp->var_tree) {
         errormsg(SH_DICT, ERROR_exit(1), "local can only be used in a function");
+        __builtin_unreachable();
     }
 #endif  // SHOPT_BASH
     opt_info.disc = 0;
@@ -427,6 +433,7 @@ endargs:
     if (error_info.errors) errormsg(SH_DICT, ERROR_usage(2), "%s", optusage(NULL));
     if (sizeof(char *) < 8 && tdata.argnum > SHRT_MAX) {
         errormsg(SH_DICT, ERROR_exit(2), "option argument cannot be greater than %d", SHRT_MAX);
+        __builtin_unreachable();
     }
     if (isfloat) flag |= NV_DOUBLE;
     if (isshort) {
@@ -464,6 +471,7 @@ endargs:
         stkseek(stkp, offset);
         if (!tdata.tp) {
             errormsg(SH_DICT, ERROR_exit(1), "%s: unknown type", tdata.prefix);
+            __builtin_unreachable();
         } else if (nv_isnull(tdata.tp)) {
             nv_newtype(tdata.tp);
         }
@@ -479,6 +487,7 @@ endargs:
     if (!tdata.sh->mktype) tdata.help = 0;
     if (tdata.aflag == '+' && (flag & (NV_ARRAY | NV_IARRAY | NV_COMVAR)) && argv[1]) {
         errormsg(SH_DICT, ERROR_exit(1), e_nounattr);
+        __builtin_unreachable();
     }
     return setall(argv, flag, troot, &tdata);
 }
@@ -575,6 +584,7 @@ static_fn int setall(char **argv, int flag, Dt_t *troot, struct tdata *tp) {
                     // Function names cannot be special builtin.
                     if ((np = nv_search(name, shp->bltin_tree, 0)) && nv_isattr(np, BLT_SPC)) {
                         errormsg(SH_DICT, ERROR_exit(1), e_badfun, name);
+                        __builtin_unreachable();
                     }
                     if (shp->namespace) {
                         np = sh_fsearch(shp, name, NV_ADD | HASH_NOSCOPE);
@@ -644,6 +654,7 @@ static_fn int setall(char **argv, int flag, Dt_t *troot, struct tdata *tp) {
                        (mp = (Namval_t *)np->nvenv) && (ap = nv_arrayptr(mp)) &&
                        (ap->flags & ARRAY_TREE)) {
                 errormsg(SH_DICT, ERROR_exit(1), e_typecompat, nv_name(np));
+                __builtin_unreachable();
             } else if ((ap = nv_arrayptr(np)) && nv_aindex(np) > 0 && ap->nelem == 1 &&
                        nv_getval(np) == Empty) {
                 ap->nelem++;
@@ -652,6 +663,7 @@ static_fn int setall(char **argv, int flag, Dt_t *troot, struct tdata *tp) {
             } else if (iarray && ap && ap->fun) {
                 errormsg(SH_DICT, ERROR_exit(1),
                          "cannot change associative array %s to index array", nv_name(np));
+                __builtin_unreachable();
             } else if ((iarray || (flag & NV_ARRAY)) && nv_isvtree(np) && !nv_type(np)) {
                 _nv_unset(np, NV_EXPORT);
             }
@@ -730,7 +742,10 @@ static_fn int setall(char **argv, int flag, Dt_t *troot, struct tdata *tp) {
             if (!(flag & NV_INTEGER) && (flag & (NV_LTOU | NV_UTOL))) {
                 Namfun_t *fp;
                 char *cp;
-                if (!tp->wctname) errormsg(SH_DICT, ERROR_exit(1), e_mapchararg, nv_name(np));
+                if (!tp->wctname) {
+                    errormsg(SH_DICT, ERROR_exit(1), e_mapchararg, nv_name(np));
+                    __builtin_unreachable();
+                }
                 cp = (char *)nv_mapchar(np, 0);
                 fp = nv_mapchar(np, tp->wctname);
                 if (fp) {
@@ -749,6 +764,7 @@ static_fn int setall(char **argv, int flag, Dt_t *troot, struct tdata *tp) {
             if (tp->aflag == '-') {
                 if ((flag & NV_EXPORT) && (strchr(name, '.') || nv_isvtree(np))) {
                     errormsg(SH_DICT, ERROR_exit(1), e_badexport, name);
+                    __builtin_unreachable();
                 }
 #if SHOPT_BASH
                 if (flag & NV_EXPORT) nv_offattr(np, NV_IMPORT);
@@ -766,6 +782,7 @@ static_fn int setall(char **argv, int flag, Dt_t *troot, struct tdata *tp) {
             } else {
                 if ((flag & NV_RDONLY) && (curflag & NV_RDONLY)) {
                     errormsg(SH_DICT, ERROR_exit(1), e_readonly, nv_name(np));
+                    __builtin_unreachable();
                 }
                 newflag = curflag & ~flag;
             }
@@ -989,6 +1006,7 @@ int b_builtin(int argc, char *argv[], Shbltin_t *context) {
     if (arg || *argv) {
         if (sh_isoption(tdata.sh, SH_RESTRICTED)) {
             errormsg(SH_DICT, ERROR_exit(1), e_restricted, argv[-opt_info.index]);
+            __builtin_unreachable();
         }
         if (tdata.sh->subshell && !tdata.sh->subshare) sh_subfork();
     }
@@ -1016,7 +1034,7 @@ int b_builtin(int argc, char *argv[], Shbltin_t *context) {
 #endif  // _AST_VERSION >= 20040404
         {
             errormsg(SH_DICT, ERROR_exit(0), "%s: %s", arg, dlerror());
-            return (1);
+            return 1;
         }
 #endif  // SH_PLUGIN_VERSION
         sh_addlib(tdata.sh, library, arg, NULL);

--- a/src/cmd/ksh93/bltins/ulimit.c
+++ b/src/cmd/ksh93/bltins/ulimit.c
@@ -53,7 +53,7 @@ int b_ulimit(int argc, char *argv[], Shbltin_t *context) {
     UNUSED(context);
 
     errormsg(SH_DICT, ERROR_exit(2), e_nosupport);
-    return 0;
+    __builtin_unreachable();
 }
 
 #else  // _no_ulimit

--- a/src/cmd/ksh93/bltins/umask.c
+++ b/src/cmd/ksh93/bltins/umask.c
@@ -83,6 +83,7 @@ int b_umask(int argc, char *argv[], Shbltin_t *context) {
                     flag = (flag << 3) + (c - '0');
                 } else {
                     errormsg(SH_DICT, ERROR_exit(1), e_number, *argv);
+                    __builtin_unreachable();
                 }
             }
         } else {
@@ -92,6 +93,7 @@ int b_umask(int argc, char *argv[], Shbltin_t *context) {
             if (*cp) {
                 umask(flag);
                 errormsg(SH_DICT, ERROR_exit(1), e_format, mask);
+                __builtin_unreachable();
             }
             flag = (~c & 0777);
         }

--- a/src/cmd/ksh93/bltins/whence.c
+++ b/src/cmd/ksh93/bltins/whence.c
@@ -70,8 +70,10 @@ int b_command(int argc, char *argv[], Shbltin_t *context) {
     while ((n = optget(argv, sh_optcommand))) {
         switch (n) {
             case 'p': {
-                if (sh_isoption(shp, SH_RESTRICTED))
+                if (sh_isoption(shp, SH_RESTRICTED)) {
                     errormsg(SH_DICT, ERROR_exit(1), e_restricted, "-p");
+                    __builtin_unreachable();
+                }
                 sh_onstate(shp, SH_DEFPATH);
                 break;
             }

--- a/src/cmd/ksh93/edit/pcomplete.c
+++ b/src/cmd/ksh93/edit/pcomplete.c
@@ -293,6 +293,7 @@ char **ed_pcomplete(struct Complete *comp, const char *line, const char *prefix,
     if (comp->fname && !comp->fun &&
         !(comp->fun = nv_search(comp->fname, sh_subfuntree(shp, 0), 0))) {
         errormsg(SH_DICT, ERROR_exit(1), "%s: function not found", comp->fname);
+        __builtin_unreachable();
     }
     if (comp->command || comp->fun) {
         char *cpsave;
@@ -590,6 +591,7 @@ int b_complete(int argc, char *argv[], Shbltin_t *context) {
                 if ((n = action(Action_names, opt_info.arg)) == 0) {
                     errormsg(SH_DICT, ERROR_exit(1), "invalid -%c option name %s", 'A',
                              opt_info.arg);
+                    __builtin_unreachable();
                 }
                 // FALL THRU
             }
@@ -624,6 +626,7 @@ int b_complete(int argc, char *argv[], Shbltin_t *context) {
                 if ((n = action(Option_names, opt_info.arg)) == 0) {
                     errormsg(SH_DICT, ERROR_exit(1), "invalid -%c option name %s", 'o',
                              opt_info.arg);
+                    __builtin_unreachable();
                 }
                 n = (strchr(Options, n) - Options);
                 comp.options |= 1 << n;

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -267,6 +267,7 @@ int sh_argopts(int argc, char *argv[], void *context) {
             case 'O': {  // shopt options, only in bash mode
                 if (!sh_isoption(shp, SH_BASH))
                     errormsg(SH_DICT, ERROR_exit(1), e_option, opt_info.name);
+                    __builtin_unreachable();
             }
 #endif
             case 'o': {  // set options
@@ -293,6 +294,7 @@ int sh_argopts(int argc, char *argv[], void *context) {
                 o &= 0xff;
                 if (sh_isoption(shp, SH_RESTRICTED) && !f && o == SH_RESTRICTED) {
                     errormsg(SH_DICT, ERROR_exit(1), e_restricted, opt_info.arg);
+                    __builtin_unreachable();
                 }
                 break;
             }
@@ -406,6 +408,7 @@ int sh_argopts(int argc, char *argv[], void *context) {
         } else {
             if (o == SH_RESTRICTED && sh_isoption(shp, SH_RESTRICTED)) {
                 errormsg(SH_DICT, ERROR_exit(1), e_restricted, "r");
+                __builtin_unreachable();
             }
             if (o == SH_XTRACE) trace = 0;
             off_option(&newflags, o);

--- a/src/cmd/ksh93/sh/array.c
+++ b/src/cmd/ksh93/sh/array.c
@@ -176,7 +176,10 @@ static_fn union Value *array_getup(Namval_t *np, Namarr_t *arp, int update) {
             return ((union Value *)((*arp->fun)(np, NULL, 0)));
         }
     } else {
-        if (ap->cur >= ap->maxi) errormsg(SH_DICT, ERROR_exit(1), e_subscript, nv_name(np));
+        if (ap->cur >= ap->maxi) {
+            errormsg(SH_DICT, ERROR_exit(1), e_subscript, nv_name(np));
+            __builtin_unreachable();
+        }
         up = &(ap->val[ap->cur]);
         nofree = array_isbit(ap->bits, ap->cur, ARRAY_NOFREE);
     }
@@ -266,7 +269,10 @@ static_fn Namval_t *array_find(Namval_t *np, Namarr_t *arp, int flag) {
         if (!(ap->header.flags & ARRAY_SCAN) && ap->cur >= ap->maxi) {
             ap = array_grow(np, ap, (int)ap->cur);
         }
-        if (ap->cur >= ap->maxi) errormsg(SH_DICT, ERROR_exit(1), e_subscript, nv_name(np));
+        if (ap->cur >= ap->maxi) {
+            errormsg(SH_DICT, ERROR_exit(1), e_subscript, nv_name(np));
+            __builtin_unreachable();
+        }
         up = &(ap->val[ap->cur]);
         if ((!up->cp || up->cp == Empty) && nv_type(np) && nv_isvtree(np)) {
             char *cp;
@@ -614,6 +620,7 @@ static_fn struct index_array *array_grow(Namval_t *np, struct index_array *arp, 
 
     if (maxi >= ARRAY_MAX) {
         errormsg(SH_DICT, ERROR_exit(1), e_subscript, fmtbase((long)maxi, 10, 0));
+        __builtin_unreachable();
     }
     size = (newsize - 1) * sizeof(union Value *) + newsize;
     ap = calloc(1, sizeof(struct index_array) + size);
@@ -692,7 +699,10 @@ bool nv_atypeindex(Namval_t *np, const char *tname) {
     stkseek(shp->stk, offset);
     if (tp) {
         struct index_array *ap = (struct index_array *)nv_arrayptr(np);
-        if (!nv_hasdisc(tp, &ENUM_disc)) errormsg(SH_DICT, ERROR_exit(1), e_notenum, tp->nvname);
+        if (!nv_hasdisc(tp, &ENUM_disc)) {
+            errormsg(SH_DICT, ERROR_exit(1), e_notenum, tp->nvname);
+            __builtin_unreachable();
+        }
         if (!ap) ap = array_grow(np, ap, 1);
         ap->xp = calloc(NV_MINSZ, 1);
         np = nv_namptr(ap->xp, 0);
@@ -702,8 +712,9 @@ bool nv_atypeindex(Namval_t *np, const char *tname) {
         nv_offattr(np, NV_RDONLY);
         return true;
     }
+
     errormsg(SH_DICT, ERROR_exit(1), e_unknowntype, n, tname);
-    return false;
+    __builtin_unreachable();
 }
 
 Namarr_t *nv_arrayptr(Namval_t *np) {
@@ -912,7 +923,7 @@ Namval_t *nv_putsub(Namval_t *np, char *sp, long size, int flags) {
         if (size < 0 && ap) size += array_maxindex(np);
         if (size >= ARRAY_MAX || (size < 0)) {
             errormsg(SH_DICT, ERROR_exit(1), e_subscript, nv_name(np));
-            return NULL;
+            __builtin_unreachable();
         }
         if (!ap || size >= ap->maxi) {
             if (size == 0 && !(flags & ARRAY_FILL)) return (NULL);
@@ -1312,6 +1323,7 @@ void nv_setvec(Namval_t *np, int append, int argc, char *argv[]) {
         if (ap && is_associative(ap)) {
             errormsg(SH_DICT, ERROR_exit(1), "cannot append index array to associative array %s",
                      nv_name(np));
+            __builtin_unreachable();
         }
     }
     if (append) {

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -209,7 +209,7 @@ static_fn char *nospace(int unused) {
     UNUSED(unused);
 
     errormsg(SH_DICT, ERROR_exit(3), e_nospace);
-    return NULL;
+    __builtin_unreachable();
 }
 
 // Trap for VISUAL and EDITOR variables.
@@ -289,6 +289,7 @@ static_fn void put_restricted(Namval_t *np, const void *val, int flags, Namfun_t
 
     if (!(flags & NV_RDONLY) && sh_isoption(shp, SH_RESTRICTED)) {
         errormsg(SH_DICT, ERROR_exit(1), e_restricted, nv_name(np));
+        __builtin_unreachable();
     }
     if (np == PATHNOD || (path_scoped = (strcmp(name, PATHNOD->nvname) == 0))) {
         nv_scan(shp->track_tree, rehash, (void *)0, NV_TAGGED, NV_TAGGED);
@@ -1215,7 +1216,10 @@ static_fn void put_mode(Namval_t *np, const char *val, int flag, Namfun_t *nfp) 
             }
         } else {
             mode = strperm(val, &last, 0);
-            if (*last) errormsg(SH_DICT, ERROR_exit(1), "%s: invalid mode string", val);
+            if (*last) {
+                errormsg(SH_DICT, ERROR_exit(1), "%s: invalid mode string", val);
+                __builtin_unreachable();
+            }
         }
         nv_putv(np, (char *)&mode, NV_INTEGER, nfp);
     } else {
@@ -1434,6 +1438,7 @@ Shell_t *sh_init(int argc, char *argv[], Shinit_f userinit) {
         // Careful of #! setuid scripts with name beginning with -.
         if (shp->login_sh && argv[1] && strcmp(argv[0], argv[1]) == 0) {
             errormsg(SH_DICT, ERROR_exit(1), e_prohibited);
+            __builtin_unreachable();
         }
     } else {
         sh_offoption(shp, SH_PRIVILEGED);
@@ -1645,9 +1650,8 @@ static_fn Namval_t *create_svar(Namval_t *np, const void *vp, int flag, Namfun_t
         }
     }
 
-    // This is a can't happen case. The return is just to avoid lint warnings. It isn't reached.
     errormsg(SH_DICT, ERROR_exit(1), e_notelem, strlen(name), name, nv_name(np));
-    return NULL;
+    __builtin_unreachable();
 }
 
 static_fn Namfun_t *clone_svar(Namval_t *np, Namval_t *mp, int flags, Namfun_t *fp) {

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -1181,7 +1181,10 @@ int sh_redirect(Shell_t *shp, struct ionod *iop, int flag) {
 #endif  // SHOPT_COSHELL
         if (iop->iovname) {
             np = nv_open(iop->iovname, shp->var_tree, NV_NOASSIGN | NV_VARNAME);
-            if (nv_isattr(np, NV_RDONLY)) errormsg(SH_DICT, ERROR_exit(1), e_readonly, nv_name(np));
+            if (nv_isattr(np, NV_RDONLY)) {
+                errormsg(SH_DICT, ERROR_exit(1), e_readonly, nv_name(np));
+                __builtin_unreachable();
+            }
             io_op[0] = '}';
             if ((iof & IOLSEEK) || ((iof & IOMOV) && *fname == '-')) fn = nv_getnum(np);
         }
@@ -1332,6 +1335,7 @@ int sh_redirect(Shell_t *shp, struct ionod *iop, int flag) {
             } else if (iof & IORDW) {
                 if (sh_isoption(shp, SH_RESTRICTED)) {
                     errormsg(SH_DICT, ERROR_exit(1), e_restricted, fname);
+                    __builtin_unreachable();
                 }
                 io_op[2] = '>';
                 o_mode = O_RDWR | O_CREAT;
@@ -1343,6 +1347,7 @@ int sh_redirect(Shell_t *shp, struct ionod *iop, int flag) {
                 fd = sh_iomovefd(shp, fd);
             } else if (sh_isoption(shp, SH_RESTRICTED)) {
                 errormsg(SH_DICT, ERROR_exit(1), e_restricted, fname);
+                __builtin_unreachable();
             } else {
                 if (iof & IOAPP) {
                     io_op[2] = '>';
@@ -1725,6 +1730,7 @@ void sh_iosave(Shell_t *shp, int origfd, int oldtop, char *name) {
         filemapsize += 8;
         if (!(filemap = (struct fdsave *)realloc(filemap, filemapsize * sizeof(struct fdsave)))) {
             errormsg(SH_DICT, ERROR_exit(4), e_nospace);
+            __builtin_unreachable();
         }
         moved = (char *)filemap - oldptr;
         if (moved) {

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -87,7 +87,10 @@ pid_t pid_fromstring(char *str) {
     } else {
         pid = (pid_t)strtol(str, &last, 10);
     }
-    if (errno == ERANGE || *last) errormsg(SH_DICT, ERROR_exit(1), "%s: invalid process id", str);
+    if (errno == ERANGE || *last) {
+        errormsg(SH_DICT, ERROR_exit(1), "%s: invalid process id", str);
+        __builtin_unreachable();
+    }
     return pid;
 }
 
@@ -293,7 +296,10 @@ int job_cowalk(int (*fun)(struct process *, int), int arg, char *name) {
     for (csp = (struct cosh *)job.colist; csp; csp = csp->next) {
         if (strncmp(name, csp->name, n) == 0 && csp->name[n] == 0) break;
     }
-    if (!csp) errormsg(SH_DICT, ERROR_exit(1), e_jobusage, name);
+    if (!csp) {
+        errormsg(SH_DICT, ERROR_exit(1), e_jobusage, name);
+        __builtin_unreachable();
+    }
     if (cp) {
         n = pid_fromstring(cp + 1);
         val = (csp->id << 16) | n | COPID_BIT;
@@ -855,7 +861,10 @@ int job_walk(Shell_t *shp, Sfio_t *file, int (*fun)(struct process *, int), int 
     } else {
         while (*jobs) {
             job_string = jobid = *jobs++;
-            if (*jobid == 0) errormsg(SH_DICT, ERROR_exit(1), e_jobusage, job_string);
+            if (*jobid == 0) {
+                errormsg(SH_DICT, ERROR_exit(1), e_jobusage, job_string);
+                __builtin_unreachable();
+            }
 #if SHOPT_COSHELL
             if (isalpha(*jobid)) {
                 r = job_cowalk(fun, arg, jobid);
@@ -1150,7 +1159,10 @@ static_fn struct process *job_byname(char *name) {
     if (*cp == '?') cp++, flag = &offset;
     for (; pw; pw = pw->p_nxtjob) {
         if (hist_match(shgd->hist_ptr, pw->p_name, cp, flag) >= 0) {
-            if (pz) errormsg(SH_DICT, ERROR_exit(1), e_jobusage, name - 1);
+            if (pz) {
+                errormsg(SH_DICT, ERROR_exit(1), e_jobusage, name - 1);
+                __builtin_unreachable();
+            }
             pz = pw;
         }
     }

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -1097,6 +1097,7 @@ int sh_lex(Lex_t *lp) {
                         if (mode == ST_NAME) {
                             errormsg(SH_DICT, ERROR_exit(SYNBAD), e_lexsyntax1, shp->inlineno, "[]",
                                      "empty subscript");
+                            __builtin_unreachable();
                         }
                         if (!epatchar || epatchar == '%') continue;
                     } else {
@@ -1541,6 +1542,7 @@ done:
     lp->assignok = (endchar(lp) == RBRACT ? assignok : 0);
     if (lp->heredoc && !inheredoc) {
         errormsg(SH_DICT, ERROR_exit(SYNBAD), e_lexsyntax5, lp->sh->inlineno, lp->heredoc->ioname);
+        __builtin_unreachable();
     }
     return messages;
 }
@@ -1855,7 +1857,7 @@ static_fn char *fmttoken(Lex_t *lp, int sym, char *tok) {
 //
 // Print a bad syntax message.
 //
-void sh_syntax(Lex_t *lp) {
+__attribute__((noreturn)) void sh_syntax(Lex_t *lp) {
     Shell_t *shp = lp->sh;
     const char *cp = sh_translate(e_unexpected);
     char *tokstr;
@@ -1889,8 +1891,10 @@ void sh_syntax(Lex_t *lp) {
     if (shp->inlineno != 1) {
 #endif
         errormsg(SH_DICT, ERROR_exit(SYNBAD), e_lexsyntax1, lp->lastline, tokstr, cp);
+        __builtin_unreachable();
     } else {
         errormsg(SH_DICT, ERROR_exit(SYNBAD), e_lexsyntax2, tokstr, cp);
+        __builtin_unreachable();
     }
 }
 

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -195,6 +195,7 @@ char *sh_mactrim(Shell_t *shp, char *str, int mode) {
             str = arglist->argval;
         } else if (mode > 1) {
             errormsg(SH_DICT, ERROR_exit(1), e_ambiguous, str);
+            __builtin_unreachable();
         }
         sh_trim(str);
     }
@@ -675,6 +676,7 @@ static_fn void copyto(Mac_t *mp, int endch, int newquote) {
                         if (first[c - 2] == '.') offset = stktell(stkp);
                         if (isastchar(*cp) && cp[1] == ']') {
                             errormsg(SH_DICT, ERROR_exit(1), e_badsubscript, *cp);
+                            __builtin_unreachable();
                         }
                     }
                     first = fcseek(c);
@@ -1142,7 +1144,10 @@ retry1:
             if (!v && sh_isoption(mp->shp, SH_NOUNSET)) {
                 d = fcget();
                 fcseek(-1);
-                if (!(d && strchr(":+-?=", d))) errormsg(SH_DICT, ERROR_exit(1), e_notset, ltos(c));
+                if (!(d && strchr(":+-?=", d))) {
+                    errormsg(SH_DICT, ERROR_exit(1), e_notset, ltos(c));
+                    __builtin_unreachable();
+                }
             }
             break;
         }
@@ -1380,6 +1385,7 @@ retry1:
                 if (sh_isoption(mp->shp, SH_NOUNSET) && !isastchar(mode) &&
                     (type == M_VNAME || type == M_SIZE)) {
                     errormsg(SH_DICT, ERROR_exit(1), e_notset, id);
+                    __builtin_unreachable();
                 }
                 v = 0;
                 if (type == M_VNAME) {
@@ -1488,6 +1494,7 @@ skip:
             if (newops && sh_isoption(mp->shp, SH_NOUNSET) && *id && id != idbuff &&
                 (!np || nv_isnull(np))) {
                 errormsg(SH_DICT, ERROR_exit(1), e_notset, id);
+                __builtin_unreachable();
             }
             if (c == ',' || c == '^' || c == '/' || c == ':' ||
                 ((!v || (nulflg && *v == 0)) ^ (c == '+' || c == '#' || c == '%'))) {
@@ -1796,10 +1803,13 @@ retry2:
             if (*argp) {
                 sfputc(stkp, 0);
                 errormsg(SH_DICT, ERROR_exit(1), "%s: %s", id, argp);
+                __builtin_unreachable();
             } else if (v) {
                 errormsg(SH_DICT, ERROR_exit(1), e_nullset, id);
+                __builtin_unreachable();
             } else {
                 errormsg(SH_DICT, ERROR_exit(1), e_notset, id);
+                __builtin_unreachable();
             }
         } else if (c == '=') {
             if (np) {
@@ -1826,6 +1836,7 @@ retry2:
             nv_close(np);
         }
         errormsg(SH_DICT, ERROR_exit(1), e_notset, id);
+        __builtin_unreachable();
     }
     if (np) nv_close(np);
     if (pattern) free(pattern);
@@ -2537,9 +2548,10 @@ static_fn char *special(Shell_t *shp, int c) {
 //
 // Handle macro expansion errors.
 //
-static_fn void mac_error(Namval_t *np) {
+static_fn __attribute__((noreturn)) void mac_error(Namval_t *np) {
     if (np) nv_close(np);
     errormsg(SH_DICT, ERROR_exit(1), e_subst, fcfirst());
+    __builtin_unreachable();
 }
 
 //

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -195,6 +195,7 @@ Namval_t *nv_addnode(Namval_t *np, int remove) {
             nv_delete(sp->nodes[0], root, NV_NOFREE);
             dtinsert(root, sp->rp);
             errormsg(SH_DICT, ERROR_exit(1), e_redef, sp->nodes[0]->nvname);
+            __builtin_unreachable();
         }
     }
     for (i = 0; i < sp->numnodes; i++) {
@@ -337,6 +338,7 @@ Namval_t **sh_setlist(Shell_t *shp, struct argnod *arg, int flags, Namval_t *typ
                 }
                 if (nv_isattr(np, NV_RDONLY) && np->nvfun && !(flags & NV_RDONLY)) {
                     errormsg(SH_DICT, ERROR_exit(1), e_readonly, nv_name(np));
+                    __builtin_unreachable();
                 }
                 if (nv_isattr(np, NV_NOFREE) && nv_isnull(np)) nv_offattr(np, NV_NOFREE);
                 if (nv_istable(np)) _nv_unset(np, 0);
@@ -375,6 +377,7 @@ Namval_t **sh_setlist(Shell_t *shp, struct argnod *arg, int flags, Namval_t *typ
                         np == ((struct sh_type *)shp->mktype)->nodes[0]) {
                         shp->mktype = 0;
                         errormsg(SH_DICT, ERROR_exit(1), "%s: not a known type name", argv[0]);
+                        __builtin_unreachable();
                     }
                     if (!(arg->argflag & ARG_APPEND)) {
                         if (!nv_isarray(np) || ((ap = nv_arrayptr(np)) && (ap->nelem))) {
@@ -465,6 +468,7 @@ Namval_t **sh_setlist(Shell_t *shp, struct argnod *arg, int flags, Namval_t *typ
                         if (nv_isarray(np)) {
                             if ((sub = nv_aimax(np)) < 0 && nv_arrayptr(np)) {
                                 errormsg(SH_DICT, ERROR_exit(1), e_badappend, nv_name(np));
+                                __builtin_unreachable();
                             }
                             if (sub == 0 && nv_type(np) && (ap = nv_arrayptr(np)) &&
                                 array_elem(ap) == 0) {
@@ -838,6 +842,7 @@ Namval_t *nv_create(const char *name, Dt_t *root, int flags, Namfun_t *dp) {
                     shp->first_root = root;
                     if (nv_isref(np) && (c == '[' || c == '.' || !(flags & NV_ASSIGN))) {
                         errormsg(SH_DICT, ERROR_exit(1), e_noref, nv_name(np));
+                        __builtin_unreachable();
                     }
                     if (sub && c == 0) {
                         if (flags & NV_ARRAY) {
@@ -1363,6 +1368,7 @@ skip:
             msg = e_noarray;
         }
         errormsg(SH_DICT, ERROR_exit(1), msg, name);
+        __builtin_unreachable();
     }
     if (fun.nofree & 1) stkseek(shp->stk, offset);
     return np;
@@ -1397,6 +1403,7 @@ void nv_putval(Namval_t *np, const void *vp, int flags) {
     }
     if (!(flags & NV_RDONLY) && nv_isattr(np, NV_RDONLY) && np->nvalue.cp != Empty) {
         errormsg(SH_DICT, ERROR_exit(1), e_readonly, nv_name(np));
+        __builtin_unreachable();
     }
     // The following could cause the shell to fork if assignment would cause a side effect.
     shp->argaddr = 0;
@@ -2108,6 +2115,7 @@ void _nv_unset(Namval_t *np, int flags) {
 
     if (!(flags & NV_RDONLY) && nv_isattr(np, NV_RDONLY)) {
         errormsg(SH_DICT, ERROR_exit(1), e_readonly, nv_name(np));
+        __builtin_unreachable();
     }
     if (is_afunction(np) && np->nvalue.ip) {
         struct slnod *slp = (struct slnod *)(np->nvenv);
@@ -2430,7 +2438,10 @@ Sfdouble_t nv_getnum(Namval_t *np) {
     char *str;
 
     if (!nv_local && shp->argaddr) nv_optimize(np);
-    if (nv_istable(np)) errormsg(SH_DICT, ERROR_exit(1), e_number, nv_name(np));
+    if (nv_istable(np)) {
+        errormsg(SH_DICT, ERROR_exit(1), e_number, nv_name(np));
+        __builtin_unreachable();
+    }
     if (np->nvfun && np->nvfun->disc) {
         if (!nv_local) {
             nv_local = 1;
@@ -2447,6 +2458,7 @@ Sfdouble_t nv_getnum(Namval_t *np) {
         if (sh_isoption(shp, SH_NOUNSET) && nv_isattr(np, NV_NOTSET) == NV_NOTSET) {
             int i = nv_aindex(np);
             errormsg(SH_DICT, ERROR_exit(1), e_notset2, nv_name(np), i);
+            __builtin_unreachable();
         }
         up = &np->nvalue;
         if (!up->lp || up->cp == Empty) {
@@ -2515,6 +2527,7 @@ void nv_newattr(Namval_t *np, unsigned newatts, int size) {
         ((sp = nv_name(np)) == nv_name(PATHNOD) || sp == nv_name(SHELLNOD) ||
          sp == nv_name(ENVNOD) || sp == nv_name(FPATHNOD))) {
         errormsg(SH_DICT, ERROR_exit(1), e_restricted, nv_name(np));
+        __builtin_unreachable();
     }
     // Handle attributes that do not change data separately.
     n = np->nvflag;
@@ -2736,7 +2749,7 @@ bool nv_rename(Namval_t *np, int flags) {
     if (flags & NV_MOVE) {
         if (!(cp = (char *)(mp ? mp : np)->nvalue.cp)) {
             errormsg(SH_DICT, ERROR_exit(1), e_varname, "");
-            return false;
+            __builtin_unreachable();
         }
         (mp ? mp : np)->nvalue.cp = 0;
     } else if (!(cp = nv_getval(np))) {
@@ -2744,6 +2757,7 @@ bool nv_rename(Namval_t *np, int flags) {
     }
     if (lastdot(cp, 0, (void *)shp) && nv_isattr(np, NV_MINIMAL)) {
         errormsg(SH_DICT, ERROR_exit(1), e_varname, nv_name(np));
+        __builtin_unreachable();
     }
     arraynr = cp[strlen(cp) - 1] == ']';
     if (nv_isarray(np) && !mp) index = nv_aindex(np);
@@ -2762,6 +2776,7 @@ bool nv_rename(Namval_t *np, int flags) {
     shp->prefix = prefix;
     if (sh_isoption(shp, SH_NOUNSET) && (!nr || nv_isnull(nr))) {
         errormsg(SH_DICT, ERROR_exit(1), e_notset, cp);
+        __builtin_unreachable();
     }
     if (!nr) {
         if (!nv_isvtree(np)) _nv_unset(np, 0);
@@ -2873,7 +2888,10 @@ void nv_setref(Namval_t *np, Dt_t *hp, int flags) {
     Namval_t *last_table = shp->last_table;
 
     if (nv_isref(np)) return;
-    if (nv_isarray(np)) errormsg(SH_DICT, ERROR_exit(1), e_badref, nv_name(np));
+    if (nv_isarray(np)) {
+        errormsg(SH_DICT, ERROR_exit(1), e_badref, nv_name(np));
+        __builtin_unreachable();
+    }
     if (!(cp = nv_getval(np))) {
         _nv_unset(np, 0);
         nv_onattr(np, NV_REF);
@@ -2881,6 +2899,7 @@ void nv_setref(Namval_t *np, Dt_t *hp, int flags) {
     }
     if ((ep = lastdot(cp, 0, (void *)shp)) && nv_isattr(np, NV_MINIMAL)) {
         errormsg(SH_DICT, ERROR_exit(1), e_badref, nv_name(np));
+        __builtin_unreachable();
     }
     if (hp) hpnext = dtvnext(hp);
     shp->namref_root = hp;
@@ -2912,10 +2931,12 @@ void nv_setref(Namval_t *np, Dt_t *hp, int flags) {
     if (nr == np) {
         if (shp->namespace && nv_dict(shp->namespace) == hp) {
             errormsg(SH_DICT, ERROR_exit(1), e_selfref, nv_name(np));
+            __builtin_unreachable();
         }
         // Bind to earlier scope, or add to global scope.
         if (!(hp = dtvnext(hp)) || (nq = nv_search((char *)np, hp, NV_ADD | HASH_BUCKET)) == np) {
             errormsg(SH_DICT, ERROR_exit(1), e_selfref, nv_name(np));
+            __builtin_unreachable();
         }
         if (nv_isarray(nq)) nv_putsub(nq, (char *)0, 0, ARRAY_UNDEF);
     }
@@ -2937,6 +2958,7 @@ void nv_setref(Namval_t *np, Dt_t *hp, int flags) {
         _nv_unset(np, NV_RDONLY);
         nv_onattr(np, NV_REF);
         errormsg(SH_DICT, ERROR_exit(1), e_globalref, nv_name(np));
+        __builtin_unreachable();
     }
     shp->instance = 1;
     if (nq && !ep && (ap = nv_arrayptr(nq)) && !(ap->flags & (ARRAY_UNDEF | ARRAY_SCAN))) {

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -415,6 +415,7 @@ static_fn Namfun_t *clone_type(Namval_t *np, Namval_t *mp, int flags, Namfun_t *
                 if (nv_isattr(nq, NV_RDONLY) && nv_type(np) != np &&
                     (nq->nvalue.cp || nv_isattr(nq, NV_INTEGER))) {
                     errormsg(SH_DICT, ERROR_exit(1), e_readonly, nq->nvname);
+                    __builtin_unreachable();
                 }
                 if (nv_isref(nq)) nq = nv_refnode(nq);
                 if ((size = nv_datasize(nr, (size_t *)0)) && size == nv_datasize(nq, (size_t *)0)) {
@@ -524,7 +525,10 @@ found:
                 if ((strncmp(name, dp->names[i], n) == 0) && dp->names[i][n] == 0) return (nq);
             }
         }
-        if (!(flag & NV_NOFAIL)) errormsg(SH_DICT, ERROR_exit(1), e_notelem, n, name, nv_name(np));
+        if (!(flag & NV_NOFAIL)) {
+            errormsg(SH_DICT, ERROR_exit(1), e_notelem, n, name, nv_name(np));
+            __builtin_unreachable();
+        }
     }
     return nq;
 }
@@ -834,6 +838,7 @@ Namval_t *nv_mktype(Namval_t **nodes, int numnodes) {
         cp = nodes[0]->nvname;
         _nv_unset(nodes[0], NV_RDONLY);
         errormsg(SH_DICT, ERROR_exit(1), e_badtypedef, cp);
+        __builtin_unreachable();
     }
     for (nnodes = 1, i = 1; i < numnodes; i++) {
         np = nodes[i];
@@ -1248,6 +1253,7 @@ int nv_settype(Namval_t *np, Namval_t *tp, int flags) {
     if (nv_isarray(np) && (tq = nv_type(np))) {
         if (tp == tq) return 0;
         errormsg(SH_DICT, ERROR_exit(1), e_redef, nv_name(np));
+        __builtin_unreachable();
     }
     if ((ap = nv_arrayptr(np)) && ap->nelem > 0) {
         nv_putsub(np, NULL, 0, ARRAY_SCAN);
@@ -1352,7 +1358,10 @@ Namval_t *nv_mkstruct(const char *name, int rsize, stat_fields_t *fields, void *
             tp =
                 nv_open(stkptr(shp->stk, offset), shp->var_tree, NV_VARNAME | NV_NOADD | NV_NOFAIL);
             stkseek(shp->stk, r);
-            if (!tp) errormsg(SH_DICT, ERROR_exit(1), e_unknowntype, strlen(fp->type), fp->type);
+            if (!tp) {
+                errormsg(SH_DICT, ERROR_exit(1), e_unknowntype, strlen(fp->type), fp->type);
+                __builtin_unreachable();
+            }
             dp = (Namtype_t *)nv_hasdisc(tp, &type_disc);
             if (dp) {
                 nnodes += dp->numnodes;
@@ -1596,6 +1605,7 @@ void nv_checkrequired(Namval_t *mp) {
         np = nv_namptr(dp->nodes, i);
         if (nv_isattr(np, NV_RDONLY) && np->nvalue.cp == Empty) {
             errormsg(SH_DICT, ERROR_exit(1), e_required, np->nvname, nv_type(mp)->nvname);
+            __builtin_unreachable();
         }
         if (nv_isattr(nq, NV_RDONLY)) nv_onattr(np, NV_RDONLY);
     }

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -351,7 +351,10 @@ void *sh_parse(Shell_t *shp, Sfio_t *iop, int flag) {
             fcclose();
             fcrestore(&sav_input);
             lexp->arg = sav_arg;
-            if (version > 3) errormsg(SH_DICT, ERROR_exit(1), e_lexversion);
+            if (version > 3) {
+                errormsg(SH_DICT, ERROR_exit(1), e_lexversion);
+                __builtin_unreachable();
+            }
             if (sffileno(iop) == shp->infd || (flag & SH_FUNEVAL)) shp->binscript = 1;
             sfgetc(iop);
             t = sh_trestore(shp, iop);
@@ -771,6 +774,7 @@ static_fn Shnode_t *funct(Lex_t *lexp) {
             t->funct.functargs = ac = (struct comnod *)simple(lexp, SH_NOIO | SH_FUNDEF, NULL);
             if (ac->comset || (ac->comtyp & COMSCAN)) {
                 errormsg(SH_DICT, ERROR_exit(3), e_lexsyntax4, lexp->sh->inlineno);
+                __builtin_unreachable();
             }
             argv0 = argv = ((struct dolnod *)ac->comarg)->dolval + ARG_SPARE;
             while ((cp = *argv++)) {
@@ -779,7 +783,10 @@ static_fn Shnode_t *funct(Lex_t *lexp) {
                     while (c = mbchar(cp), isaname(c))
                         ;
             }
-            if (c) errormsg(SH_DICT, ERROR_exit(3), e_lexsyntax4, lexp->sh->inlineno);
+            if (c) {
+                errormsg(SH_DICT, ERROR_exit(3), e_lexsyntax4, lexp->sh->inlineno);
+                __builtin_unreachable();
+            }
             nargs = argv - argv0;
             size += sizeof(struct dolnod) + (nargs + ARG_SPARE) * sizeof(char *);
             if (shp->shcomp && strncmp(".sh.math.", t->funct.functnam, 9) == 0) {
@@ -1209,6 +1216,7 @@ static_fn Shnode_t *item(Lex_t *lexp, int flag) {
                 if (strcmp(argp->argval, lexp->arg->argval) == 0) {
                     errormsg(SH_DICT, ERROR_exit(3), e_lexsyntax3, lexp->sh->inlineno,
                              argp->argval);
+                    __builtin_unreachable();
                 }
                 argp = argp->argnxt.ap;
             }

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -430,7 +430,10 @@ static_fn int path_opentype(Shell_t *shp, const char *name, Pathcomp_t *pp, int 
 
     if (!pp && !shp->pathlist) path_init(shp);
     if (!fun && strchr(name, '/')) {
-        if (sh_isoption(shp, SH_RESTRICTED)) errormsg(SH_DICT, ERROR_exit(1), e_restricted, name);
+        if (sh_isoption(shp, SH_RESTRICTED)) {
+            errormsg(SH_DICT, ERROR_exit(1), e_restricted, name);
+            __builtin_unreachable();
+        }
     }
     do {
         pp = path_nextcomp(shp, oldpp = pp, name, 0);
@@ -900,7 +903,10 @@ void path_exec(Shell_t *shp, const char *arg0, char *argv[], struct argnod *loca
     if (strchr(arg0, '/')) {
         slash = 1;
         // Name containing / not allowed for restricted shell.
-        if (sh_isoption(shp, SH_RESTRICTED)) errormsg(SH_DICT, ERROR_exit(1), e_restricted, arg0);
+        if (sh_isoption(shp, SH_RESTRICTED)) {
+            errormsg(SH_DICT, ERROR_exit(1), e_restricted, arg0);
+            __builtin_unreachable();
+        }
     } else {
         pp = path_get(shp, arg0);
     }

--- a/src/cmd/ksh93/sh/shcomp.c
+++ b/src/cmd/ksh93/sh/shcomp.c
@@ -149,7 +149,10 @@ int main(int argc, char *argv[]) {
                 strcmp(nv_name((Namval_t *)t->com.comnamp), "alias") == 0) {
                 sh_exec(shp, t, 0);
             }
-            if (!dflag && sh_tdump(out, t) < 0) errormsg(SH_DICT, ERROR_exit(1), "dump failed");
+            if (!dflag && sh_tdump(out, t) < 0) {
+                errormsg(SH_DICT, ERROR_exit(1), "dump failed");
+                __builtin_unreachable();
+            }
         } else if (sfeof(in)) {
             break;
         }

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -278,7 +278,6 @@ static_fn int p_time(Shell_t *shp, Sfio_t *out, const char *format, clock_t *tm)
         } else if (c != 'R') {
             stkseek(stkp, offset);
             errormsg(SH_DICT, ERROR_exit(0), e_badtformat, c);
-            return (0);
         }
         d = (double)tm[n] / shp->gd->lim.clk_tck;
     skip:
@@ -700,7 +699,10 @@ static_fn void *sh_coinit(Shell_t *shp, char **argv) {
         }
         csp = csp->next;
     }
-    if (!xopen) errormsg(SH_DICT, ERROR_exit(1), "%s: unknown namespace", name);
+    if (!xopen) {
+        errormsg(SH_DICT, ERROR_exit(1), "%s: unknown namespace", name);
+        __builtin_unreachable();
+    }
     environ[0][2] = 0;
     csp = newof(0, struct cosh, 1, strlen(name) + 1);
     if (!(csp->coshell = coopen(NULL, CO_SHELL | CO_SILENT, argv[1]))) {
@@ -1031,6 +1033,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                             if (!nv_getval(SH_FUNNAMENOD)) {
                                 errormsg(SH_DICT, ERROR_exit(1),
                                          "%s: can only be used in a function", com0);
+                                __builtin_unreachable();
                             }
                             if (!shp->st.var_local) {
                                 sh_scope(shp, (struct argnod *)0, 0);
@@ -2435,6 +2438,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                     fname = stkptr(stkp, offset);
                 } else if ((mp = nv_search(fname, shp->bltin_tree, 0)) && nv_isattr(mp, BLT_SPC)) {
                     errormsg(SH_DICT, ERROR_exit(1), e_badfun, fname);
+                    __builtin_unreachable();
                 }
                 if (shp->namespace && !shp->prefix && *fname != '.') {
                     np = sh_fsearch(shp, fname, NV_ADD | HASH_NOSCOPE);
@@ -2445,7 +2449,10 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                 }
                 if (npv) {
                     if (!shp->mktype) cp = nv_setdisc(npv, cp, np, (Namfun_t *)npv);
-                    if (!cp) errormsg(SH_DICT, ERROR_exit(1), e_baddisc, fname);
+                    if (!cp) {
+                        errormsg(SH_DICT, ERROR_exit(1), e_baddisc, fname);
+                        __builtin_unreachable();
+                    }
                 }
                 if (np->nvalue.rp) {
                     struct Ufunction *rp = np->nvalue.rp;
@@ -3045,7 +3052,10 @@ int cmdrecurse(int argc, char *argv[], int ac, char *av[]) {
 //
 static_fn void coproc_init(Shell_t *shp, int pipes[]) {
     int outfd;
-    if (shp->coutpipe >= 0 && shp->cpid) errormsg(SH_DICT, ERROR_exit(1), e_pexists);
+    if (shp->coutpipe >= 0 && shp->cpid) {
+        errormsg(SH_DICT, ERROR_exit(1), e_pexists);
+        __builtin_unreachable();
+    }
     shp->cpid = 0;
     if (shp->cpipe[0] <= 0 || shp->cpipe[1] <= 0) {
         // First co-process.
@@ -3146,6 +3156,7 @@ static_fn pid_t sh_ntfork(Shell_t *shp, const Shnode_t *t, char *argv[], int *jo
             }
         } else if (sh_isoption(shp, SH_RESTRICTED)) {
             errormsg(SH_DICT, ERROR_exit(1), e_restricted, path);
+            __builtin_unreachable();
         }
         if (!path) {
             spawnpid = -1;
@@ -3363,6 +3374,7 @@ int sh_funscope_20120720(Shell_t *shp, int argn, char *argv[], int (*fun)(void *
     if (shp->topscope != (Shscope_t *)shp->st.self) sh_setscope(shp, shp->topscope);
     if (--shp->fn_depth == 1 && jmpval == SH_JMPERRFN) {
         errormsg(SH_DICT, ERROR_exit(1), e_toodeep, argv[0]);
+        __builtin_unreachable();
     }
     sh_popcontext(shp, buffp);
     sh_unscope(shp);


### PR DESCRIPTION
Some lint warnings are due to statements like

errormsg(SH_DICT, ERROR_exit(1), e_nospace);

Those never return because they perform a longjmp() to return control
to the execution engine. But only if the value passed to ERROR_exit()
is not zero. Adding __builtin_unreachable() after those statements tells
the compiler and lint tools subsequent statements aren't reachable.
Thus improving their ability to determine, for example, whether or not
a null pointer might be dereferenced.

Long term I'd prefer to modify the error logging API to separate the
calls that can return from those that cannot.