### PR TITLE
Fix copying overlapping buffers in hist_word()

### DIFF
--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -909,7 +909,8 @@ char *hist_word(char *string, int size, int word) {
         }
     }
     *cp = 0;
-    if (s1 != string) strcpy(string, s1);
+    // We can't use strcpy() because the two buffers may overlap.
+    if (s1 != string) memmove(string, s1, strlen(s1) + 1);
     return string;
 }
 


### PR DESCRIPTION
This came to light as a consequence of @siteshwar adding unit tests for
interactive emacs mode editing behavior.