### PR TITLE
Small refactoring of sh_lex

### DIFF
--- a/src/cmd/ksh93/include/lexstates.h
+++ b/src/cmd/ksh93/include/lexstates.h
@@ -23,6 +23,7 @@
 #include <wchar.h>
 #include <wctype.h>
 
+#define S_NOP 0    // absence of a state change, do nothing.
 #define S_BREAK 1  // end of token
 #define S_EOF 2    // end of buffer
 #define S_NL 3     // new-line when not a token
@@ -92,7 +93,7 @@
 #define LEN _Fcin.fclen
 #define isaname(c) ((c) > 0x7f ? isalpha(c) : sh_lexstates[ST_NAME][(c)] == 0)
 #define isaletter(c) ((c) > 0x7f ? isalpha(c) : sh_lexstates[ST_DOL][(c)] == S_ALP && (c) != '.')
-#define STATE(s, c) (s[mbwide() ? ((c = fcmbget(&LEN)), LEN > 1 ? 'a' : c) : (c = fcget())])
+#define STATE(s, c) ((s)[mbwide() ? (((c) = fcmbget(&LEN)), LEN > 1 ? 'a' : (c)) : ((c) = fcget())])
 #define isadigit(c) (sh_lexstates[ST_DOL][c] == S_DIG)
 #define isastchar(c) ((c) == '@' || (c) == '*')
 #define isexp(c) (sh_lexstates[ST_MACRO][c] == S_PAT || (c) == '$' || (c) == '`')

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -299,9 +299,14 @@ static inline void read_to_next_state_transition(int lexer_mode, char **state_ta
 int sh_lex(Lex_t *lp) {
     Shell_t *shp = lp->sh;
     const char *state;
-    int n, c, mode = ST_BEGIN, wordflags = 0;
+    int n;
+    int c;
+    int mode = ST_BEGIN;
+    int wordflags = 0;
     Stk_t *stkp = shp->stk;
-    int inlevel = lp->lexd.level, assignment = 0, ingrave = 0;
+    int inlevel = lp->lexd.level;
+    int assignment = 0;
+    int ingrave = 0;
     int epatchar = 0;
     Sfio_t *sp;
 


### PR DESCRIPTION
The `sh_lex` function is currently a 1000+ line behemoth that severely needs to
be broken apart in order to reclaim any degree of intellectual understanding
and control.

This is a first, modest attempt at such a refactoring. Namely, the following
things are done to help clarify portions of the function:

* Add `S_NOP` lex state to indicate states that are not processed.
* Add `read_to_next_state_transition` function to encapsulate lexer behavior.
* Break apart opening assignments so they are one per line.
* Rename `state` to `state_table`.
* Add `data` variable to take on overloaded `state_table` usage as string data holder.