### PR TITLE
Update code to convert version string to number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 sudo: required
 language: c
 
+# Get full repo to correctly determine tags from commits
+git:
+    depth: false
+
 matrix:
     include:
         - os: linux
           compiler: gcc
           env:
             - DISTRO_TYPE=fedora
-              INSTALL_REQUIREMENTS="dnf repolist; dnf install -y gcc python3 meson sudo langpacks-zh_CN ed ncurses vi findutils which nmap-ncat expect"
+              INSTALL_REQUIREMENTS="dnf repolist; dnf install -y gcc python3 meson sudo langpacks-zh_CN ed ncurses vi findutils which nmap-ncat expect git"
           before_install:
               - docker pull ${DISTRO_TYPE}
 
@@ -17,7 +21,7 @@ matrix:
           compiler: gcc
           env:
             - DISTRO_TYPE=opensuse
-              INSTALL_REQUIREMENTS="zypper refresh; zypper in -y gcc python3 python3-pip ninja sudo glibc-locale glibc-devel ed ncurses-utils vim findutils which netcat expect; pip3 install meson==0.44.0"
+              INSTALL_REQUIREMENTS="zypper refresh; zypper in -y gcc python3 python3-pip ninja sudo glibc-locale glibc-devel ed ncurses-utils vim findutils which netcat expect git; pip3 install meson==0.44.0"
           before_install:
               - docker pull ${DISTRO_TYPE}
 
@@ -26,7 +30,7 @@ matrix:
           compiler: gcc
           env:
             - DISTRO_TYPE=ubuntu
-              INSTALL_REQUIREMENTS="apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -yq gcc python3 sudo locales ed vim python3-pip ninja-build findutils debianutils netcat-openbsd expect; pip3 install meson==0.44.0; locale-gen en_US.UTF-8"
+              INSTALL_REQUIREMENTS="apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -yq gcc python3 sudo locales ed vim python3-pip ninja-build findutils debianutils netcat-openbsd expect git; pip3 install meson==0.44.0; locale-gen en_US.UTF-8"
           before_install:
               - docker pull ${DISTRO_TYPE}
 
@@ -35,7 +39,7 @@ matrix:
           compiler: gcc
           env:
             - DISTRO_TYPE=debian
-              INSTALL_REQUIREMENTS="apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -yq gcc python3 python3-pip ninja-build sudo locales ed vim procps findutils debianutils netcat-openbsd expect; pip3 install meson==0.44.0; sed -i '/# en_US.UTF-8 UTF-8/s/..//' /etc/locale.gen && locale-gen"
+              INSTALL_REQUIREMENTS="apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -yq gcc python3 python3-pip ninja-build sudo locales ed vim procps findutils debianutils netcat-openbsd expect git; pip3 install meson==0.44.0; sed -i '/# en_US.UTF-8 UTF-8/s/..//' /etc/locale.gen && locale-gen"
           before_install:
               - docker pull ${DISTRO_TYPE}
 
@@ -51,6 +55,9 @@ services:
     - docker
 
 script:
+    # Fetch tags to set version number
+    - git fetch --tags
+
     - if [[ $TRAVIS_OS_NAME == "osx" ]]; then exec scripts/build-on-macos.sh; fi
 
     - docker run -v $TRAVIS_BUILD_DIR:/source ${DISTRO_TYPE} bash -c "set -e;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ None at this time.
 - <> operator now redirects standard input by default (issue #75).
 - Support for the build time SHOPT_ACCTFILE symbol and code has been removed
   (issue #210).
+- Versioning scheme has been changed to use semantic version numbers (issue #335).
 
 ## Notable fixes and improvements
 

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -821,3 +821,8 @@ expect="$0"
 actual="${.sh.file}"
 [[ $actual == $expect ]] ||
     log_error ".sh.file is not set to correct value after sourcing a file" "$expect" "$actual"
+
+# Check if version string is set to nonsense value in arithmetic context
+# Due to backward compatibility concerns any major release can have maximum yyyy.99.99 releases
+# i.e. minor versions and patches can not go above number 99.
+[[ $((.sh.version)) -ge 20170000 ]] && [[ $((.sh.version)) -le 20990000 ]] || log_error "Version string is set incorrectly to $((.sh.version))"


### PR DESCRIPTION
We have switched to semantic version numbering and this commit modifies
code to convert version string to number in arithmetic context. Also,
add a test case for it and update changelog.