### PR TITLE
Refactor nv_mapchar()

### DIFF
--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -330,7 +330,8 @@ int b_typeset(int argc, char *argv[], Shbltin_t *context) {
                 break;
             }
             case 'M': {
-                if ((tdata.wctname = opt_info.arg) && !nv_mapchar((Namval_t *)0, tdata.wctname)) {
+                tdata.wctname = opt_info.arg;
+                if (tdata.wctname && !wctrans(tdata.wctname)) {
                     errormsg(SH_DICT, ERROR_exit(1), e_unknownmap, tdata.wctname);
                     __builtin_unreachable();
                 }
@@ -750,7 +751,7 @@ static_fn int setall(char **argv, int flag, Dt_t *troot, struct tdata *tp) {
                     errormsg(SH_DICT, ERROR_exit(1), e_mapchararg, nv_name(np));
                     __builtin_unreachable();
                 }
-                cp = (char *)nv_mapchar(np, 0);
+                cp = (char *)nv_mapchar(np, NULL);
                 fp = nv_mapchar(np, tp->wctname);
                 if (fp) {
                     if (tp->aflag == '+') {

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -2172,15 +2172,16 @@ static const Namdisc_t TRANS_disc = {
     sizeof(struct Mapchar), put_trans, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
 Namfun_t *nv_mapchar(Namval_t *np, const char *name) {
-    wctrans_t trans = name ? wctrans(name) : 0;
-    struct Mapchar *mp = 0;
-    int low;
-    size_t n = 0;
-    if (np) mp = (struct Mapchar *)nv_hasdisc(np, &TRANS_disc);
-    if (!name) return (mp ? (Namfun_t *)mp->name : 0);
+    struct Mapchar *mp = (struct Mapchar *)nv_hasdisc(np, &TRANS_disc);
+
+    if (!name) return mp ? (Namfun_t *)mp->name : NULL;
+
+    wctrans_t trans = wctrans(name);
     if (!trans) return NULL;
-    if (!np) return pointerof(1);
-    if ((low = strcmp(name, e_tolower)) && strcmp(name, e_toupper)) n += strlen(name) + 1;
+
+    size_t n = 0;
+    int low = strcmp(name, e_tolower);
+    if (low && strcmp(name, e_toupper)) n += strlen(name) + 1;
     if (mp) {
         if (strcmp(name, mp->name) == 0) return (&mp->hdr);
         nv_disc(np, &mp->hdr, NV_POP);

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -1866,7 +1866,7 @@ static_fn void attstore(Namval_t *np, void *data) {
     ap->tp = 0;
     if (!(flag & NV_EXPORT) || (flag & NV_FUNCT)) return;
     if ((flag & (NV_UTOL | NV_LTOU | NV_INTEGER)) == (NV_UTOL | NV_LTOU)) {
-        data = (void *)nv_mapchar(np, 0);
+        data = nv_mapchar(np, NULL);
         if (strcmp(data, e_tolower) && strcmp(data, e_toupper)) return;
     }
     flag &= (NV_RDONLY | NV_UTOL | NV_LTOU | NV_RJUST | NV_LJUST | NV_ZFILL | NV_INTEGER);
@@ -1961,7 +1961,7 @@ static_fn int scanfilter(Dt_t *dict, void *arg, void *data) {
                     return 0;
                 }
             } else if ((sp->scanflags == NV_UTOL || sp->scanflags == NV_LTOU) &&
-                       (cp = (char *)nv_mapchar(np, 0)) && strcmp(cp, tp->mapname)) {
+                       (cp = (char *)nv_mapchar(np, NULL)) && strcmp(cp, tp->mapname)) {
                 return 0;
             }
         }

--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -491,7 +491,8 @@ void nv_attribute(Namval_t *np, Sfio_t *out, char *prefix, int noname) {
                     }
                 }
                 if (val == NV_UTOL || val == NV_LTOU) {
-                    if ((cp = (char *)nv_mapchar(np, 0)) && strcmp(cp, tp->sh_name + 2)) {
+                    cp = (char *)nv_mapchar(np, NULL);
+                    if (cp && strcmp(cp, tp->sh_name + 2)) {
                         sfprintf(out, "-M %s ", cp);
                         continue;
                     }


### PR DESCRIPTION
There is exactly one place that calls `nv_mapchar()` with a null `np`
argument. That is the `typeset -M` use case. All that does is test
whether `wctrans(name)` is true. So replace that one caller with a
direct call to `wctrans()` and simplify `nv_mapchar()`.