### PR TITLE
Fix a case of double sh_close()

### DIFF
--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -790,7 +790,6 @@ Pathcomp_t *path_absolute(Shell_t *shp, const char *name, Pathcomp_t *pp) {
             nv_onattr(nv_open(name, sh_subfuntree(shp, 1), NV_NOARRAY | NV_IDENT | NV_NOSCOPE),
                       NV_LTOU | NV_FUNCTION);
             funload(shp, f, name);
-            sh_close(f);
             return NULL;
         } else if (f >= 0 && (oldpp->flags & PATH_STD_DIR)) {
             int n = stktell(shp->stk);


### PR DESCRIPTION
File descriptor 'f' is closed by funload() function. There is no need to
call sh_close() on it separately.

Resolves: cid#287609