### PR TITLE
Fix dead code in walk_tree

### DIFF
--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -1051,13 +1051,14 @@ static_fn char *walk_tree(Namval_t *np, Namval_t *xp, int flags) {
         }
         if (nq) {
             nv_delete(nq, walk.root, 0);
+            nq = NULL;
         }
         if (!cp) break;
         if (cp[len] != '.') continue;
 
         if (xp) {
             Dt_t *dp = shp->var_tree;
-            Namval_t *nq, *mq;
+            Namval_t *mq;
             if (strlen(cp) <= len) continue;
             nq = nv_open(cp, walk.root, NV_VARNAME | NV_NOADD | NV_NOASSIGN | NV_NOFAIL);
             if (!nq && (flags & NV_MOVE)) nq = nv_search(cp, walk.root, NV_NOADD);


### PR DESCRIPTION
Address coverity #287602.

Fixes an issue originally injected in d9a8de2 where an unused variable `nq` led
to dead code. From what I can tell the variable was originally added to fix a
"free after use bug" (#398). Unfortunately the original declaration in a later
scope was not removed. This meant that rather than being assigned a value, the
more shallowly scoped `nq` was permanently hidden and never assigned a value,
as specified in C99 ISO/IEC 9899 6.2.1§4.

The fix prescribed here is to merely remove the later redeclaration of `nq`
allowing the shallow declaraction to both be assigned a value and successfully
freed if needed. Based on the above analysis this seems in line with the
original intent of the fix.