### PR TITLE
Remove dead code in nvtree

### DIFF
--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -1134,7 +1134,7 @@ Namfun_t *nv_isvtree(Namval_t *np) {
 // Get discipline for compound initializations.
 //
 char *nv_getvtree(Namval_t *np, Namfun_t *fp) {
-    int flags = 0, dsize = 0;
+    int flags = 0;
     for (; fp && fp->next; fp = fp->next) {
         if (fp->next->disc && (fp->next->disc->getnum || fp->next->disc->getval)) {
             return nv_getv(np, fp);
@@ -1148,7 +1148,6 @@ char *nv_getvtree(Namval_t *np, Namfun_t *fp) {
     if (flags) nv_offattr(np, NV_EXPORT | NV_TAGGED);
     flags |= nv_isattr(np, NV_TABLE);
     if (flags) nv_offattr(np, NV_TABLE);
-    if (dsize && (flags & NV_EXPORT)) return "()";
     return walk_tree(np, (Namval_t *)0, flags);
 }
 


### PR DESCRIPTION
Coverity issue 253760 identified more dead code due to constant assignment to
a variable. The variable `dsize` traversed the following path to its current
state:

* In 93u `dsize` was assigned `fp->dsize` if `fp` was not `NULL`, otherwise it was `0`.
* In 93v this was strangely changed to always be zero in a constant `#if 1` branch, 93u version was the other side of this branch.
* In master the `#if 1` branch was just removed and so this became a constant assignment.

So, this has been a part of the codebase since 93v and does not appear to be
the source of any known issue.