### PR TITLE
Cleanup direct shell references

### DIFF
--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -1274,7 +1274,7 @@ Shell_t *sh_init(int argc, char *argv[], Shinit_f userinit) {
 #endif
     if (!beenhere) {
         beenhere = 1;
-        shp = &sh;
+        shp = sh_getinterp();
         shgd = newof(0, struct shared, 1, 0);
         shgd->pid = getpid();
         shgd->ppid = getppid();

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -908,8 +908,6 @@ Namval_t *nv_mkclone(Namval_t *mp) {
 Namval_t *nv_search(const char *name, Dt_t *root, int mode) {
     Shell_t *shp = sh_getinterp();
 
-    if (!shp) shp = &sh;
-
     Namval_t *np;
     Dt_t *dp = 0;
     if (mode & HASH_NOSCOPE) dp = dtview(root, 0);


### PR DESCRIPTION
Another small fix, separated into two tiny commits. The goal here is to, in line with [this comment in shell.h](https://github.com/att/ast/blob/master/src/cmd/ksh93/include/shell.h#L379), remove the remaining direct references to the global [`Shell_t sh`](https://github.com/att/ast/blob/master/src/cmd/ksh93/include/shell.h#L381) variable in favor of using [`sh_getinterp()`](https://github.com/att/ast/blob/master/src/cmd/ksh93/sh/init.c#L1527).

The following are the changes included in this PR:

* Remove direct reference to `sh` in `sh_init` in favor of using `sh_getinterp`.
* Remove redundant line that was also a direct reference to `sh` in `nv_search`. The line removed is functionally equivalent to the line above it and no longer operates as a valid fallback if that line fails.
