### PR TITLE
Remove mb2wc, mbnchar, and mbnsize macros

### DIFF
--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -449,7 +449,7 @@ static_fn char strformat(char *s) {
                 }
 
                 if (w) {
-                    t += mbconv(t, c);
+                    t += wctomb(t, c);
                     continue;
                 }
                 if (c == '%') {

--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -485,7 +485,7 @@ static_fn char *fmthtml(Shell_t *shp, const char *string, int flags) {
     if (!(flags & SFFMT_ALTER)) {
         while ((c = *(unsigned char *)cp++)) {
             int s;
-            s = mbsize(cp - 1);
+            s = mblen(cp - 1, MB_CUR_MAX);
             if (s > 1) {
                 cp += (s - 1);
                 continue;
@@ -635,7 +635,7 @@ static_fn int varname(const char *str, ssize_t n) {
         n = strlen(str);
     }
     for (; n > 0; n -= len) {
-        len = mbsize(str);
+        len = mblen(str, MB_CUR_MAX);
         c = mbchar(str);
         if (dot && !(isalpha(c) || c == '_')) {
             break;
@@ -818,7 +818,7 @@ static_fn int extend(Sfio_t *sp, void *v, Sffmt_t *fe) {
                 break;
             }
             case 'c': {
-                if (mbwide() && (n = mbsize(argp)) > 1) {
+                if (mbwide() && (n = mblen(argp, MB_CUR_MAX)) > 1) {
                     fe->fmt = 's';
                     fe->size = n;
                     value->s = argp;
@@ -853,7 +853,7 @@ static_fn int extend(Sfio_t *sp, void *v, Sffmt_t *fe) {
                     case '\'':
                     case '"': {
                         w = argp + 1;
-                        if (mbwide() && mbsize(w) > 1) {
+                        if (mbwide() && mblen(w, MB_CUR_MAX) > 1) {
                             value->ll = mbchar(w);
                         } else {
                             value->ll = *(unsigned char *)w++;
@@ -1038,7 +1038,7 @@ static_fn int fmtvecho(Shell_t *shp, const char *string, struct printf *pp) {
     int chlen;
     if (mbwide()) {
         while (1) {
-            chlen = mbsize(cp);
+            chlen = mblen(cp, MB_CUR_MAX);
             // Skip over multibyte characters.
             if (chlen > 1) {
                 cp += chlen;
@@ -1054,7 +1054,7 @@ static_fn int fmtvecho(Shell_t *shp, const char *string, struct printf *pp) {
     c = --cp - string;
     if (c > 0) sfwrite(shp->stk, (void *)string, c);
     for (; (c = *cp); cp++) {
-        if (mbwide() && ((chlen = mbsize(cp)) > 1)) {
+        if (mbwide() && ((chlen = mblen(cp, MB_CUR_MAX)) > 1)) {
             sfwrite(shp->stk, cp, chlen);
             cp += (chlen - 1);
             continue;

--- a/src/cmd/ksh93/bltins/read.c
+++ b/src/cmd/ksh93/bltins/read.c
@@ -603,7 +603,7 @@ int sh_readline(Shell_t *shp, char **names, void *readfn, volatile int fd, int f
                         mbinit();
                         *cur = 0;
                         x = z = 0;
-                        while (up < cur && (z = mbsize(up)) > 0) {
+                        while (up < cur && (z = mblen(up, MB_CUR_MAX)) > 0) {
                             up += z;
                             x++;
                         }
@@ -672,7 +672,7 @@ int sh_readline(Shell_t *shp, char **names, void *readfn, volatile int fd, int f
             case S_MBYTE: {
                 if (val == 0) val = (char *)(cp - 1);
                 if (sh_strchr(ifs, (char *)cp - 1, cpmax - cp + 1) >= 0) {
-                    c = mbsize((char *)cp - 1);
+                    c = mblen((char *)cp - 1, MB_CUR_MAX);
                     if (name) cp[-1] = 0;
                     if (c > 1) cp += (c - 1);
                     c = S_DELIM;
@@ -761,7 +761,7 @@ int sh_readline(Shell_t *shp, char **names, void *readfn, volatile int fd, int f
                 if (!val) continue;
                 if (c == S_MBYTE) {
                     if (sh_strchr(ifs, (char *)cp - 1, cpmax - cp + 1) >= 0) {
-                        if ((c = mbsize((char *)cp - 1)) > 1) cp += (c - 1);
+                        if ((c = mblen((char *)cp - 1, MB_CUR_MAX)) > 1) cp += (c - 1);
                         c = S_DELIM;
                     } else {
                         c = 0;

--- a/src/cmd/ksh93/bltins/read.c
+++ b/src/cmd/ksh93/bltins/read.c
@@ -600,7 +600,6 @@ int sh_readline(Shell_t *shp, char **names, void *readfn, volatile int fd, int f
                         int x;
                         int z;
 
-                        mbinit();
                         *cur = 0;
                         x = z = 0;
                         while (up < cur && (z = mblen(up, MB_CUR_MAX)) > 0) {

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -666,7 +666,7 @@ static int putstack(Edit_t *ep, char string[], int nbyte, int type) {
                 errno = 0;
             }
 #endif  // EILSEQ
-            else if ((endp - p) < mbmax()) {
+            else if ((endp - p) < MB_CUR_MAX) {
                 if ((c = ed_read(ep, ep->e_fd, endp, 1, 0)) == 1) {
                     *++endp = 0;
                     goto again;
@@ -675,7 +675,7 @@ static int putstack(Edit_t *ep, char string[], int nbyte, int type) {
             } else {
                 ed_ringbell();
                 c = -(int)((*p) & STRIP);
-                offset += mbmax() - 1;
+                offset += MB_CUR_MAX - 1;
             }
         }
         ep->e_lbuf[--offset] = c;

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -780,7 +780,7 @@ void ed_putchar(Edit_t *ep, int c) {
     buf[0] = c;
     // Check for place holder.
     if (c == MARKER) return;
-    if ((size = mbconv(buf, (wchar_t)c)) > 1) {
+    if ((size = wctomb(buf, (wchar_t)c)) > 1) {
         for (i = 0; i < (size - 1); i++) *dp++ = buf[i];
         c = buf[i];
     } else {
@@ -824,7 +824,7 @@ Edpos_t ed_curpos(Edit_t *ep, genchar *phys, int off, int cur, Edpos_t curpos) {
     }
     while (off-- > 0) {
         if (c) c = *sp++;
-        if (c && (mbconv(p, (wchar_t)c)) == 1 && p[0] == '\n') {
+        if (c && (wctomb(p, (wchar_t)c)) == 1 && p[0] == '\n') {
             col = 0;
         } else {
             col++;
@@ -1015,7 +1015,7 @@ int ed_external(const genchar *src, char *dest) {
         return c;
     }
     while ((wc = *src++) && dp < dpmax) {
-        if ((size = mbconv(dp, wc)) < 0) {
+        if ((size = wctomb(dp, wc)) < 0) {
             // Copy the character as is.
             size = 1;
             *dp = wc;

--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -826,7 +826,6 @@ int hist_match(History_t *hp, off_t offset, char *string, int *coffset) {
     char *first, *cp;
     int m, n, c = 1, line = 0;
 
-    mbinit();
     sfseek(hp->histfp, offset, SEEK_SET);
     cp = first = sfgetr(hp->histfp, 0, 0);
     if (!cp) return -1;

--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -839,7 +839,7 @@ int hist_match(History_t *hp, off_t offset, char *string, int *coffset) {
         }
         if (!coffset) break;
         if (*cp == '\n') line++;
-        c = mbsize(cp);
+        c = mblen(cp, MB_CUR_MAX);
         if (c < 0) c = 1;
         cp += c;
         m -= c;

--- a/src/cmd/ksh93/sh/fcin.c
+++ b/src/cmd/ksh93/sh/fcin.c
@@ -145,7 +145,7 @@ void fcrestore(Fcin_t *fp) { _Fcin = *fp; }
 
 int _fcmbget(short *len) {
     int c;
-    *len = mbsize(_Fcin.fcptr);
+    *len = mblen((char *)_Fcin.fcptr, MB_CUR_MAX);
     switch (*len) {
         case -1: {
             *len = 1;

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -438,7 +438,7 @@ static_fn char *get_ifs(Namval_t *np, Namfun_t *fp) {
         memset(shp->ifstable, 0, (1 << CHAR_BIT));
         cp = value;
         if (cp) {
-            while (n = mbsize(cp), c = *(unsigned char *)cp) {
+            while (n = mblen(cp, MB_CUR_MAX), c = *(unsigned char *)cp) {
                 cp++;
                 if (n > 1) {
                     cp += (n - 1);

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -2099,7 +2099,7 @@ static_fn void put_trans(Namval_t *np, const void *vp, int flags, Namfun_t *fp) 
             c = towctrans(c, mp->trans);
             stakseek(off + c);
             stakseek(off);
-            c = mbconv(stakptr(off), c);
+            c = wctomb(stakptr(off), c);
             off += c;
             stakseek(off);
         }

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -1675,7 +1675,7 @@ static_fn int here_copy(Lex_t *lp, struct ionod *iop) {
         if (n != S_NL) {
             // Skip over regular characters.
             do {
-                if (fcleft() < MB_LEN_MAX && mbsize(fcseek(0)) < 0) {
+                if (fcleft() < MB_LEN_MAX && mblen(fcseek(0), MB_CUR_MAX) < 0) {
                     n = S_EOF;
                     LEN = -fcleft();
                     break;
@@ -1944,7 +1944,7 @@ struct argnod *sh_endword(Shell_t *shp, int mode) {
     if (mbwide()) {
         do {
             int len;
-            switch (len = mbsize(sp)) {
+            switch (len = mblen(sp, MB_CUR_MAX)) {
                 case -1: /* illegal multi-byte char */
                 case 0:
                 case 1: {
@@ -2119,7 +2119,7 @@ struct argnod *sh_endword(Shell_t *shp, int mode) {
         if (mbwide()) {
             do {
                 int len;
-                switch (len = mbsize(sp)) {
+                switch (len = mblen(sp, MB_CUR_MAX)) {
                     case -1:  // illegal multi-byte char
                     case 0:
                     case 1: {

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -1595,7 +1595,6 @@ skip:
             if (vsize < type) {
                 v = 0;
             } else if (mbwide()) {
-                mbinit();
                 for (c = type; c; c--) mbchar(v);
                 c = ':';
             } else {
@@ -1616,7 +1615,6 @@ skip:
             } else if (type < vsize) {
                 if (mbwide()) {
                     char *vp = v;
-                    mbinit();
                     while (type-- > 0) {
                         if ((c = mblen(vp, MB_CUR_MAX)) < 1) c = 1;
                         vp += c;
@@ -2327,7 +2325,6 @@ static_fn char *lastchar(const char *string, const char *endstring) {
     char *str = (char *)string;
     int c;
 
-    mbinit();
     while (*str) {
         if ((c = mblen(str, MB_CUR_MAX)) < 0) c = 1;
         if (str + c > endstring) break;
@@ -2341,7 +2338,6 @@ static_fn int charlen(const char *string, int len) {
     if (mbwide()) {
         const char *str = string, *strmax = string + len;
         int n = 0;
-        mbinit();
         if (len > 0) {
             while (str < strmax && mbchar(str)) n++;
         } else {

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -298,7 +298,7 @@ void sh_machere(Shell_t *shp, Sfio_t *infile, Sfio_t *outfile, char *string) {
         if (mbwide()) {
             do {
                 ssize_t len;
-                switch (len = mbsize(cp)) {
+                switch (len = mblen(cp, MB_CUR_MAX)) {
                     case -1:  // illegal multi-byte char
                     case 0:
                     case 1: {
@@ -453,7 +453,7 @@ static_fn void copyto(Mac_t *mp, int endch, int newquote) {
         if (mbwide()) {
             ssize_t len;
             do {
-                switch (len = mbsize(cp)) {
+                switch (len = mblen(cp, MB_CUR_MAX)) {
                     case -1:  // illegal multi-byte char
                     case 0: {
                         len = 1;
@@ -1618,7 +1618,7 @@ skip:
                     char *vp = v;
                     mbinit();
                     while (type-- > 0) {
-                        if ((c = mbsize(vp)) < 1) c = 1;
+                        if ((c = mblen(vp, MB_CUR_MAX)) < 1) c = 1;
                         vp += c;
                     }
                     type = vp - v;
@@ -1802,7 +1802,7 @@ retry2:
                 if (mode != '@' && mp->ifsp) {
                     // Handle multi-byte characters being used for the internal
                     // field separator (IFS).
-                    for (int i = 0; i < mbsize(mp->ifsp); i++) {
+                    for (int i = 0; i < mblen(mp->ifsp, MB_CUR_MAX); i++) {
                         sfputc(sfio_ptr, mp->ifsp[i]);
                     }
                 } else {
@@ -2329,7 +2329,7 @@ static_fn char *lastchar(const char *string, const char *endstring) {
 
     mbinit();
     while (*str) {
-        if ((c = mbsize(str)) < 0) c = 1;
+        if ((c = mblen(str, MB_CUR_MAX)) < 0) c = 1;
         if (str + c > endstring) break;
         str += c;
     }

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -2104,7 +2104,7 @@ static_fn void mac_copy(Mac_t *mp, const char *str, size_t size) {
         state = sh_lexstates[ST_MACRO];
         // Insert \ before file expansion characters.
         while (size-- > 0) {
-            len = mbnsize(cp, ep - cp);
+            len = mblen(cp, ep - cp);
             if (len > 1) {
                 cp += len;
                 size -= (len - 1);
@@ -2166,7 +2166,7 @@ static_fn void mac_copy(Mac_t *mp, const char *str, size_t size) {
         }
         while (size-- > 0) {
             n = state[c = *(unsigned char *)cp++];
-            if (n != S_MBYTE && (len = mbnsize(cp - 1, ep - cp + 1)) > 1) {
+            if (n != S_MBYTE && (len = mblen(cp - 1, ep - cp + 1)) > 1) {
                 sfwrite(stkp, cp - 1, len);
                 cp += --len;
                 size -= len;
@@ -2181,7 +2181,7 @@ static_fn void mac_copy(Mac_t *mp, const char *str, size_t size) {
             } else if (n && mp->ifs) {
                 if (n == S_MBYTE) {
                     if (sh_strchr(mp->ifsp, cp - 1, ep - cp + 1) < 0) continue;
-                    n = mbnsize(cp - 1, ep - cp + 1) - 1;
+                    n = mblen(cp - 1, ep - cp + 1) - 1;
                     if (n == -2) n = 0;
                     cp += n;
                     size -= n;
@@ -2193,7 +2193,7 @@ static_fn void mac_copy(Mac_t *mp, const char *str, size_t size) {
                         size--;
                     }
                     if (n == S_MBYTE && sh_strchr(mp->ifsp, cp - 1, ep - cp + 1) >= 0) {
-                        n = mbnsize(cp - 1, ep - cp + 1) - 1;
+                        n = mblen(cp - 1, ep - cp + 1) - 1;
                         if (n == -2) n = 0;
                         cp += n;
                         size -= n;

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -491,7 +491,7 @@ static_fn void copyto(Mac_t *mp, int endch, int newquote) {
                         int i;
                         unsigned char mb[8];
 
-                        n = mbconv((char *)mb, c);
+                        n = wctomb((char *)mb, c);
                         for (i = 0; i < n; i++) sfputc(stkp, mb[i]);
                     } else {
                         sfputc(stkp, c);

--- a/src/cmd/ksh93/sh/string.c
+++ b/src/cmd/ksh93/sh/string.c
@@ -169,7 +169,7 @@ char *sh_substitute(Shell_t *shp, const char *string, const char *oldsp, char *n
         // Skip to first character which matches start of oldsp.
         while (*sp && (savesp == sp || *sp != *cp)) {
             // Skip a whole character at a time.
-            int c = mbsize(sp);
+            int c = mblen(sp, MB_CUR_MAX);
             if (c < 0) sp++;
             while (c-- > 0) sfputc(shp->stk, *sp++);
         }
@@ -206,7 +206,7 @@ void sh_trim(char *sp) {
         dp = sp;
         while ((c = *sp)) {
             int len;
-            if (mbwide() && (len = mbsize(sp)) > 1) {
+            if (mbwide() && (len = mblen(sp, MB_CUR_MAX)) > 1) {
                 memmove(dp, sp, len);
                 dp += len;
                 sp += len;

--- a/src/cmd/ksh93/sh/string.c
+++ b/src/cmd/ksh93/sh/string.c
@@ -629,8 +629,12 @@ char *sh_fmtqf(const char *string, int flags, int fold) {
 int sh_strchr(const char *string, const char *dp, size_t size) {
     wchar_t c, d;
     const char *cp = string;
-    mbinit();
-    d = mbnchar(dp, size);
+
+    // This used to use the obsolete `mbnchar()` macro. Then and now the code does not correctly
+    // handle a conversion error. In the old `mbnchar()` using code it would decrement the pointer
+    // by one. Which, at least in the context of this function was pointless and probably wrong
+    // regardless.
+    mbtowc(&d, dp, size);
     mbinit();
     while ((c = mbchar(cp))) {
         if (c == d) return cp - string;

--- a/src/cmd/ksh93/sh/string.c
+++ b/src/cmd/ksh93/sh/string.c
@@ -164,7 +164,6 @@ char *sh_substitute(Shell_t *shp, const char *string, const char *oldsp, char *n
     stkseek(shp->stk, 0);
     if (*sp == 0) return NULL;
     if (*(cp = oldsp) == 0) goto found;
-    mbinit();
     do {
         // Skip to first character which matches start of oldsp.
         while (*sp && (savesp == sp || *sp != *cp)) {
@@ -284,7 +283,6 @@ char *sh_fmtstr(const char *string, int quote) {
 
     if (!cp) return NULL;
     offset = staktell();
-    mbinit();
     state = ((c = mbchar(cp)) == 0);
     lc_unicodeliterals = quote == 'u' ? 1 : 0;
     if (quote == '"') goto skip;
@@ -329,7 +327,6 @@ char *sh_fmtstr(const char *string, int quote) {
             stakwrite("$'", 2);
         }
         cp = string;
-        mbinit();
         while (op = cp, c = mbchar(cp)) {
             state = 1;
             switch (c) {
@@ -635,7 +632,6 @@ int sh_strchr(const char *string, const char *dp, size_t size) {
     // by one. Which, at least in the context of this function was pointless and probably wrong
     // regardless.
     mbtowc(&d, dp, size);
-    mbinit();
     while ((c = mbchar(cp))) {
         if (c == d) return cp - string;
     }

--- a/src/lib/libast/comp/setlocale.c
+++ b/src/lib/libast/comp/setlocale.c
@@ -84,7 +84,6 @@ static void init_ast_struct() {
         ast.collate = strcoll;
         ast.mb_alpha = (Isw_f)iswalpha;
         ast.mb_conv = wctomb;
-        ast.mb_len = mblen;
         ast.mb_towc = mbtowc;
         ast.mb_width = wcwidth;
         ast.mb_xfrm = strxfrm;

--- a/src/lib/libast/comp/setlocale.c
+++ b/src/lib/libast/comp/setlocale.c
@@ -83,7 +83,6 @@ static void init_ast_struct() {
         ast._ast_wcsrtombs = wcsrtombs;
         ast.collate = strcoll;
         ast.mb_alpha = (Isw_f)iswalpha;
-        ast.mb_conv = wctomb;
         ast.mb_towc = mbtowc;
         ast.mb_width = wcwidth;
         ast.mb_xfrm = strxfrm;

--- a/src/lib/libast/comp/setlocale.c
+++ b/src/lib/libast/comp/setlocale.c
@@ -103,8 +103,7 @@ static void init_ast_struct() {
     const char *codeset = nl_langinfo(CODESET);
     ast.locale.is_utf8 = strcasecmp(codeset, "utf-8") == 0 || strcasecmp(codeset, "utf8") == 0;
 
-    ast.mb_cur_max = MB_CUR_MAX;
-    ast.byte_max = ast.mb_cur_max == 1 && !is_us_ascii_codeset() ? 0xff : 0x7f;
+    ast.byte_max = MB_CUR_MAX == 1 && !is_us_ascii_codeset() ? 0xff : 0x7f;
 }
 
 //

--- a/src/lib/libast/include/ast.h
+++ b/src/lib/libast/include/ast.h
@@ -330,7 +330,6 @@ extern char **environ;
                      ? ((p += ast.tmp_int), ast.tmp_wchar)                                \
                      : (p += 1, ast.tmp_int))                                             \
               : (*(unsigned char *)(p++)))
-#define mbinit()  do { } while (0)  // this is now a no-op in legacy mode
 
 #endif
 

--- a/src/lib/libast/include/ast.h
+++ b/src/lib/libast/include/ast.h
@@ -328,7 +328,6 @@ extern char **environ;
 
 #else
 
-#define mb2wc(w, p, n) (*ast.mb_towc)(&(w), (char *)(p), (n))
 #define mbchar(p)                                                                         \
     (mbwide() ? ((ast.tmp_int = (*ast.mb_towc)(&ast.tmp_wchar, (char *)(p), mbmax())) > 0 \
                      ? ((p += ast.tmp_int), ast.tmp_wchar)                                \
@@ -339,7 +338,7 @@ extern char **environ;
                      ? ((p += ast.tmp_int), ast.tmp_wchar)                          \
                      : (p += 1, ast.tmp_int))                                       \
               : (*(unsigned char *)(p++)))
-#define mbinit() (mbwide() ? (*ast.mb_towc)((wchar_t *)0, (char *)0, mbmax()) : 0)
+#define mbinit()  // this is now a no-op in legacy mode
 // You cannot call this with a parameter that has side-effects (e.g.,
 // decrement/increment) because it won't occur if we're not in a wide locale.
 #define mbsize(p) (mbwide() ? (*ast.mb_len)((char *)(p), mbmax()) : 1)

--- a/src/lib/libast/include/ast.h
+++ b/src/lib/libast/include/ast.h
@@ -331,7 +331,6 @@ extern char **environ;
                      : (p += 1, ast.tmp_int))                                             \
               : (*(unsigned char *)(p++)))
 #define mbinit()  do { } while (0)  // this is now a no-op in legacy mode
-#define mbconv(s, w) (ast.mb_conv ? (*ast.mb_conv)(s, w) : ((*(s) = (w)), 1))
 
 #endif
 

--- a/src/lib/libast/include/ast.h
+++ b/src/lib/libast/include/ast.h
@@ -331,9 +331,6 @@ extern char **environ;
                      : (p += 1, ast.tmp_int))                                             \
               : (*(unsigned char *)(p++)))
 #define mbinit()  do { } while (0)  // this is now a no-op in legacy mode
-// You cannot call this with a parameter that has side-effects (e.g.,
-// decrement/increment) because it won't occur if we're not in a wide locale.
-#define mbsize(p) (mbwide() ? (*ast.mb_len)((char *)(p), MB_CUR_MAX) : 1)
 #define mbconv(s, w) (ast.mb_conv ? (*ast.mb_conv)(s, w) : ((*(s) = (w)), 1))
 
 #endif

--- a/src/lib/libast/include/ast.h
+++ b/src/lib/libast/include/ast.h
@@ -158,11 +158,8 @@
 /*
  * multibyte macros
  */
-
-#define mbmax() (ast.mb_cur_max)
-
 #define mbcoll() (ast.mb_xfrm != 0)
-#define mbwide() (mbmax() > 1)
+#define mbwide() (MB_CUR_MAX > 1)
 
 #define mbwidth(w) (ast.mb_width ? (*ast.mb_width)(w) : 1)
 #define mbxfrm(t, f, n) (mbcoll() ? (*ast.mb_xfrm)((char *)(t), (char *)(f), n) : 0)
@@ -329,14 +326,14 @@ extern char **environ;
 #else
 
 #define mbchar(p)                                                                         \
-    (mbwide() ? ((ast.tmp_int = (*ast.mb_towc)(&ast.tmp_wchar, (char *)(p), mbmax())) > 0 \
+    (mbwide() ? ((ast.tmp_int = (*ast.mb_towc)(&ast.tmp_wchar, (char *)(p), MB_CUR_MAX)) > 0 \
                      ? ((p += ast.tmp_int), ast.tmp_wchar)                                \
                      : (p += 1, ast.tmp_int))                                             \
               : (*(unsigned char *)(p++)))
 #define mbinit()  do { } while (0)  // this is now a no-op in legacy mode
 // You cannot call this with a parameter that has side-effects (e.g.,
 // decrement/increment) because it won't occur if we're not in a wide locale.
-#define mbsize(p) (mbwide() ? (*ast.mb_len)((char *)(p), mbmax()) : 1)
+#define mbsize(p) (mbwide() ? (*ast.mb_len)((char *)(p), MB_CUR_MAX) : 1)
 #define mbconv(s, w) (ast.mb_conv ? (*ast.mb_conv)(s, w) : ((*(s) = (w)), 1))
 
 #endif

--- a/src/lib/libast/include/ast.h
+++ b/src/lib/libast/include/ast.h
@@ -333,13 +333,10 @@ extern char **environ;
                      ? ((p += ast.tmp_int), ast.tmp_wchar)                                \
                      : (p += 1, ast.tmp_int))                                             \
               : (*(unsigned char *)(p++)))
-#define mbinit()  // this is now a no-op in legacy mode
+#define mbinit()  do { } while (0)  // this is now a no-op in legacy mode
 // You cannot call this with a parameter that has side-effects (e.g.,
 // decrement/increment) because it won't occur if we're not in a wide locale.
 #define mbsize(p) (mbwide() ? (*ast.mb_len)((char *)(p), mbmax()) : 1)
-// You cannot call this with a parameter that has side-effects (e.g.,
-// decrement/increment) because it won't occur if we're not in a wide locale.
-#define mbnsize(p, n) (mbwide() ? (*ast.mb_len)((char *)(p), n) : 1)
 #define mbconv(s, w) (ast.mb_conv ? (*ast.mb_conv)(s, w) : ((*(s) = (w)), 1))
 
 #endif

--- a/src/lib/libast/include/ast.h
+++ b/src/lib/libast/include/ast.h
@@ -333,11 +333,6 @@ extern char **environ;
                      ? ((p += ast.tmp_int), ast.tmp_wchar)                                \
                      : (p += 1, ast.tmp_int))                                             \
               : (*(unsigned char *)(p++)))
-#define mbnchar(p, n)                                                               \
-    (mbwide() ? ((ast.tmp_int = (*ast.mb_towc)(&ast.tmp_wchar, (char *)(p), n)) > 0 \
-                     ? ((p += ast.tmp_int), ast.tmp_wchar)                          \
-                     : (p += 1, ast.tmp_int))                                       \
-              : (*(unsigned char *)(p++)))
 #define mbinit()  // this is now a no-op in legacy mode
 // You cannot call this with a parameter that has side-effects (e.g.,
 // decrement/increment) because it won't occur if we're not in a wide locale.

--- a/src/lib/libast/include/ast_std.h
+++ b/src/lib/libast/include/ast_std.h
@@ -96,7 +96,6 @@ typedef struct {
     int (*mb_towc)(wchar_t *, const char *, size_t);
     size_t (*mb_xfrm)(char *, const char *, size_t);
     int (*mb_width)(wchar_t);
-    int (*mb_conv)(char *, wchar_t);
 
     uint32_t env_serial;
     uint32_t mb_sync;

--- a/src/lib/libast/include/ast_std.h
+++ b/src/lib/libast/include/ast_std.h
@@ -93,7 +93,6 @@ typedef struct {
     int tmp_int;
     void *tmp_pointer;
 
-    int (*mb_len)(const char *, size_t);
     int (*mb_towc)(wchar_t *, const char *, size_t);
     size_t (*mb_xfrm)(char *, const char *, size_t);
     int (*mb_width)(wchar_t);

--- a/src/lib/libast/include/ast_std.h
+++ b/src/lib/libast/include/ast_std.h
@@ -93,7 +93,6 @@ typedef struct {
     int tmp_int;
     void *tmp_pointer;
 
-    int mb_cur_max;
     int (*mb_len)(const char *, size_t);
     int (*mb_towc)(wchar_t *, const char *, size_t);
     size_t (*mb_xfrm)(char *, const char *, size_t);

--- a/src/lib/libast/misc/state.c
+++ b/src/lib/libast/misc/state.c
@@ -29,5 +29,4 @@
 
 #undef strcmp
 
-_Ast_info_t _ast_info = {
-    .id = "libast", .collate = strcmp, .mb_cur_max = 1, .version = 20130624, .pwd = AT_FDCWD};
+_Ast_info_t _ast_info = {.id = "libast", .collate = strcmp, .version = 20130624, .pwd = AT_FDCWD};

--- a/src/lib/libast/sfio/sfgetwc.c
+++ b/src/lib/libast/sfio/sfgetwc.c
@@ -61,7 +61,7 @@ int sfgetwc(Sfio_t *f) {
         c = mbchar(&w, s, n, q);
         if (!mberrno(q))
             f->next = s;
-        else if (n < (m = mbmax())) {
+        else if (n < (m = MB_CUR_MAX)) {
             for (i = 0; i < n; i++) buf[i] = *s++;
             for (;;) {
                 f->next = s;

--- a/src/lib/libast/sfio/sfhdr.h
+++ b/src/lib/libast/sfio/sfhdr.h
@@ -116,7 +116,6 @@
 
 #define _has_multibyte 1
 
-#define SFMBMAX mbmax()
 #define SFMBCPY(to, fr) (*(Mbstate_t *)(to) = *(fr))
 #define SFMBCLR(mb) mbtinit(((Mbstate_t *)(mb)))
 #define SFMBSET(lhs, v) (lhs = (v))

--- a/src/lib/libast/sfio/sfvscanf.c
+++ b/src/lib/libast/sfio/sfvscanf.c
@@ -210,7 +210,7 @@ static int _sfwaccept(wchar_t wc, Accept_t *ac) {
 
 static int _sfgetwc(Scan_t *sc, wchar_t *wc, int fmt, Accept_t *ac, void *mbs) {
     int n, v;
-    char b[16]; /* assuming that SFMBMAX <= 16! */
+    char b[16]; /* assuming that MB_CUR_MAX <= 16! */
 
 #if 0
     // TODO: Figure out why the author of this code thought this was legal.
@@ -220,7 +220,7 @@ static int _sfgetwc(Scan_t *sc, wchar_t *wc, int fmt, Accept_t *ac, void *mbs) {
 
     /* shift left data so that there will be more room to back up on error.
        this won't help streams with small buffers - c'est la vie! */
-    if (sc->d > sc->f->data && (n = sc->endd - sc->d) > 0 && n < SFMBMAX) {
+    if (sc->d > sc->f->data && (n = sc->endd - sc->d) > 0 && n < MB_CUR_MAX) {
         memcpy(sc->f->data, sc->d, n);
         if (sc->f->endr == sc->f->endb) sc->f->endr = sc->f->data + n;
         if (sc->f->endw == sc->f->endb) sc->f->endw = sc->f->data + n;
@@ -231,7 +231,7 @@ static int _sfgetwc(Scan_t *sc, wchar_t *wc, int fmt, Accept_t *ac, void *mbs) {
     }
 #endif
 
-    for (n = 0; n < SFMBMAX;) {
+    for (n = 0; n < MB_CUR_MAX;) {
         if ((v = _scgetc((void *)sc, 0)) <= 0)
             goto no_match;
         else
@@ -350,7 +350,7 @@ loop_fmt:
             } else {
             match_1:
 #if _has_multibyte
-                if ((n = (int)mbrtowc(&wc, form - 1, SFMBMAX, (mbstate_t *)&fmbs)) <= 0)
+                if ((n = (int)mbrtowc(&wc, form - 1, MB_CUR_MAX, (mbstate_t *)&fmbs)) <= 0)
                     goto pop_fmt;
                 if (n > 1) {
                     acc.wc = wc;

--- a/src/lib/libast/string/utf32stowcs.c
+++ b/src/lib/libast/string/utf32stowcs.c
@@ -89,7 +89,7 @@ ssize_t utf32stowcs(wchar_t *wchar, uint32_t *utf32, size_t n) {
             char *outbuf_start;
             int oerrno;
 
-            outbytesleft = n * mbmax();
+            outbytesleft = n * MB_CUR_MAX;
             outbuf_start = oldof(0, char, (outbytesleft + 2) + (n * UTF8_LEN_MAX + 1), 0);
             if (!outbuf_start) return -1;
             inbuf_start = outbuf_start + outbytesleft + 2;

--- a/src/lib/libast/string/wcstoutf32s.c
+++ b/src/lib/libast/string/wcstoutf32s.c
@@ -63,7 +63,7 @@ ssize_t wcstoutf32s(uint32_t *utf32, wchar_t *wchar, size_t n) {
             if (ast.mb_wc2uc == (iconv_t)-1) ast.mb_wc2uc = NULL;
         }
         if (ast.mb_wc2uc == NULL) return -1;
-        inbytesleft = n * mbmax();
+        inbytesleft = n * MB_CUR_MAX;
         outbytesleft = n * sizeof(uint32_t);
         inbuf_start = oldof(0, char, (inbytesleft + 2) + outbytesleft, 0);
         if (!inbuf_start) return -1;

--- a/src/lib/libcmd/cat.c
+++ b/src/lib/libcmd/cat.c
@@ -163,7 +163,7 @@ static int vcat(char *states, Sfio_t *ip, Sfio_t *op, Reserve_f reserve, int fla
                     ;
                 if (n < T_CONTROL) break;
                 pp = cp - 1;
-                m = mbnsize(pp, MB_LEN_MAX);
+                m = mblen((char *)pp, MB_LEN_MAX);
                 if (m > 1)
                     cp += m - 1;
                 else {
@@ -173,7 +173,7 @@ static int vcat(char *states, Sfio_t *ip, Sfio_t *op, Reserve_f reserve, int fla
                                 *end = last;
                                 last = -1;
                                 c = end - pp + 1;
-                                m = mbnsize(pp, MB_LEN_MAX);
+                                m = mblen((char *)pp, MB_LEN_MAX);
                                 if (m == c) {
                                     any = 1;
                                     if (header) {
@@ -203,7 +203,7 @@ static int vcat(char *states, Sfio_t *ip, Sfio_t *op, Reserve_f reserve, int fla
                                     n = end - cp + 1;
                                     if (n >= (sizeof(tmp) - c)) n = sizeof(tmp) - c - 1;
                                     memcpy(tmp + c, cp, n);
-                                    m = mbnsize(tmp, MB_LEN_MAX);
+                                    m = mblen((char *)tmp, MB_LEN_MAX);
                                     if (m >= c) {
                                         any = 1;
                                         if (header) {

--- a/src/lib/libcmd/cat.c
+++ b/src/lib/libcmd/cat.c
@@ -151,7 +151,6 @@ static int vcat(char *states, Sfio_t *ip, Sfio_t *op, Reserve_f reserve, int fla
     line = 1;
     states[0] = T_ENDBUF;
     raw = !mbwide();
-    if (!raw) mbinit();
     for (;;) {
         cur = cp;
         if (raw)

--- a/src/lib/libcmd/cut.c
+++ b/src/lib/libcmd/cut.c
@@ -379,7 +379,7 @@ static void cutfields(Cut_t *cut, Sfio_t *fdin, Sfio_t *fdout) {
                                 continue;
                             case SP_WIDE:
                                 wp = --cp;
-                                while ((c = mb2wc(w, cp, ep - cp)) <= 0) {
+                                while ((c = mbtowc(&w, (char *)cp, ep - cp)) <= 0) {
                                     /* mb char possibly spanning buffer boundary -- fun stuff */
                                     if ((ep - cp) < mbmax()) {
                                         int i;
@@ -388,7 +388,7 @@ static void cutfields(Cut_t *cut, Sfio_t *fdin, Sfio_t *fdout) {
 
                                         if (lastchar != cut->eob) {
                                             *ep = lastchar;
-                                            c = mb2wc(w, cp, ep - cp);
+                                            c = mbtowc(&w, (char *)cp, ep - cp);
                                             if (c > 0) break;
                                         }
                                         if (copy) {
@@ -409,7 +409,7 @@ static void cutfields(Cut_t *cut, Sfio_t *fdin, Sfio_t *fdout) {
                                         j = i;
                                         k = 0;
                                         while (j < mbmax()) mb[j++] = cp[k++];
-                                        c = mb2wc(w, (char *)mb, j);
+                                        c = mbtowc(&w, (char *)mb, j);
                                         if (c <= 0) {
                                             c = i;
                                             w = 0;

--- a/src/lib/libcmd/cut.c
+++ b/src/lib/libcmd/cut.c
@@ -381,7 +381,7 @@ static void cutfields(Cut_t *cut, Sfio_t *fdin, Sfio_t *fdout) {
                                 wp = --cp;
                                 while ((c = mbtowc(&w, (char *)cp, ep - cp)) <= 0) {
                                     /* mb char possibly spanning buffer boundary -- fun stuff */
-                                    if ((ep - cp) < mbmax()) {
+                                    if ((ep - cp) < MB_CUR_MAX) {
                                         int i;
                                         int j;
                                         int k;
@@ -408,7 +408,7 @@ static void cutfields(Cut_t *cut, Sfio_t *fdin, Sfio_t *fdout) {
                                         if (lastchar != cut->eob) *ep = cut->eob;
                                         j = i;
                                         k = 0;
-                                        while (j < mbmax()) mb[j++] = cp[k++];
+                                        while (j < MB_CUR_MAX) mb[j++] = cp[k++];
                                         c = mbtowc(&w, (char *)mb, j);
                                         if (c <= 0) {
                                             c = i;

--- a/src/lib/libcmd/cut.c
+++ b/src/lib/libcmd/cut.c
@@ -268,7 +268,7 @@ static void cutcols(Cut_t *cut, Sfio_t *fdin, Sfio_t *fdout) {
                 while (w > 0) {
                     if (!(*s & 0x80)) {
                         z = 1;
-                    } else if ((z = mbnsize(s, w)) <= 0) {
+                    } else if ((z = mblen(s, w)) <= 0) {
                         if (s == bp && xx) {
                             w += s - xx;
                             bp = (char *)(s = xx);
@@ -292,7 +292,7 @@ static void cutcols(Cut_t *cut, Sfio_t *fdin, Sfio_t *fdout) {
 
                 while (w > 0 && ncol > 0) {
                     ncol--;
-                    if (!(*s & 0x80) || (z = mbnsize(s, w)) <= 0) z = 1;
+                    if (!(*s & 0x80) || (z = mblen(s, w)) <= 0) z = 1;
                     s += z;
                     w -= z;
                 }

--- a/src/lib/libcmd/wclib.c
+++ b/src/lib/libcmd/wclib.c
@@ -170,7 +170,7 @@ int wc_count(Wc_t *wp, Sfio_t *fd, const char *file) {
     if (wp->mb < 0 && (wp->mode & (WC_MBYTE | WC_WORDS))) {
         cp = buff = endbuff = 0;
         for (;;) {
-            if (cp >= endbuff || (n = mb2wc(x, cp, endbuff - cp)) < 0) {
+            if (cp >= endbuff || (n = mbtowc(&x, (char *)cp, endbuff - cp)) < 0) {
                 o = endbuff - cp;
                 if (o < sizeof(side)) {
                     if (buff) {

--- a/src/lib/libcmd/wclib.c
+++ b/src/lib/libcmd/wclib.c
@@ -175,7 +175,6 @@ int wc_count(Wc_t *wp, Sfio_t *fd, const char *file) {
                 if (o < sizeof(side)) {
                     if (buff) {
                         if (o) memcpy(side, cp, o);
-                        mbinit();
                     } else {
                         o = 0;
                     }


### PR DESCRIPTION
As part of resolving issue #779 these three legacy macros can be removed or replaced by equivalent APIs to simplify the code.