### PR TITLE
Add tests for special /dev/... path names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
           compiler: gcc
           env:
             - DISTRO_TYPE=fedora
-              INSTALL_REQUIREMENTS="dnf repolist; dnf install -y gcc python3 meson sudo langpacks-zh_CN ed ncurses vi findutils which"
+              INSTALL_REQUIREMENTS="dnf repolist; dnf install -y gcc python3 meson sudo langpacks-zh_CN ed ncurses vi findutils which nmap-ncat"
           before_install:
               - docker pull ${DISTRO_TYPE}
 
@@ -17,7 +17,7 @@ matrix:
           compiler: gcc
           env:
             - DISTRO_TYPE=opensuse
-              INSTALL_REQUIREMENTS="zypper refresh; zypper in -y gcc python3 python3-pip ninja sudo glibc-locale glibc-devel ed ncurses-utils vim findutils which; pip3 install meson==0.44.0"
+              INSTALL_REQUIREMENTS="zypper refresh; zypper in -y gcc python3 python3-pip ninja sudo glibc-locale glibc-devel ed ncurses-utils vim findutils which netcat; pip3 install meson==0.44.0"
           before_install:
               - docker pull ${DISTRO_TYPE}
 
@@ -26,7 +26,7 @@ matrix:
           compiler: gcc
           env:
             - DISTRO_TYPE=ubuntu
-              INSTALL_REQUIREMENTS="apt-get update; apt-get install -y gcc python3 sudo locales ed vim python3-pip ninja-build findutils debianutils; pip3 install meson==0.44.0; locale-gen en_US.UTF-8"
+              INSTALL_REQUIREMENTS="apt-get update; apt-get install -y gcc python3 sudo locales ed vim python3-pip ninja-build findutils debianutils netcat-openbsd; pip3 install meson==0.44.0; locale-gen en_US.UTF-8"
           before_install:
               - docker pull ${DISTRO_TYPE}
 
@@ -35,7 +35,7 @@ matrix:
           compiler: gcc
           env:
             - DISTRO_TYPE=debian
-              INSTALL_REQUIREMENTS="apt-get update; apt-get install -y gcc python3 python3-pip ninja-build sudo locales ed vim procps findutils debianutils; pip3 install meson==0.44.0; sed -i '/# en_US.UTF-8 UTF-8/s/..//' /etc/locale.gen && locale-gen"
+              INSTALL_REQUIREMENTS="apt-get update; apt-get install -y gcc python3 python3-pip ninja-build sudo locales ed vim procps findutils debianutils netcat-openbsd; pip3 install meson==0.44.0; sed -i '/# en_US.UTF-8 UTF-8/s/..//' /etc/locale.gen && locale-gen"
           before_install:
               - docker pull ${DISTRO_TYPE}
 

--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -100,8 +100,13 @@ all_tests = [
     ['readcsv'], ['recttype'], ['restricted'], ['return'], ['select'],
     ['sh_match'], ['sigchld', 100], ['signal'], ['statics'], ['subshell', 100],
     ['substring'], ['tilde'], ['timetype'], ['treemove'], ['types'],
-    ['variables'], ['vartree1'], ['vartree2'], ['wchar']
+    ['variables'], ['vartree1'], ['vartree2'], ['wchar'], ['special-dev-paths']
 ]
+
+# This is a list of the tests that must be run in isolation; i.e., not in parallel with other tests.
+# For example, the `special-dev-paths` test opens network connections on fixed TCP/IP port numbers
+# and thus cannot be run in parellel.
+serial_tests = ['special-dev-paths']
 
 # This is a list of tests to be skipped because they are known to be broken when
 # compiled by `shcomp`.
@@ -112,9 +117,10 @@ shcomp_tests_to_skip = ['io', 'namespace', 'treemove']
 foreach testspec : all_tests
     testname = testspec[0]
     timeout = (testspec.length() == 2) ? testspec[1] : default_timeout
+    parallel = serial_tests.contains(testname) ? false : true
     foreach locale : locales
         lang_var = 'LANG=' + locale
