### PR TITLE
Disable building api tests in coverity scan

### DIFF
--- a/coverity-travis.yml
+++ b/coverity-travis.yml
@@ -27,7 +27,7 @@ addons:
         notification_email: svashisht@redhat.com
 
         # Commands to prepare for build_command
-        build_command_prepend: meson build
+        build_command_prepend: meson -Dbuild-api-tests=false build
 
         # The command that will be added as an argument to "cov-build" to compile your project for analysis,
         build_command: ninja -C build


### PR DESCRIPTION
It's not on priority to fix defects found in these tests, so skip
building them.