### PR TITLE
Fix integer truncation in put_enum

### DIFF
--- a/src/cmd/ksh93/bltins/enum.c
+++ b/src/cmd/ksh93/bltins/enum.c
@@ -149,7 +149,8 @@ static_fn Namfun_t *clone_enum(Namval_t *np, Namval_t *mp, int flags, Namfun_t *
 static_fn void put_enum(Namval_t *np, const void *val, int flags, Namfun_t *fp) {
     struct Enum *ep = (struct Enum *)fp;
     const char *v;
-    unsigned short i = 0, n;
+    unsigned short i = 0;
+    int n;
     if (!val && !(flags & NV_INTEGER)) {
         nv_putv(np, val, flags, fp);
         nv_disc(np, &ep->hdr, NV_POP);


### PR DESCRIPTION
Coverity identified an issue with integer truncation in `put_enum`.  The
function was truncating the return values of `strcasecmp` and `strcmp` from an
`int` to an `unsigned short` when assigning them to the local variable `n`.
Since either of these methods can return a value that is not in the set
`{0, 1, -1}` the later check if `n == 0` could spuriously evaluate to true. For
example, in the case where either function returned `-65536`.

The fix is simply to change `n` from an `unsigned short` to an `int` to avoid
the possibility of truncation. Since the only purpose of `n` is the store the
return values of these checks, this does not have any side effects.