### PR TITLE
Skip interactive dialogue during package installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,14 @@ matrix:
           before_install:
               - docker pull ${DISTRO_TYPE}
 
-# TODO: Renable this test env when issue #783 is fixed.
-#
-#       # Ubuntu requires explicitly generating en_US.UTF-8 locale
-#       - os: linux
-#         compiler: gcc
-#         env:
-#           - DISTRO_TYPE=ubuntu
-#             INSTALL_REQUIREMENTS="apt-get update; apt-get install -y gcc python3 sudo locales ed vim python3-pip ninja-build findutils debianutils netcat-openbsd expect; pip3 install meson==0.44.0; locale-gen en_US.UTF-8"
-#         before_install:
-#             - docker pull ${DISTRO_TYPE}
+        # Ubuntu requires explicitly generating en_US.UTF-8 locale
+        - os: linux
+          compiler: gcc
+          env:
+            - DISTRO_TYPE=ubuntu
+              INSTALL_REQUIREMENTS="apt-get update; apt-get install -y gcc python3 sudo locales ed vim python3-pip ninja-build findutils debianutils netcat-openbsd expect; pip3 install meson==0.44.0; locale-gen en_US.UTF-8"
+          before_install:
+              - docker pull ${DISTRO_TYPE}
 
         # Debian requires explicitly generating en_US.UTF-8 locale too
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
           compiler: gcc
           env:
             - DISTRO_TYPE=ubuntu
-              INSTALL_REQUIREMENTS="apt-get update; apt-get install -y gcc python3 sudo locales ed vim python3-pip ninja-build findutils debianutils netcat-openbsd expect; pip3 install meson==0.44.0; locale-gen en_US.UTF-8"
+              INSTALL_REQUIREMENTS="apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -yq gcc python3 sudo locales ed vim python3-pip ninja-build findutils debianutils netcat-openbsd expect; pip3 install meson==0.44.0; locale-gen en_US.UTF-8"
           before_install:
               - docker pull ${DISTRO_TYPE}
 
@@ -35,7 +35,7 @@ matrix:
           compiler: gcc
           env:
             - DISTRO_TYPE=debian
-              INSTALL_REQUIREMENTS="apt-get update; apt-get install -y gcc python3 python3-pip ninja-build sudo locales ed vim procps findutils debianutils netcat-openbsd expect; pip3 install meson==0.44.0; sed -i '/# en_US.UTF-8 UTF-8/s/..//' /etc/locale.gen && locale-gen"
+              INSTALL_REQUIREMENTS="apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -yq gcc python3 python3-pip ninja-build sudo locales ed vim procps findutils debianutils netcat-openbsd expect; pip3 install meson==0.44.0; sed -i '/# en_US.UTF-8 UTF-8/s/..//' /etc/locale.gen && locale-gen"
           before_install:
               - docker pull ${DISTRO_TYPE}
 


### PR DESCRIPTION
Certain packages like tzdata may ask for user input during installation,
this will block builds on Travis. We should skip it by settting
DEBIAN_FRONTEND to noninteractive.
    
Resolves: #783
