### PR TITLE
read builtin should not wait indefinitely

### DIFF
--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -488,8 +488,7 @@ void ed_setup(Edit_t *ep, int fd, int reedit) {
                     int skip = 0;
                     ep->e_crlf = 0;
                     if (pp < ppmax) *pp++ = c;
-                    for (n = 1; *last; n++) {
-                        c = *last++;
+                    for (n = 1; c = *last++; n++) {
                         if (pp < ppmax) *pp++ = c;
                         if (c == '\a' || c == ESC || c == '\r') break;
                         if (skip || (c >= '0' && c <= '9')) {


### PR DESCRIPTION
read builtin waits indefinitely on executing commands like "read foo".
This is a regression introduced by
1dc56d2151541c8f723240f20faf368a9fee02d9 and before this commit
condition in for loop had a side effect even when it's false. This
commit reverts change to this line.

Resolves: #774