-        test(testname + '/' + locale, ksh93_exe, timeout: timeout,
+        test(testname + '/' + locale, ksh93_exe, timeout: timeout, is_parallel: parallel,
              args: [test_driver, testname],
              env: [shell_var, lang_var, ld_library_path, libsample_path])
     endforeach

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -475,7 +475,7 @@ int sh_close(int fd) {
 }
 
 //
-// Return <protocol>/<host>/<service> fd.
+// Return /dev/<protocol>/<host>/<service> fd.
 // If called with flags==O_NONBLOCK return 1 if protocol is supported.
 //
 typedef int (*Inetintr_f)(struct addrinfo *, void *);

--- a/src/cmd/ksh93/tests/bracket.sh
+++ b/src/cmd/ksh93/tests/bracket.sh
@@ -418,11 +418,6 @@ unset x y z foo bar
 { x=$($SHELL -c '[[ (( $# -eq 0 )) ]] && print ok') 2> /dev/null;}
 [[ $x == ok ]] || log_error '((...)) inside [[...]] not treated as nested ()'
 
-[[ -e /dev/fd/ ]] || log_error '/dev/fd/ does not exits'
-[[ -e /dev/tcp/ ]] || log_error '/dev/tcp/ does not exist'
-[[ -e /dev/udp/ ]] || log_error '/dev/udp/ does not exist'
-[[ -e /dev/xxx/ ]] &&  log_error '/dev/xxx/ exists'
-
 $SHELL 2> /dev/null -c '[[(-n foo)]]' || log_error '[[(-n foo)]] should not require space in front of ('
 
 $SHELL 2> /dev/null -c '[[ "]" == ~(E)[]] ]]' || log_error 'pattern "~(E)[]]" does not match "]"'

--- a/src/cmd/ksh93/tests/special-dev-paths.sh
+++ b/src/cmd/ksh93/tests/special-dev-paths.sh
@@ -1,0 +1,171 @@
+#
+# Verify that the special /dev paths such as /dev/stdin, /dev/fd/0, and /dev/tcp/host/port work when
+# used in a test and actually opened. This is primarily meant to exercise the `sh_open()` functions
+# handling of special paths.
+#
+readonly host=localhost
+readonly port=65123
+
+fd_check=no
+
+# Some tests will want to verify whether or not a fd was allocated. We could use the `lsof` command
+# but don't want to add that as a dependency. Instead just do the verification on platforms which
+# support /proc/self/fd.
+[[ -d /proc/self/fd ]] && fd_check=yes
+[[ $fd_check == yes ]] && fd_count=$( ls -1 /proc/$$/fd | wc -l )
+
+# Check if the `nc` (netcat) command is available.
+whence -q nc && readonly nc_available=yes || readonly nc_available=no
+
+# Check if the system supports the /dev/{stdin,stdout,stderr} paths.
+[[ -e /dev/stdin ]] && readonly dev_stdin=yes || readonly dev_stdin=no
+
+# ==========
+# Verify that testing variations of the special dev paths work as expected.
+# Note that these should not result in a fd being opened.
+[[ -e /dev/stdin ]] || log_error '-e /dev/stdin failed'
+[[ -e /dev/stdout ]] || log_error '-e /dev/stdout failed'
+[[ -e /dev/stderr ]] || log_error '-e /dev/stderr failed'
+[[ -e /dev/stdinX ]] && log_error '-e /dev/stdinX succeeded but should have failed'
+[[ -e /dev/stdoutX ]] && log_error '-e /dev/stdoutX succeeded but should have failed'
+[[ -e /dev/stderrX ]] && log_error '-e /dev/stderrX succeeded but should have failed'
+
+[[ -e /dev/fd/0 ]] || log_error '-e /dev/fd/0 failed'
+# TODO: This test currently fails. It thinks the bogus path is valid.
+# [[ -e /dev/fd/xxx ]] && log_error '-e /dev/fd/xxx succeeded but should have failed'
+
+[[ -e /dev/tcp/localhost/666 ]] || log_error '-e /dev/tcp/localhost/666 failed'
+[[ -e /dev/TCP/localhost/666 ]] && \
+    log_error '-e /dev/TCP/localhost/666 succeeded but should have failed'
+
+# TODO: This test currently fails. It thinks the bogus path is valid.
+# [[ -e /dev/tcp/a_host/666/xxx ]] && \
+#    log_error '-e /dev/TCP/a_host/666/xxx succeeded but should have failed'
+
+# TODO: This test currently fails. It thinks the bogus path is valid.
+# [[ -e /dev/tcp/a_host ]] && \
+#    log_error '-e /dev/TCP/a_host succeeded but should have failed'
+
+# TODO: This test currently fails. It thinks the bogus path is valid.
+# [[ -e /dev/tcp/ ]] && log_error '-e /dev/tcp/ succeeded but should have failed'
+
+[[ -e /dev/udp/localhost/666 ]] || log_error '-e /dev/udp/localhost/666 failed'
+[[ -e /dev/UDP/localhost/666 ]] && \
+    log_error '-e /dev/UDP/localhost/666 succeeded but should have failed'
+
+# TODO: This test currently fails. It thinks the bogus path is valid.
+# [[ -e /dev/udp/a_host/666/xxx ]] && \
+#     log_error '-e /dev/udp/a_host/666/xxx succeeded but should have failed'
+
+# TODO: This test currently fails. It thinks the bogus path is valid.
+# [[ -e /dev/udp/a_host ]] && \
+#     log_error '-e /dev/udp/a_host succeeded but should have failed'
+
+# The tests we just ran should not have opened any fds.
+if [[ $fd_check == yes ]]
+then
+    new_fd_count=$( ls -1 /proc/$$/fd | wc -l )
+    [[ $new_fd_count -eq $fd_count ]] || \
+        log_error 'fds unexpectedly opened' "$fd_count" "$new_fd_count"
+fi
+
+# ==========
+# Verify that opening the special /dev/stdXXX paths works. This does not require the system to
+# natively support these paths. The emulation should also result in a new fd being assigned.
+exec {actual_fd}</dev/stdin
+expect_fd=10
+[[ $actual_fd -ge $expect_fd ]] || \
+    log_error 'Opening /dev/stdin failed' "$expect_fd" "$actual_fd"
+
+exec {actual_fd}>/dev/stdout
+expect_fd=10
+[[ $actual_fd -ge $expect_fd ]] || \
+    log_error 'Opening /dev/stdout failed' "$expect_fd" "$actual_fd"
+
+exec {actual_fd}>/dev/stderr
+expect_fd=10
+[[ $actual_fd -ge $expect_fd ]] || \
+    log_error 'Opening /dev/stderr failed' "$expect_fd" "$actual_fd"
+
+# The tests we just ran should have opened three fds.
+if [[ $fd_check == yes ]]
+then
+    new_fd_count=$( ls -1 /proc/$$/fd | wc -l )
+    (( fd_count += 3 ))
+    [[ new_fd_count -eq fd_count ]] || log_error 'fd count wrong' "$fd_count" "$new_fd_count"
+fi
+
+# ==========
+# Verify that opening the special /dev/tcp/host/service path works.
+# This requires the netcat program.
+if [[ $nc_available == no ]]
+then
+    log_info 'Skipping the /dev/tcp/... I/O tests because nc is not available'
+else
+    nc -l $host $port >nc.out &
+    sleep 0.1  # give nc a chance to bind to the port an listen for connections
+    exec {fd}>/dev/tcp/$host/$port || log_error "Could not open /dev/tcp/$host/$port"
+    if [[ $fd_check == yes ]]
+    then
+        new_fd_count=$( ls -1 /proc/$$/fd | wc -l )
+        (( new_fd_count == fd_count + 1 )) || \
+            log_error 'One fd should have been opened' "$fd_count + 1" "$new_fd_count"
+    fi
+
+    expect='hello tcp'
+    echo $expect >&$fd || log_error "Could not write to /dev/tcp/$host/$port"
+    exec {fd}>&-  # close the connection so that `nc` will exit
+    wait
+    actual=$(< nc.out)
+    [[ $actual == $expect ]] || \
+        log_error "Did not capture the expected text written to /dev/tcp/$host/$port" \
+            "$expect" "$actual"
+
+    # The tests we just ran should not have have left any open fds.
+    if [[ $fd_check == yes ]]
+    then
+        new_fd_count=$( ls -1 /proc/$$/fd | wc -l )
+        [[ $new_fd_count -eq $fd_count ]] || \
+            log_error 'fds unexpectedly opened' "$fd_count" "$new_fd_count"
+    fi
+fi
+
+# ==========
+# Verify that opening the special /dev/udp/host/service path works.
+# This requires the netcat program.
+if [[ $nc_available == no ]]
+then
+    log_info 'Skipping the /dev/udp/... I/O tests because nc is not available'
+else
+    nc -u -l $host $port >nc.out &
+    sleep 0.1  # give nc a chance to bind to the port an listen for connections
+    exec {fd}>/dev/udp/$host/$port || log_error "Could not open /dev/udp/$host/$port"
+    if [[ $fd_check == yes ]]
+    then
+        new_fd_count=$( ls -1 /proc/$$/fd | wc -l )
+        (( new_fd_count == fd_count + 1 )) || \
+            log_error 'One fd should have been opened' "$fd_count + 1" "$new_fd_count"
+    fi
+
+    expect='hello udp'
+    echo $expect >&$fd || log_error "Could not write to /dev/udp/$host/$port"
+    # Note that while we want to close `fd` so that we don't have a fd leak it doesn't actually
+    # cause the `nc` process to exit. That's because UDP is not connection oriented like TCP.
+    # Instead we have to kill the process after giving it a chance to write the message we sent.
+    exec {fd}>&-  # close the connection
+    sleep 0.1
+    kill %1  # kill the background `nc`
+    wait
+    actual=$(< nc.out)
+    [[ $actual == $expect ]] || \
+        log_error "Did not capture the expected text written to /dev/udp/$host/$port" \
+            "$expect" "$actual"
+
+    # The tests we just ran should not have have left any open fds.
+    if [[ $fd_check == yes ]]
+    then
+        new_fd_count=$( ls -1 /proc/$$/fd | wc -l )
+        [[ $new_fd_count -eq $fd_count ]] || \
+            log_error 'fds unexpectedly opened' "$fd_count" "$new_fd_count"
+    fi
+fi


### PR DESCRIPTION
I intend to refactor `sh_open()` to a) fix lint warnings about accessing
bytes past the end of the pathe string and b) improve readability. Before
doing so it would be nice if there were tests of the existing behavior.

These tests are necessarily incomplete because we don't (yet) have a way to
force on or off the emulation code or pretend that paths like /dev/stdin
are not actually supported by the platform. This is a small step towards
creating a comprehensive set of tests for the magic /dev/... path names.