### PR TITLE
Convert getop() from a macro to a function

### DIFF
--- a/src/cmd/ksh93/sh/streval.c
+++ b/src/cmd/ksh93/sh/streval.c
@@ -106,45 +106,102 @@ typedef int (*Math_3i_f)(Sfdouble_t, Sfdouble_t, Sfdouble_t);
 #define peekchr(vp) (*(vp)->nextchr)
 #define ungetchr(vp) ((vp)->nextchr--)
 
-#if ('a' == 97) /* ASCII encodings */
-#define getop(c)                                                                       \
-    (((c) >= sizeof(strval_states))                                                    \
-         ? ((c) == '|' ? A_OR : ((c) == '^' ? A_XOR : ((c) == '~' ? A_TILDE : A_REG))) \
-         : strval_states[(c)])
-#else
-#define getop(c)                                                                                                \
-    (isdigit(c)                                                                                                 \
-         ? A_DIG                                                                                                \
-         : ((c == ' ' || c == '\t' || c == '\n' || c == '"')                                                    \
-                ? 0                                                                                             \
-                : (c == '<'                                                                                     \
-                       ? A_LT                                                                                   \
-                       : (c == '>'                                                                              \
-                              ? A_GT                                                                            \
-                              : (c == '='                                                                       \
-                                     ? A_ASSIGN                                                                 \
-                                     : (c == '+'                                                                \
-                                            ? A_PLUS                                                            \
-                                            : (c == '-'                                                         \
-                                                   ? A_MINUS                                                    \
-                                                   : (c == '*'                                                  \
-                                                          ? A_TIMES                                             \
-                                                          : (c == '/'                                           \
-                                                                 ? A_DIV                                        \
-                                                                 : (c == '%'                                    \
-                                                                        ? A_MOD                                 \
-                                                                        : (c == ','                             \
-                                                                               ? A_COMMA                        \
-                                                                               : (c == '&'                      \
-                                                                                      ? A_AND                   \
-                                                                                      : (c == '!'               \
-                                                                                             ? A_NOT            \
-                                                                                             : (                \
-                                                                                                   c ==         \
-                                                                                                           '('  \
-                                                                                                       ? A_LPAR \
-                                                                                                       : (c == ')' ? A_RPAR : (c == 0 ? A_EOF : (c == ':' ? A_COLON : (c == '?' ? A_QUEST : (c == '|' ? A_OR : (c == '^' ? A_XOR : (c == '\'' ? A_LIT : (c == '.' ? A_DOT : (c == '~' ? A_TILDE : A_REG)))))))))))))))))))))))
-#endif
+#if 'a' == 97  // ASCII encodings
+
+// This is used on systems with ASCII char encoding to convert characters to
+// math expression tokens.
+static inline int getop(int c) {
+    if (c < sizeof(strval_states)) return strval_states[(c)];
+    switch (c) {
+        case '|': {
+            return A_OR;
+        }
+        case '^': {
+            return A_XOR;
+        }
+        case '~': {
+            return A_TILDE;
+        }
+        default: { return A_REG; }
+    }
+}
+
+#else  // 'a' == 97
+
+// This is used on systems with non-ASCII char encodings (e.g., EBCDIC) to convert characters to
+// math expression tokens.
+static_fn int getop(int c) {
+    if (isdigit(c)) return A_DIG;
+    if (c == ' ' || c == '\t' || c == '\n' || c == '"') return 0;
+    switch (c) {
+        case '<': {
+            return A_LT;
+        }
+        case '>': {
+            return A_GT;
+        }
+        case '=': {
+            return A_ASSIGN;
+        }
+        case '+': {
+            return A_PLUS;
+        }
+        case '-': {
+            return A_MINUS;
+        }
+        case '*': {
+            return A_TIMES;
+        }
+        case '/': {
+            return A_DIV;
+        }
+        case '%': {
+            return A_MOD;
+        }
+        case ',': {
+            return A_COMMA;
+        }
+        case '&': {
+            return A_AND;
+        }
+        case '!': {
+            return A_NOT;
+        }
+        case '(': {
+            return A_LPAR;
+        }
+        case ')': {
+            return A_RPAR;
+        }
+        case ':': {
+            return A_COLON;
+        }
+        case '?': {
+            return A_QUEST;
+        }
+        case '|': {
+            return A_OR;
+        }
+        case '^': {
+            return A_XOR;
+        }
+        case '\'': {
+            return A_LIT;
+        }
+        case '.': {
+            return A_DOT;
+        }
+        case '~': {
+            return A_TILDE;
+        }
+        case 0: {
+            return A_EOF;
+        }
+        default: { return A_REG; }
+    }
+}
+
+#endif  // 'a' == 97
 
 #define seterror(v, msg) _seterror(v, ERROR_dictionary(msg))
 #define ERROR(vp, msg) return (seterror((vp), msg))


### PR DESCRIPTION
The getop macro is hard to read, understand, and edit. Convert it to a
function. I tested both implementations. The non-ASCII implementation
works fine on ASCII systems it is just less efficient than the ASCII
version.