### PR TITLE
Fix write after free error in history.c

### DIFF
--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -638,8 +638,9 @@ void hist_flush(History_t *hp) {
             Shell_t *shp = hp->histshell;
             hist_close(hp);
             if (!sh_histinit(shp)) sh_offoption((Shell_t *)shp, SH_HISTORY);
+        } else {
+            hp->histflush = 0;
         }
-        hp->histflush = 0;
     }
 }
 


### PR DESCRIPTION
This fixes Coverity #253710 in which we attempt to access the variable `hp`
after it has already been closed. This happens in the case where the predicate
`sfsync(hp->hisfp) < 0` evaluates to true. This results in a call to
`hist_close` which also frees `hp`.

Instead, we now avoid accessing `hp` altogether in the case where the predicate
is true, avoiding this issue.