### PR TITLE
Locale shcomp

### DIFF
--- a/src/cmd/ksh93/tests/util/run_test.sh
+++ b/src/cmd/ksh93/tests/util/run_test.sh
@@ -222,7 +222,7 @@ else
     then
         $TEST_DIR/$test_script $test_name < /dev/null
     else
-        $SHCOMP $test_script > $test_script.comp
+        $SHCOMP $test_script > $test_script.comp || exit
         $SHELL $TEST_DIR/$test_script.comp $test_name < /dev/null
     fi
 fi

--- a/src/lib/libast/string/utf32stowcs.c
+++ b/src/lib/libast/string/utf32stowcs.c
@@ -59,7 +59,7 @@ ssize_t utf32stowcs(wchar_t *wchar, uint32_t *utf32, size_t n) {
             if (ast.mb_uc2wc == (iconv_t)-1) ast.mb_uc2wc = NULL;
         }
         if (ast.mb_uc2wc == NULL) return -1;
-        (void)iconv(ast.mb_wc2uc, NULL, NULL, NULL, NULL);
+        (void)iconv(ast.mb_uc2wc, NULL, NULL, NULL, NULL);
         if (n == 1) {
             char tmp_in[UTF8_LEN_MAX + 1];
             char tmp_out[16];


### PR DESCRIPTION
Fail the test if `shcomp` fails. Workaround `iconv()` failing in the `C` locale on some platforms.