### PR TITLE
Remove unused parameter from path_pwd

### DIFF
--- a/src/cmd/ksh93/bltins/cd_pwd.c
+++ b/src/cmd/ksh93/bltins/cd_pwd.c
@@ -141,7 +141,7 @@ int b_cd(int argc, char *argv[], Shbltin_t *context) {
     if (error_info.errors > 0 || argc > 2) {
         errormsg(SH_DICT, ERROR_usage(2), "%s", optusage((char *)0));
     }
-    shp->pwd = path_pwd(shp, 0);
+    shp->pwd = path_pwd(shp);
     oldpwd = (char *)shp->pwd;
     opwdnod = (shp->subshell ? sh_assignok(OLDPWDNOD, 1) : OLDPWDNOD);
     pwdnod = (shp->subshell ? sh_assignok(PWDNOD, 1) : PWDNOD);
@@ -182,7 +182,7 @@ int b_cd(int argc, char *argv[], Shbltin_t *context) {
                 cdpath->shp = shp;
             }
         }
-        if (!oldpwd) oldpwd = path_pwd(shp, 1);
+        if (!oldpwd) oldpwd = path_pwd(shp);
     }
     if (dirfd == shp->pwdfd && *dir != '/') {
         // Check for leading ..
@@ -349,11 +349,11 @@ int b_pwd(int argc, char *argv[], Shbltin_t *context) {
         return 0;
     }
     if (pflag) {
-        cp = path_pwd(shp, 0);
+        cp = path_pwd(shp);
         cp = strcpy(stakseek(strlen(cp) + PATH_MAX), cp);
         pathcanon(cp, PATH_MAX, PATH_ABSOLUTE | PATH_PHYSICAL);
     } else {
-        cp = path_pwd(shp, 0);
+        cp = path_pwd(shp);
     }
 
     if (*cp != '/') errormsg(SH_DICT, ERROR_system(1), e_pwd);

--- a/src/cmd/ksh93/bltins/whence.c
+++ b/src/cmd/ksh93/bltins/whence.c
@@ -276,7 +276,7 @@ static_fn int whence(Shell_t *shp, char **argv, int flags) {
                     if (*cp != '/') {
                         if (!np && (np = nv_search(name, shp->track_tree, 0))) {
                             sfprintf(sfstdout, "%s %s %s/%s\n", name, sh_translate(is_talias),
-                                     path_pwd(shp, 0), cp);
+                                     path_pwd(shp), cp);
                         } else if (!np || nv_isnull(np)) {
                             sfprintf(sfstdout, "%s%s\n", name, sh_translate(is_ufunction));
                         }

--- a/src/cmd/ksh93/include/path.h
+++ b/src/cmd/ksh93/include/path.h
@@ -83,7 +83,7 @@ extern void path_exec(Shell_t *, const char *, char *[], struct argnod *);
 extern pid_t path_spawn(Shell_t *, const char *, char *[], char *[], Pathcomp_t *, int);
 extern int path_open(Shell_t *, const char *, Pathcomp_t *);
 extern Pathcomp_t *path_get(Shell_t *, const char *);
-extern char *path_pwd(Shell_t *, int);
+extern char *path_pwd(Shell_t *);
 extern Pathcomp_t *path_nextcomp(Shell_t *, Pathcomp_t *, const char *, Pathcomp_t *);
 extern bool path_search(Shell_t *, const char *, Pathcomp_t **, int);
 extern char *path_relative(Shell_t *, const char *);

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -1130,7 +1130,7 @@ static_fn int newconf(const char *name, const char *path, const char *value) {
     } else if (strcmp(name, "UNIVERSE") == 0 && strcmp(astconf(name, 0, 0), value)) {
         shp->universe = 0;
         // Set directory in new universe.
-        if (*(arg = path_pwd(shp, 0)) == '/') chdir(arg);
+        if (*(arg = path_pwd(shp)) == '/') chdir(arg);
         // Clear out old tracked alias.
         stkseek(shp->stk, 0);
         sfputr(shp->stk, nv_getval(PATHNOD), 0);
@@ -2090,7 +2090,7 @@ static_fn void env_init(Shell_t *shp) {
 
     if (nv_isnull(PWDNOD) || nv_isattr(PWDNOD, NV_TAGGED)) {
         nv_offattr(PWDNOD, NV_TAGGED);
-        path_pwd(shp, 0);
+        path_pwd(shp);
     }
 
     cp = nv_getval(SHELLNOD);

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -1336,7 +1336,7 @@ int job_post(Shell_t *shp, pid_t pid, pid_t join) {
         do {
             pw->p_nxtjob = job.pwlist;
         } while (asocasptr(&job.pwlist, pw->p_nxtjob, pw) != pw->p_nxtjob);
-        pw->p_curdir = path_pwd(shp, 0);
+        pw->p_curdir = path_pwd(shp);
         if (pw->p_curdir) pw->p_curdir = strdup(pw->p_curdir);
     }
     job_unlock();

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -135,7 +135,7 @@ int sh_main(int ac, char *av[], Shinit_f userinit) {
     // Set pidname '$$'.
     srand(shp->gd->pid & 0x7fff);
     if (nv_isnull(PS4NOD)) nv_putval(PS4NOD, e_traceprompt, NV_RDONLY);
-    path_pwd(shp, 1);
+    path_pwd(shp);
     iop = (Sfio_t *)0;
     sh_onoption(shp, SH_BRACEEXPAND);
     if ((beenhere++) == 0) {
@@ -181,7 +181,7 @@ int sh_main(int ac, char *av[], Shinit_f userinit) {
             }
         }
         // Make sure PWD is set up correctly.
-        path_pwd(shp, 1);
+        path_pwd(shp);
         if (!sh_isoption(shp, SH_NOEXEC)) {
             if (!sh_isoption(shp, SH_NOUSRPROFILE) && !sh_isoption(shp, SH_PRIVILEGED) &&
                 sh_isoption(shp, SH_RC)) {

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -209,11 +209,10 @@ static_fn pid_t path_xargs(Shell_t *shp, const char *path, char *argv[], char *c
 }
 
 //
-// Make sure PWD is set up correctly. Return the present working directory. Invokes getcwd() if
-// flag==0 and if necessary. Sets the PWD variable to this value.
+// Returns the present working directory (PWD). Attempts several different locations before
+// falling back to getcwd(). Sets shp->pwd and $PWD to the first valid value found.
 //
-char *path_pwd(Shell_t *shp, int flag) {
-    UNUSED(flag);
+char *path_pwd(Shell_t *shp) {
     char *cp;
     int count = 0;
 
@@ -381,7 +380,7 @@ Pathcomp_t *path_nextcomp(Shell_t *shp, Pathcomp_t *pp, const char *name, Pathco
     }
     if (pp && (pp->name[0] != '.' || pp->name[1])) {
         if (*pp->name != '/') {
-            sfputr(shp->stk, path_pwd(shp, 1), -1);
+            sfputr(shp->stk, path_pwd(shp), -1);
             if (*stkptr(shp->stk, stktell(shp->stk) - 1) != '/') sfputc(shp->stk, '/');
         }
         sfwrite(shp->stk, pp->name, pp->len);
@@ -495,7 +494,7 @@ char *path_fullname(Shell_t *shp, const char *name) {
     size_t len = strlen(name) + 1, dirlen = 0;
     char *path, *pwd;
     if (*name != '/') {
-        pwd = path_pwd(shp, 1);
+        pwd = path_pwd(shp);
         dirlen = strlen(pwd) + 1;
     }
     path = (char *)malloc(len + dirlen);
@@ -586,7 +585,7 @@ bool path_search(Shell_t *shp, const char *name, Pathcomp_t **oldpp, int flag) {
         }
         if (*name == '/') return true;
         stkseek(shp->stk, PATH_OFFSET);
-        sfputr(shp->stk, path_pwd(shp, 1), '/');
+        sfputr(shp->stk, path_pwd(shp), '/');
         sfputr(shp->stk, name, 0);
         return false;
     }

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -497,7 +497,7 @@ Sfio_t *sh_subshell(Shell_t *shp, Shnode_t *t, volatile int flags, int comsub) {
         path_get(shp, e_dot);
         shp->pathinit = 0;
     }
-    if (!shp->pwd) path_pwd(shp, 0);
+    if (!shp->pwd) path_pwd(shp);
     sp->bckpid = shp->bckpid;
     if (comsub) {
         sh_stats(STAT_COMSUB);

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1222,7 +1222,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                                 for (item = buffp->olist; item; item = item->next) item->strm = 0;
                             }
                             if (!nv_isattr(np, BLT_ENV) && !nv_isattr(np, BLT_SPC)) {
-                                if (!shp->pwd) path_pwd(shp, 0);
+                                if (!shp->pwd) path_pwd(shp);
 #ifndef O_SEARCH
                                 else if (shp->pwdfd >= 0) {
                                     fstat(shp->pwdfd, &statb);


### PR DESCRIPTION
The `flags` parameter formerly passed to path_pwd was completely unused.
Therefore, it was a prime target for removal.

This change removes the `flags` parameter and updates all invocations of
`path_pwd` to no longer pass this value in. In addition, the documentation
above the function is updated to more accurately describe its current behavior.