### PR TITLE
Compiler warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,10 @@ system = host_machine.system()
 # So the `config_ast.h`, `lc.h`, and other headers can be found (see below).
 configuration_incdir = include_directories(['.', 'features/locales'])
 
+if get_option('warnings-are-errors') == true
+    add_global_arguments('-Werror', language: 'c')
+endif
+
 # Global compiler flags aren't used by the feature tests. So instead put them
 # in an array that will be used by the feature tests.
 feature_test_args = ['-std=gnu99', '-D_GNU_SOURCE']

--- a/meson.build
+++ b/meson.build
@@ -40,6 +40,11 @@ add_global_arguments('-D_GNU_SOURCE', language: 'c')
 # char pointer is safe to use as an array index.
 add_global_arguments('-Wno-char-subscripts', language: 'c')
 
+# The AST/ksh code is littered with aliasing that violates the assumptions the
+# compiler makes when `-fstrict-aliasing` is in effect so make sure those
+# optimizations are disabled.
+add_global_arguments('-fno-strict-aliasing', language: 'c')
+
 # Enable malloc debug options for macOS, GNU, FreeBSD, and other
 # implementations. This isn't a replacement for Valgrind or Asan but is useful
 # for detecting problems without incurring the overhead of those tools.

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,5 @@
 option('build-pty', type : 'boolean', value : true)
-#
+
 # This build symbol used to be named SHOPT_TIMEOUT. It was renamed when it
 # stopped being used to conditionally compile segments of code. It defines
 # the default, and maximum, read timeout value (see the `TMOUT` shell var).
@@ -10,7 +10,7 @@ option('build-pty', type : 'boolean', value : true)
 # option('read-timeout', type : 'integer', min : 0, value : 0)
 #
 option('read-timeout', type : 'string', value : '0')
-#
+
 # This build symbol used to be named SHOPT_AUDITFILE. It was renamed when it
 # stopped being used to conditionally compile segments of code. It defines
 # the default pathname for recording shell auditable events.
@@ -32,3 +32,7 @@ option('fallback-version-number', type : 'string', value : '0.0.0')
 # To build with support for ASAN (AddressSanitizer:
 #   meson -DASAN=true
 option('ASAN', type : 'boolean', value : false)
+
+# Enable this in CI environments to cause compiler warnings to be treated
+# as errors.
+option('warnings-are-errors', type : 'boolean', value : false)

--- a/scripts/build-on-docker.sh
+++ b/scripts/build-on-docker.sh
@@ -15,7 +15,7 @@ mkdir build
 cd build
 
 echo ==== Configuring the build
-if ! meson
+if ! meson -Dwarnings-are-errors=true
 then
     cat meson-logs/meson-log.txt
     exit 1

--- a/scripts/build-on-macos.sh
+++ b/scripts/build-on-macos.sh
@@ -12,7 +12,7 @@ mkdir build
 cd build
 
 echo ==== Configuring the build
-if ! meson
+if ! meson -Dwarnings-are-errors=true
 then
     cat meson-logs/meson-log.txt
     exit 1

--- a/scripts/travis_common.sh
+++ b/scripts/travis_common.sh
@@ -3,15 +3,6 @@
 # and running the unit tests.
 #
 export LANG=en_US.UTF-8
-export CFLAGS="-fno-strict-aliasing -Wno-unknown-pragmas -Wno-missing-braces"
-CFLAGS="$CFLAGS -Wno-unused-result -Wno-return-type -Wno-int-to-pointer-cast"
-CFLAGS="$CFLAGS -Wno-parentheses -Wno-unused"
-if [ "$DISTRO_TYPE" != "macOS" ]
-then
-    # At this time the clang compiler in the Travis macOS environment does not
-    # support these compiler flags. So include them only if not on macOS.
-    CFLAGS="$CFLAGS -Wno-unused-but-set-variable -Wno-cpp"
-fi
 
 # Removing all the TRAVIS_*, NodeJS, Ruby and other irrelevant env vars. This
 # makes a huge difference in the size of the unit test logfile.


### PR DESCRIPTION
There is no longer any need to suppress a lot of warnings as the code
has been cleaned up to avoid triggering those warnings. Furthermore, the
one compiler flag that does make sense, `-fno-strict-aliasing`, is only
being enforced for Travis builds, not local builds. Move that flag into
the Meson config.