### PR TITLE
Remove another use of `pointerof()`

### DIFF
--- a/src/cmd/ksh93/include/defs.h
+++ b/src/cmd/ksh93/include/defs.h
@@ -304,6 +304,11 @@ extern Namval_t *sh_fsearch(Shell_t *, const char *, int);
 extern int sh_diropenat(Shell_t *, int, const char *);
 extern int sh_strchr(const char *, const char *, size_t);
 
+// These two magic pointers are used to distinguish the purpose of the `extra` parameter of the
+// `sh_addbuiltin()` function. It should be one of these two values, NULL, or a `Namfun_t*`.
+extern void * const builtin_delete;
+extern void * const builtin_disable;
+
 #ifndef ERROR_dictionary
 #define ERROR_dictionary(s) (s)
 #endif

--- a/src/cmd/ksh93/sh/defs.c
+++ b/src/cmd/ksh93/sh/defs.c
@@ -45,3 +45,10 @@ int32_t sh_mailchk = 600;
 
 // Reserve room for writable state table.
 char *sh_lexstates[ST_NONE] = {0};
+
+// These two magic pointers are used to distinguish the purpose of the `extra` parameter of the
+// `sh_addbuiltin()` function. It should be one of these two values, NULL, or a `Namfun_t*`.
+static int _builtin_delete;
+static int _builtin_disable;
+void * const builtin_delete = &_builtin_delete;
+void * const builtin_disable = &_builtin_disable;


### PR DESCRIPTION
In addition to removing another questionable use of `pointerof()` this also
improves the clarity of the code by replacing magic numbers with symbols
that make the intent clear; i.e., whether to disable or delete the builtin.