### PR TITLE
Fix ASAN bug in lex.c

### DIFF
--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -1142,13 +1142,10 @@ int sh_lex(Lex_t *lp) {
                 }
                 isfirst = (lp->lexd.first && fcseek(0) == lp->lexd.first + 1);
                 n = fcgetc();
+                if (n < 0) break;
                 // Check for {}.
                 if (c == LBRACE && n == RBRACE) break;
-                if (n > 0) {
-                    fcseek(-LEN);
-                } else if (lp->lex.reservok) {
-                    break;
-                }
+                fcseek(-LEN);
                 // Check for reserved word { or }.
                 if (lp->lex.reservok && state[n] == S_BREAK && isfirst) break;
                 if (sh_isoption(lp->sh, SH_BRACEEXPAND) && c == LBRACE && !assignment &&


### PR DESCRIPTION
The `sh_lex()` function incorrectly dereferences `state[n]` when `n` is -1.
If `fcgetc()` returns -1 it means we've reached EOF. So any attempt to
use that unavailable character is meaningless. Just break from the loop
regardless of whether `lp->lex.reservok` is true.

Fixes #685