### PR TITLE
Remove dead code in print.c

### DIFF
--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -674,7 +674,6 @@ static_fn const char *mapformat(Sffmt_t *fe) {
 static_fn int extend(Sfio_t *sp, void *v, Sffmt_t *fe) {
     UNUSED(sp);
     char *lastchar = "";
-    int neg = 0;
     Sfdouble_t d;
     Sfdouble_t longmin = LDBL_LLONG_MIN;
     Sfdouble_t longmax = LDBL_LLONG_MAX;
@@ -899,7 +898,6 @@ static_fn int extend(Sfio_t *sp, void *v, Sffmt_t *fe) {
                         break;
                     }
                 }
-                if (neg) value->ll = -value->ll;
                 fe->size = sizeof(value->ll);
                 break;
             }


### PR DESCRIPTION
Coverity issue 253596 identified a section of dead code. The variable `neg` in
`extend` was assigned a constant `0` value and then unused and unassigned until
it was checked for a positive value in the removed `if` statement. Since the
constant value `0` would never evaluate to true, the section of code guarded by
the `if` would never execute.