### PR TITLE
Add test cases for parameter expansion modifiers

### DIFF
--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -95,7 +95,7 @@ all_tests = [
     ['basic', 90], ['bracket'], ['builtins'], ['case'], ['comvar'],
     ['comvario'], ['coprocess', 50], ['cubetype'], ['directoryfd'], ['enum'],
     ['exit'], ['expand'], ['functions'], ['glob'], ['grep'], ['heredoc'],
-    ['io'], ['locale'], ['math', 50], ['nameref'], ['namespace'],
+    ['io'], ['locale'], ['math', 50], ['nameref'], ['namespace'], ['modifiers'],
     ['options'], ['path'], ['pointtype'], ['pty'], ['quoting'], ['quoting2'],
     ['readcsv'], ['recttype'], ['restricted'], ['return'], ['select'],
     ['sh_match'], ['sigchld', 100], ['signal'], ['statics'], ['subshell', 100],

--- a/src/cmd/ksh93/tests/attributes.sh
+++ b/src/cmd/ksh93/tests/attributes.sh
@@ -269,13 +269,6 @@ else
     log_error 'typeset -usi cannot be used for unsigned short'
 fi
 
-# Check ${parameter:-word} style of parameter expansion. ':' is optional and is used to check for null (empty string).
-[[ $($SHELL -c 'unset foo;typeset -Z2 foo; print ${foo-3}') == 3 ]]  || log_error  '${foo-3} not 3 when typeset -Z2 field undefined'
-[[ $($SHELL -c 'unset foo;typeset -Z2 foo; print ${foo=3}') == 03 ]]  || log_error  '${foo=3} not 3 when typeset -Z2 foo undefined'
-
-[[ $($SHELL -c 'foo=""; print ${foo-3}') == "" ]]  || log_error  '${foo-3} not "" when foo is null'
-[[ $($SHELL -c 'foo=""; print ${foo=3}') == "" ]]  || log_error  '${foo=3} not "" when foo is null'
-
 [[ $($SHELL -c 'unset foo;typeset -Z2 foo; print ${foo:-3}') == 3 ]]  || log_error  '${foo:-3} not 3 when typeset -Z2 field undefined'
 [[ $($SHELL -c 'unset foo;typeset -Z2 foo; print ${foo:=3}') == 03 ]]  || log_error  '${foo:=3} not 3 when typeset -Z2 foo undefined'
 

--- a/src/cmd/ksh93/tests/modifiers.sh
+++ b/src/cmd/ksh93/tests/modifiers.sh
@@ -1,0 +1,46 @@
+# These are the tests for various style of parameter expansion modifiers supported by ksh93
+
+# Check ${parameter:-word} style of parameter expansion. ':' is optional and is used to check for null (empty string).
+unset foo
+[[ ${foo:-bar} == bar ]]  || log_error  '${foo:-bar} not bar when foo is not set'
+
+unset foo
+[[ ${foo-bar} == bar ]]  || log_error  '${foo-bar} not bar when foo is not set'
+
+foo=""
+[[ ${foo-bar} == "" ]]  || log_error  '${foo-bar} not "" when foo is null'
+
+# Check ${parameter:=word} style of parameter expansion. ':' is optional and is used to check for null (empty string).
+unset foo
+[[ ${foo:=bar} == bar ]]  || log_error '${foo:=bar} not bar when foo is not set'
+
+unset foo
+[[ ${foo=bar} == bar ]]  || log_error '${foo=bar} not bar when foo is not set'
+
+foo=""
+[[ ${foo=bar} == "" ]]  || log_error  '${foo=bar} not "" when foo is null'
+
+# Check ${parameter:?word} style of parameter expansion. ':' is optional and is used to check for null (empty string).
+expect="bar not set"
+actual=$( $SHELL -c 'unset foo; print ${foo:?bar not set}' 2>&1 )
+[[ $actual  =~ $expect ]]  || log_error '${foo:?bar} does not display error if foo not set'
+
+actual=$( $SHELL -c 'unset foo; print ${foo?bar not set}' 2>&1 )
+[[ $actual =~ $expect ]]  || log_error '${foo?bar} does not display error if foo is not set'
+
+[[ $( $SHELL -c 'foo=""; print ${foo?bar}' 2>&1 ) == "" ]]  || log_error  '${foo=bar} not "" when foo is null'
+
+# When nothing is specified after :?, a default error message is printed
+unset foo
+[[ $( (print ${foo:?}) 2>&1) =~ "parameter not set" ]] || log_error 'Incorrect error message with ${foo:?}'
+
+# Check ${parameter:+word} style of parameter expansion. ':' is optional and is used to check for null (empty string).
+unset foo
+[[ ${foo:+bar} == "" ]]  || log_error '${foo:+bar} not null when foo is not set'
+
+unset foo
+[[ ${foo+bar} == "" ]]  || log_error '${foo+bar} not null when foo is not set'
+
+foo="non-null value"
+[[ ${foo:+bar} == "bar" ]]  || log_error  '${foo:+bar} not bar when foo is not null'
+[[ ${foo+bar} == "bar" ]]  || log_error  '${foo+bar} not bar when foo is not null'

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -476,22 +476,6 @@ do
 done
 unset IFS
 
-if [[ $( (print ${12345:?}) 2>&1) != *12345* ]]
-then
-    log_error 'incorrect error message with ${12345?}'
-fi
-
-unset foobar
-if [[ $( (print ${foobar:?}) 2>&1) != *foobar* ]]
-then
-    log_error 'incorrect error message with ${foobar?}'
-fi
-
-unset bar
-if [[ $( (print ${bar:?bam}) 2>&1) != *bar*bam* ]]
-then
-    log_error 'incorrect error message with ${foobar?}'
-fi
 
 { $SHELL -c '
 function foo


### PR DESCRIPTION
- Add tests for ${:=}, ${:-}, ${:?} and ${:+} style of parameter expansions.

- Move some tests to parameter expansion modifiers test file.