### PR TITLE
Reenable leaks tests

### DIFF
--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -95,9 +95,9 @@ all_tests = [
     ['basic', 90], ['bracket'], ['builtins'], ['case'], ['comvar'],
     ['comvario'], ['coprocess', 50], ['cubetype'], ['directoryfd'], ['enum'],
     ['exit'], ['expand'], ['functions'], ['glob'], ['grep'], ['heredoc'],
-    ['io'], ['locale'], ['math', 50], ['nameref'], ['namespace'], ['modifiers'],
-    ['options'], ['path'], ['pointtype'], ['pty'], ['quoting'], ['quoting2'],
-    ['readcsv'], ['recttype'], ['restricted'], ['return'], ['select'],
+    ['io'], ['leaks'], ['locale'], ['math', 50], ['nameref'], ['namespace'],
+    ['modifiers'], ['options'], ['path'], ['pointtype'], ['pty'], ['quoting'],
+    ['quoting2'], ['readcsv'], ['recttype'], ['restricted'], ['return'], ['select'],
     ['sh_match'], ['sigchld', 100], ['signal'], ['statics'], ['subshell', 100],
     ['substring'], ['tilde'], ['timetype'], ['treemove'], ['types'],
     ['variables'], ['vartree1'], ['vartree2'], ['wchar']

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -18,7 +18,8 @@
 #                                                                      #
 ########################################################################
 
-# Test for variable reset leak #
+# Memory leaks in these tests should be caught by asan (or valgrind)
+# Test for variable reset leak
 function test_reset
 {
     integer i n=$1
@@ -29,13 +30,13 @@ function test_reset
     done
 }
 
+n=1000
+test_reset $n
 
 typeset -A foo
 typeset -lui i=0
 
-init_vsz=$(ps -o vsz $$ | tail -n 1 | tr -d '\n')
-
-for (( i=0; i<50000; i++ ))
+for (( i=0; i<500; i++ ))
 do
     unset foo[bar]
     typeset -A foo[bar]
@@ -52,17 +53,8 @@ do
     foo[bar][elem9]="data9"
 done
 
-curr_vsz=$(ps -o vsz $$ | tail -n 1 | tr -d '\n')
-
-if [[ $init_vsz -lt $curr_vsz ]];
-then
-    log_error "Memory leak on associative array: $curr_vsz > $init_vsz"
-fi
-
 # Test for leak in executing subshell after PATH is reset
-init_vsz=$(ps -o vsz $$ | tail -n 1 | tr -d '\n')
-
-for (( i=0; i<10000; i++ ))
+for (( i=0; i<100; i++ ))
 do
     PATH=.
     for DIR in /usr/bin /usr/sbin /bin /usr/local/bin
@@ -75,60 +67,24 @@ do
     done
 done
 
-curr_vsz=$(ps -o vsz $$ | tail -n 1 | tr -d '\n')
+# Memory leak with read -C when deleting compound variable
+data="(v=;sid=;di=;hi=;ti='1328244300';lv='o';id='172.3.161.178';var=(k='conn_num._total';u=;fr=;l='Number of Connections';n='22';t='number';))"
+read -C stat <<< "$data"
+for ((i=0; i < 1; i++))
+do
+    print -r -- "$data"
+done |    while read -u$n -C stat
+    do    :
+    done    {n}<&0-
 
-if [[ $init_vsz -lt $curr_vsz ]];
-then
-    log_error "Memory leak in executing subshell after PATH is reset: $curr_vsz > $init_vsz"
-fi
+    for ((i=0; i < 500; i++))
+do    print -r -- "$data"
+done |    while read -u$n -C stat
+    do    :
+    done    {n}<&0-
 
-log_info 'TODO: Enable these tests when vmstate is a builtin'
-
-#builtin vmstate 2>/dev/null || exit 0
-## one round to get to steady state -- sensitive to -x
-#
-#n=1000
-#test_reset $n
-#a=0$(vmstate --format='+%(size)u')
-#b=0$(vmstate --format='+%(size)u')
-#
-#test_reset $n
-#a=0$(vmstate --format='+%(size)u')
-#test_reset $n
-#b=0$(vmstate --format='+%(size)u')
-#
-#if    (( b > a ))
-#then    log_error "variable value reset memory leak -- $((b-a)) bytes after $n iterations"
-#fi
-#
-## buffer boundary tests
-#
-#for exp in 65535 65536
-#do    got=$($SHELL -c 'x=$(printf "%.*c" '$exp' x); print ${#x}' 2>&1)
-#    [[ $got == $exp ]] || log_error "large command substitution failed -- expected $exp, got $got"
-#done
-#
-#data="(v=;sid=;di=;hi=;ti='1328244300';lv='o';id='172.3.161.178';var=(k='conn_num._total';u=;fr=;l='Number of Connections';n='22';t='number';))"
-#read -C stat <<< "$data"
-#for ((i=0; i < 1; i++))
-#do    print -r -- "$data"
-#done |    while read -u$n -C stat
-#    do    :
-#    done    {n}<&0-
-#a=0$(vmstate --format='+%(size)u')
-#for ((i=0; i < 500; i++))
-#do    print -r -- "$data"
-#done |    while read -u$n -C stat
-#    do    :
-#    done    {n}<&0-
-#b=0$(vmstate --format='+%(size)u')
-#(( b > a )) && log_error 'memory leak with read -C when deleting compound variable'
-#
-#read -C stat <<< "$data"
-#a=0$(vmstate --format='+%(size)u')
-#for ((i=0; i < 500; i++))
-#do      read -C stat <<< "$data"
-#done
-#b=0$(vmstate --format='+%(size)u')
-#(( b > a )) && log_error 'memory leak with read -C when using <<<'
-#
+# Memory leak with read -C when using <<<
+read -C stat <<< "$data"
+for ((i=0; i < 500; i++))
+do      read -C stat <<< "$data"
+done

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -870,3 +870,9 @@ builtin -d echo
 # Check if redirections work if backticks are nested inside $()
 foo=$(print `echo bar`)
 [[ $foo == "bar" ]] || log_error 'Redirections do not work if backticks are nested inside $()'
+
+# Buffer boundary tests
+for exp in 65535 65536
+do    got=$($SHELL -c 'x=$(printf "%.*c" '$exp' x); print ${#x}' 2>&1)
+    [[ $got == $exp ]] || log_error "large command substitution failed" "$exp" "$got"
+done


### PR DESCRIPTION
Also, move one test for command substitution to subshell tests.
Resolves: #403