### PR TITLE
Fix Invalid Lexing Of Parameter Expansions With Parens

### DIFF
--- a/src/cmd/ksh93/tests/modifiers.sh
+++ b/src/cmd/ksh93/tests/modifiers.sh
@@ -44,3 +44,41 @@ unset foo
 foo="non-null value"
 [[ ${foo:+bar} == "bar" ]]  || log_error  '${foo:+bar} not bar when foo is not null'
 [[ ${foo+bar} == "bar" ]]  || log_error  '${foo+bar} not bar when foo is not null'
+
+# Check for regressions on issue #475 where parens after `-', `+', and `=' were causing syntax errors
+unset foo
+[[ ${foo:-(bar)} == "(bar)" ]]  || log_error  '${foo:-(bar)} not (bar) when foo is not set'
+
+unset foo
+[[ ${foo-(bar)} == "(bar)" ]] || log_error '${foo-(bar)} not (bar) when foo is not set'
+
+unset foo
+[[ ${foo-(wor)d} == "(wor)d" ]] || log_error '${foo-(wor)d} not (wor)d when foo is not set'
+
+unset foo
+[[ ${foo-w(or)d} == "w(or)d" ]] || log_error '${foo-w(or)d} not w(or)d when foo is not set'
+
+unset foo
+[[ ${foo-w(ord} == "w(ord" ]] || log_error '${foo-w(ord} not w(ord when foo is not set'
+
+unset foo
+[[ ${foo-wor)d} == "wor)d" ]] || log_error '${foo-wor)d} not wor)d when foo is not set'
+
+foo=""
+[[ ${foo-(bar)} == "" ]]  || log_error  '${foo-(bar)} not "" when foo is null'
+
+unset foo
+[[ ${foo:+(bar)} == "" ]]  || log_error '${foo:+(bar)} not null when foo is not set'
+
+unset foo
+[[ ${foo+(bar)} == "" ]]  || log_error '${foo+(bar)} not null when foo is not set'
+
+foo="non-null value"
+[[ ${foo:+(bar)} == "(bar)" ]]  || log_error  '${foo:+(bar)} not (bar) when foo is not null'
+[[ ${foo+(bar)} == "(bar)" ]]  || log_error  '${foo+(bar)} not (bar) when foo is not null'
+
+unset foo
+[[ ${foo=(word)} == "(word)" ]] || log_error '${foo=(word)} not (word) when foo is not set'
+
+unset foo
+[[ ${foo:=w(or)d} == "w(or)d" ]] || log_error '${foo:=w(or)d} not w(or)d when foo is not set'


### PR DESCRIPTION
This addresses #475 where ksh was found to incorrectly parse parameter
expansions with parentheses when the right-hand side of the expansion is a
string literal.

After a significant amount of analysis it was found that the lexer was mostly
functioning correctly, and that in this particular state it would actually do
the correct thing so long as it was placed in a mode where it would begin
treating the values following the parameter expansion characters as quoted.