### PR TITLE
Fix copy-paste error in ed_pcomplete

### DIFF
--- a/src/cmd/ksh93/edit/pcomplete.c
+++ b/src/cmd/ksh93/edit/pcomplete.c
@@ -396,7 +396,7 @@ char **ed_pcomplete(struct Complete *comp, const char *line, const char *prefix,
         }
     }
     if (comp->prefix) plen = strlen(comp->prefix);
-    if (comp->suffix) slen = strlen(comp->prefix);
+    if (comp->suffix) slen = strlen(comp->suffix);
     filter = comp->filter;
     if (comp->options & FILTER_AMP) {
         while (*filter) {


### PR DESCRIPTION
In the `ed_pcomplete` method, the value used to determine the suffix length
`slen` was actually taking the length of the prefix. This seemed obviously
incorrect and was flagged in coverity in #253617 as a possible copy-paste
error.