### PR TITLE
Simplify special .sh.sig compound var

### DIFF
--- a/src/cmd/ksh93/data/variables.c
+++ b/src/cmd/ksh93/data/variables.c
@@ -126,9 +126,7 @@ const Shtable_t shtab_siginfo[] = {
     {"signo", NV_RDONLY | NV_MINIMAL | NV_NOFREE | NV_INTEGER},
     {"status", NV_RDONLY | NV_MINIMAL | NV_NOFREE | NV_INTEGER},
     {"uid", NV_RDONLY | NV_MINIMAL | NV_NOFREE | NV_INTEGER},
-    {"value", NV_RDONLY | NV_MINIMAL | NV_NOFREE | NV_NODISC},
-    {"value.q", NV_RDONLY | NV_MINIMAL | NV_NOFREE | NV_INTEGER},
-    {"value.Q", NV_RDONLY | NV_MINIMAL | NV_NOFREE | NV_UNSIGN | NV_INTEGER | NV_LONG},
+    {"value", NV_RDONLY | NV_MINIMAL | NV_NOFREE | NV_INTEGER},
     {"", 0}};
 
 const Shtable_t shtab_stats[] = {{"arg_cachehits", NV_RDONLY | NV_MINIMAL | NV_NOFREE | NV_INTEGER},

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -1828,13 +1828,9 @@ void sh_setsiginfo(siginfo_t *sip) {
     np = create_svar(SH_SIG, "addr", 0, fp);
     nv_setsize(np, 16);
     np->nvalue.vp = &sip->si_addr;
-    create_svar(SH_SIG, "value", 0, fp);
-    np = create_svar(SH_SIG, "value.q", 0, fp);
+    np = create_svar(SH_SIG, "value", 0, fp);
     nv_setsize(np, 10);
     np->nvalue.ip = &(sip->si_value.sival_int);
-    np = create_svar(SH_SIG, "value.Q", 0, fp);
-    nv_setsize(np, 10);
-    np->nvalue.vp = &sip->si_value.sival_ptr;
 }
 
 //

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -196,10 +196,7 @@ static_fn void setsiginfo(Shell_t *shp, siginfo_t *info, struct process *pw) {
     info->si_uid = shp->gd->userid;
     info->si_pid = pw->p_pid;
     info->si_code = CLD_EXITED;
-    // We set sival_ptr to zero because si_value is a union and sival_ptr should be as wide or
-    // wider than sival_int. See sh_setsiginfo() for how this is used to populate compound var
-    // `.sh.sig`.
-    info->si_value.sival_ptr = 0;
+    info->si_value.sival_int = 0;
     if (WIFSTOPPED(pw->p_wstat)) {
         info->si_code = CLD_STOPPED;
         info->si_value.sival_int = WSTOPSIG(pw->p_wstat);

--- a/src/cmd/ksh93/tests/signal.sh
+++ b/src/cmd/ksh93/tests/signal.sh
@@ -410,7 +410,7 @@ expect='foo bar USR2'
 #then
 #    compound -a rtar
 #    function rttrap {
-#        integer v=${.sh.sig.value.q}
+#        integer v=${.sh.sig.value}
 #        integer s=${#rtar[v][@]}
 #        integer rtnum=$1
 #        rtar[$v][$s]=(
@@ -513,14 +513,14 @@ case "${c.car[0].code}" in
     SI_QUEUE)
         # System has sigqueue().
         expect=4
-        actual=${c.car[0].value.q}
+        actual=${c.car[0].value}
         (( $actual == $expect )) ||
-            log_error "\${c.car[0].value.q} is wrong" "$expect" "$actual"
+            log_error "\${c.car[0].value} is wrong" "$expect" "$actual"
 
         expect=5
-        actual=${c.car[1].value.q}
+        actual=${c.car[1].value}
         (( $actual == $expect )) ||
-            log_error "\${c.car[1].value.q} is wrong" "$expect" "$actual"
+            log_error "\${c.car[1].value} is wrong" "$expect" "$actual"
         ;;
     SI_USER)
         # System lacks sigqueue(), ksh called kill().

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -764,15 +764,38 @@ $SHELL -c 'unset .sh' 2> /dev/null
 x=$($SHELL -c 'foo=bar foobar=fbar; print -r -- ${!foo*}')
 [[ $x == 'foo '* ]] || log_error 'foo not included in ${!foo*}'
 
-[[ ${!.sh.sig@} == *.sh.sig.pid* ]]  ||  log_error '.sh.sig.pid not in ${!.sh.sig@]}'
-[[ ${!.sh.sig@} == *.sh.sig.status* ]]  ||  log_error '.sh.sig.status not in ${!.sh.sig@]}'
-[[ ${!.sh.sig@} == *.sh.sig.value.q* ]]  ||  log_error '.sh.sig.value.q not in ${!.sh.sig@]}'
-[[ ${!.sh.sig@} == *.sh.sig.value.Q* ]]  ||  log_error '.sh.sig.value.Q not in ${!.sh.sig@]}'
+# ==========
+# Verify that the special .sh.sig compound var contains at least a few of the expected members.
+#
+function contains_sig_var1 {
+    typeset want=$1
+    for name in "${!.sh.sig@}"
+    do
+        [[ $want == $name ]] && return 0
+    done
+    return 1
+}
 
-[[ ${!.sh.sig*} == *.sh.sig.pid* ]]  ||  log_error '.sh.sig.pid not in ${!.sh.sig*]}'
-[[ ${!.sh.sig*} == *.sh.sig.status* ]]  ||  log_error '.sh.sig.status not in ${!.sh.sig*]}'
-[[ ${!.sh.sig*} == *.sh.sig.value.q* ]]  ||  log_error '.sh.sig.value.q not in ${!.sh.sig*]}'
-[[ ${!.sh.sig*} == *.sh.sig.value.Q* ]]  ||  log_error '.sh.sig.value.Q not in ${!.sh.sig*]}'
+function contains_sig_var2 {
+    typeset want=$1
+    for name in ${!.sh.sig*}
+    do
+        [[ $want == $name ]] && return 0
+    done
+    return 1
+}
+
+contains_sig_var1 .sh.sig.pid    || log_error '.sh.sig.pid not in ${!.sh.sig@]}'
+contains_sig_var1 .sh.sig.uid    || log_error '.sh.sig.uid not in ${!.sh.sig@]}'
+contains_sig_var1 .sh.sig.signo  || log_error '.sh.sig.signo not in ${!.sh.sig@]}'
+contains_sig_var1 .sh.sig.status || log_error '.sh.sig.status not in ${!.sh.sig@]}'
+contains_sig_var1 .sh.sig.value  || log_error '.sh.sig.value.q not in ${!.sh.sig@]}'
+
+contains_sig_var2 .sh.sig.pid    || log_error '.sh.sig.pid not in ${!.sh.sig*]}'
+contains_sig_var2 .sh.sig.uid    || log_error '.sh.sig.uid not in ${!.sh.sig*]}'
+contains_sig_var2 .sh.sig.signo  || log_error '.sh.sig.signo not in ${!.sh.sig*]}'
+contains_sig_var2 .sh.sig.status || log_error '.sh.sig.status not in ${!.sh.sig*]}'
+contains_sig_var2 .sh.sig.value  || log_error '.sh.sig.value.q not in ${!.sh.sig*]}'
 
 unset x
 integer x=1


### PR DESCRIPTION
There is no legitimate reason for ksh to record both the `sival_int` and
`sival_ptr` members of `union sigval` when it receives a signal.

Resolves #717