### PR TITLE
Fix some coverity warnings for unchecked return values

### DIFF
--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -224,7 +224,7 @@ retry:
     }
     if (fd < 0) return 0;
     // Set the file to close-on-exec.
-    fcntl(fd, F_SETFD, FD_CLOEXEC);
+    (void)fcntl(fd, F_SETFD, FD_CLOEXEC);
     cp = nv_getval(HISTSIZE);
     if (cp) {
         maxlines = (unsigned)strtol(cp, NULL, 10);
@@ -309,7 +309,7 @@ retry:
             }
         }
         if (fd >= 0) {
-            fcntl(fd, F_SETFD, FD_CLOEXEC);
+            (void)fcntl(fd, F_SETFD, FD_CLOEXEC);
             hp->tty = strdup(ttyname(2));
             hp->auditfp = sfnew((Sfio_t *)0, NULL, -1, fd, SF_WRITE);
         }

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -396,7 +396,7 @@ static_fn void io_preserve(Shell_t *shp, Sfio_t *sp, int f2) {
     shp->sftable[fd] = sp;
     shp->fdstatus[fd] = shp->fdstatus[f2];
     if (fcntl(f2, F_GETFD, 0) & 1) {
-        fcntl(fd, F_SETFD, FD_CLOEXEC);
+        (void)fcntl(fd, F_SETFD, FD_CLOEXEC);
         shp->fdstatus[fd] |= IOCLEX;
     }
     shp->sftable[f2] = 0;
@@ -711,8 +711,8 @@ int sh_pipe(int pv[]) {
     if (!sh_iovalidfd(shp, fd[0])) abort();
     if (!sh_iovalidfd(shp, fd[1])) abort();
 #if _pipe_socketpair && !_stream_peek
-    if (pv[0] > 2) fcntl(pv[0], F_SETFD, FD_CLOEXEC);
-    if (pv[1] > 2) fcntl(pv[1], F_SETFD, FD_CLOEXEC);
+    if (pv[0] > 2) (void)fcntl(pv[0], F_SETFD, FD_CLOEXEC);
+    if (pv[1] > 2) (void)fcntl(pv[1], F_SETFD, FD_CLOEXEC);
 #endif
     if (pv[0] <= 2) pv[0] = sh_iomovefd(shp, pv[0]);
     if (pv[1] <= 2) pv[1] = sh_iomovefd(shp, pv[1]);
@@ -752,7 +752,7 @@ int sh_rpipe(int pv[]) {
 int sh_coaccept(Shell_t *shp, int *pv, int out) {
     int fd = accept(pv[0], NULL, NULL);
 
-    if (fd > 2) fcntl(fd, F_SETFD, FD_CLOEXEC);
+    if (fd > 2) (void)fcntl(fd, F_SETFD, FD_CLOEXEC);
     sh_close(pv[0]);
     pv[0] = -1;
     if (fd < 0) errormsg(SH_DICT, ERROR_system(1), e_pipe);
@@ -761,7 +761,7 @@ int sh_coaccept(Shell_t *shp, int *pv, int out) {
     } else {
         pv[out] = sh_iomovefd(shp, fd);
     }
-    fcntl(pv[out], F_SETFD, FD_CLOEXEC);
+    (void)fcntl(pv[out], F_SETFD, FD_CLOEXEC);
     shp->fdstatus[pv[out]] = (out ? IOWRITE : IOREAD);
     shp->fdstatus[pv[out]] |= IONOSEEK | IOCLEX;
     sh_subsavefd(pv[out]);
@@ -780,7 +780,7 @@ int sh_copipe(Shell_t *shp, int *pv, int out) {
     if (pv[out] < 0) {
         errormsg(SH_DICT, ERROR_system(1), e_pipe);
     }
-    fcntl(pv[out], F_SETFD, FD_CLOEXEC);
+    (void)fcntl(pv[out], F_SETFD, FD_CLOEXEC);
     do {
         sin.sin_family = AF_INET;
         sin.sin_port = htons(++port);
@@ -1568,7 +1568,7 @@ int sh_redirect(Shell_t *shp, struct ionod *iop, int flag) {
                 shp->sftable[-1] = 0;
             }
             if (fd > 2 && clexec && !(shp->fdstatus[fd] & IOCLEX)) {
-                fcntl(fd, F_SETFD, FD_CLOEXEC);
+                (void)fcntl(fd, F_SETFD, FD_CLOEXEC);
                 shp->fdstatus[fd] |= IOCLEX;
             }
         } else {
@@ -2267,7 +2267,7 @@ static_fn void sftrack(Sfio_t *sp, int flag, void *data) {
     mode = sfset(sp, 0, 0);
     if (sp == shp->heredocs && fd < 10 && flag == SF_SETFD) {
         fd = sfsetfd(sp, 10);
-        fcntl(fd, F_SETFD, FD_CLOEXEC);
+        (void)fcntl(fd, F_SETFD, FD_CLOEXEC);
     }
     if (fd < 3) return;
     if (flag == SF_NEW) {

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -343,7 +343,7 @@ static_fn void exfile(Shell_t *shp, Sfio_t *iop, int fno) {
                 sh_close(fno);
                 fno = r;
             }
-            fcntl(fno, F_SETFD, FD_CLOEXEC);
+            (void)fcntl(fno, F_SETFD, FD_CLOEXEC);
             shp->fdstatus[fno] |= IOCLEX;
             iop = sh_iostream((void *)shp, fno, fno);
         } else {

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -460,7 +460,7 @@ static_fn int path_opentype(Shell_t *shp, const char *name, Pathcomp_t *pp, int 
     }
 
     if (fd >= 0 && (fd = sh_iomovefd(shp, fd)) > 0) {
-        fcntl(fd, F_SETFD, FD_CLOEXEC);
+        (void)fcntl(fd, F_SETFD, FD_CLOEXEC);
         shp->fdstatus[fd] |= IOCLEX;
     }
     return fd;
@@ -1211,7 +1211,7 @@ static_fn void exscript(Shell_t *shp, char *path, char *argv[], char *const *env
         if (fstat(n, &statb) < 0 || statb.st_uid != euserid) goto fail;
         if (n != 10) {
             sh_close(10);
-            fcntl(n, F_DUPFD_CLOEXEC, 10);
+            (void)fcntl(n, F_DUPFD_CLOEXEC, 10);
             sh_close(n);
         }
     }

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -143,7 +143,7 @@ void sh_subtmpfile(Shell_t *shp) {
             fds[2] = 0;
             sh_rpipe(fds);
             sp->pipefd = fds[0];
-            sh_fcntl(sp->pipefd, F_SETFD, FD_CLOEXEC);
+            (void)sh_fcntl(sp->pipefd, F_SETFD, FD_CLOEXEC);
             // Write the data to the pipe.
             off = sftell(sfstdout);
             if (off) {
@@ -639,7 +639,7 @@ Sfio_t *sh_subshell(Shell_t *shp, Shnode_t *t, volatile int flags, int comsub) {
                     if (!sh_iovalidfd(shp, fd)) abort();
                 }
                 shp->sftable[fd] = iop;
-                fcntl(fd, F_SETFD, FD_CLOEXEC);
+                (void)fcntl(fd, F_SETFD, FD_CLOEXEC);
                 shp->fdstatus[fd] = (shp->fdstatus[1] | IOCLEX);
                 shp->fdstatus[1] = IOCLOSE;
             }

--- a/src/lib/libast/misc/procopen.c
+++ b/src/lib/libast/misc/procopen.c
@@ -221,14 +221,14 @@ static int modify(Proc_t *proc, int forked, int op, long arg1, long arg2) {
                             return -1;
                         }
 #if F_DUPFD_CLOEXEC == F_DUPFD
-                        fcntl(m->save, F_SETFD, FD_CLOEXEC);
+                        (void)fcntl(m->save, F_SETFD, FD_CLOEXEC);
 #endif
                         close(arg2);
                         if (fcntl(arg1, F_DUPFD, arg2) != arg2) return -1;
                         if (op & PROC_FD_CHILD) close(arg1);
                     } else if (op & PROC_FD_CHILD) {
                         if (m->arg.fd.parent.flag) break;
-                        fcntl(arg1, F_SETFD, FD_CLOEXEC);
+                        (void)fcntl(arg1, F_SETFD, FD_CLOEXEC);
                     } else if (!m->arg.fd.parent.flag)
                         break;
                     else
@@ -296,7 +296,7 @@ static void restore(Proc_t *proc) {
                     close(m->arg.fd.child.fd);
                     fcntl(m->save, F_DUPFD, m->arg.fd.child.fd);
                     close(m->save);
-                    if (m->arg.fd.child.flag) fcntl(m->arg.fd.child.fd, F_SETFD, FD_CLOEXEC);
+                    if (m->arg.fd.child.flag) (void)fcntl(m->arg.fd.child.fd, F_SETFD, FD_CLOEXEC);
                 } else if ((m->op & (PROC_FD_PARENT | PROC_FD_CHILD)) == PROC_FD_CHILD)
                     fcntl(m->arg.fd.parent.fd, F_SETFD, 0);
                 break;
@@ -700,8 +700,8 @@ Proc_t *procopen(const char *cmd, char **argv, char **envv, long *modv, int flag
                     close(pio[1]);
                     break;
             }
-            if (proc->rfd > 2) fcntl(proc->rfd, F_SETFD, FD_CLOEXEC);
-            if (proc->wfd > 2) fcntl(proc->wfd, F_SETFD, FD_CLOEXEC);
+            if (proc->rfd > 2) (void)fcntl(proc->rfd, F_SETFD, FD_CLOEXEC);
+            if (proc->wfd > 2) (void)fcntl(proc->wfd, F_SETFD, FD_CLOEXEC);
         }
         if (!proc->pid)
             proc->pid = getpid();

--- a/src/lib/libast/misc/spawnvex.c
+++ b/src/lib/libast/misc/spawnvex.c
@@ -96,8 +96,8 @@ static pid_t spawn(const char *path, int nmap, const int map[], const struct inh
     if (pipe(msg) < 0) {
         msg[0] = msg[1] = -1;
     } else {
-        fcntl(msg[0], F_SETFD, FD_CLOEXEC);
-        fcntl(msg[1], F_SETFD, FD_CLOEXEC);
+        (void)fcntl(msg[0], F_SETFD, FD_CLOEXEC);
+        (void)fcntl(msg[1], F_SETFD, FD_CLOEXEC);
     }
     sigcritical(SIG_REG_EXEC | SIG_REG_PROC);
     pid = fork();
@@ -108,7 +108,7 @@ static pid_t spawn(const char *path, int nmap, const int map[], const struct inh
         for (i = 0; i < nmap; i++) {
             for (j = 0; j < elementsof(msg); j++) {
                 if (i == msg[j] && (k = fcntl(i, F_DUPFD, 0)) >= 0) {
-                    fcntl(k, F_SETFD, FD_CLOEXEC);
+                    (void)fcntl(k, F_SETFD, FD_CLOEXEC);
                     msg[j] = k;
                 }
             }
@@ -186,8 +186,8 @@ static pid_t spawnve(int mode, const char *path, char *const argv[], char *const
     if (pipe(msg) < 0) {
         msg[0] = msg[1] = -1;
     } else {
-        fcntl(msg[0], F_SETFD, FD_CLOEXEC);
-        fcntl(msg[1], F_SETFD, FD_CLOEXEC);
+        (void)fcntl(msg[0], F_SETFD, FD_CLOEXEC);
+        (void)fcntl(msg[1], F_SETFD, FD_CLOEXEC);
     }
 
     sigcritical(SIG_REG_EXEC | SIG_REG_PROC);
@@ -314,7 +314,7 @@ Spawnvex_t *spawnvex_open(unsigned int flags) {
         vex->debug = (flags & SPAWN_DEBUG) ? fcntl(2, F_DUPFD_CLOEXEC, 60) : -1;
 #else
         if ((vex->debug = (flags & SPAWN_DEBUG) ? fcntl(2, F_DUPFD, 60) : -1) >= 0)
-            fcntl(vex->debug, F_SETFD, FD_CLOEXEC);
+            (void)fcntl(vex->debug, F_SETFD, FD_CLOEXEC);
 #endif
     }
     return vex;
@@ -755,8 +755,8 @@ bad:
         if (pipe(msg) < 0) {
             msg[0] = msg[1] = -1;
         } else {
-            fcntl(msg[0], F_SETFD, FD_CLOEXEC);
-            fcntl(msg[1], F_SETFD, FD_CLOEXEC);
+            (void)fcntl(msg[0], F_SETFD, FD_CLOEXEC);
+            (void)fcntl(msg[1], F_SETFD, FD_CLOEXEC);
         }
         if (!(flags & SPAWN_FOREGROUND)) sigcritical(SIG_REG_EXEC | SIG_REG_PROC);
         pid = fork();

--- a/src/lib/libcoshell/coexec.c
+++ b/src/lib/libcoshell/coexec.c
@@ -66,7 +66,7 @@ static Cojob_t *service(Coshell_t *co, Coservice_t *cs, Cojob_t *cj, int flags, 
         }
     }
     cs->fd = fds[1];
-    fcntl(cs->fd, F_SETFD, FD_CLOEXEC);
+    (void)fcntl(cs->fd, F_SETFD, FD_CLOEXEC);
     ops[0] = PROC_FD_DUP(fds[0], 0, PROC_FD_PARENT);
     ops[1] = PROC_FD_DUP(co->gsmfd, 1, PROC_FD_CHILD);
     ops[2] = 0;

--- a/src/lib/libcoshell/coopen.c
+++ b/src/lib/libcoshell/coopen.c
@@ -354,8 +354,8 @@ Coshell_t *coopen(const char *path, int flags, const char *attributes) {
         }
     }
     co->flags &= ~CO_INIT;
-    fcntl(pio[1], F_SETFD, FD_CLOEXEC);
-    fcntl(pio[2], F_SETFD, FD_CLOEXEC);
+    (void)fcntl(pio[1], F_SETFD, FD_CLOEXEC);
+    (void)fcntl(pio[2], F_SETFD, FD_CLOEXEC);
     co->next = state.coshells;
     state.coshells = co;
     if (!(co->flags & CO_SHELL)) {


### PR DESCRIPTION
These calls should never fail, so we can ignore their return value.