### PR TITLE
Remove a condition which is always true

### DIFF
--- a/src/cmd/ksh93/sh/string.c
+++ b/src/cmd/ksh93/sh/string.c
@@ -335,7 +335,8 @@ char *sh_fmtstr(const char *string, int quote) {
         while (op = cp, c = mbchar(cp)) {
             state = 1;
             switch (c) {
-                case ('a'==97?'\033':39): {
+                // Escape character
+                case ('\033'): {
                         c = 'E';
                         break;
                     }


### PR DESCRIPTION
'a' is always 97 in decimal, so remove the test to check for it's value.

Resolves: cid#253601