### PR TITLE
Do not show error if ksh fails to execute a directory

### DIFF
--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -925,7 +925,7 @@ void path_exec(Shell_t *shp, const char *arg0, char *argv[], struct argnod *loca
                 opath = arg0;
             }
             path_spawn(shp, opath, argv, envp, libpath, 0);
-            if ((shp->path_err != ENOENT) && (shp->path_err != EACCES)) {
+            if ((shp->path_err != ENOENT) && (shp->path_err != EACCES) && (shp->path_err != EISDIR)) {
                 // An executable command was found, but failed to execute it
                 errormsg(SH_DICT, ERROR_system(ERROR_NOEXEC), e_exec, arg0);
             } else if (shp->path_err == EACCES) {

--- a/src/cmd/ksh93/tests/path.sh
+++ b/src/cmd/ksh93/tests/path.sh
@@ -409,3 +409,12 @@ then
     builtin -d date
     [[ $(type date) == *builtin* ]] && log_error 'builtin -d does not delete builtin'
 fi
+
+# https://github.com/att/ast/issues/757
+OPATH="$PATH"
+PATH=".:$PATH"
+mkdir cat || log_error "mkdir cat failed"
+cat < /dev/null || log_error "Directories should not be treated as executables"
+
+# Restore PATH
+PATH="$OPATH"


### PR DESCRIPTION
Ksh shows an error if it fails to execute a command that has same name
as a directory that appears under PATH. This is a regression introduced
by commit 17f2fe2caa809e7aa7f27746048fc8f231d7111a and worked as
expected in ksh93u+ release.

Resolves: #757