### PR TITLE
Remove `mb_xfrm`

### DIFF
--- a/src/lib/libast/comp/setlocale.c
+++ b/src/lib/libast/comp/setlocale.c
@@ -84,7 +84,6 @@ static_fn void init_ast_struct() {
         ast.collate = strcoll;
         ast.mb_alpha = (Isw_f)iswalpha;
         ast.mb_width = wcwidth;
-        ast.mb_xfrm = strxfrm;
     }
 
     if (ast.mb_uc2wc != (iconv_t)-1) {

--- a/src/lib/libast/include/ast.h
+++ b/src/lib/libast/include/ast.h
@@ -158,11 +158,11 @@
 /*
  * multibyte macros
  */
-#define mbcoll() (ast.mb_xfrm != 0)
+#define mbcoll() (1)
 #define mbwide() (MB_CUR_MAX > 1)
 
 #define mbwidth(w) (ast.mb_width ? (*ast.mb_width)(w) : 1)
-#define mbxfrm(t, f, n) (mbcoll() ? (*ast.mb_xfrm)((char *)(t), (char *)(f), n) : 0)
+#define mbxfrm(t, f, n) strxfrm((char *)(t), (char *)(f), n)
 #define mbalpha(w) (ast.mb_alpha ? (*ast.mb_alpha)(w) : isalpha((w)&0xff))
 
 #define mbsrtowcs(w, s, n, q) (*ast._ast_mbsrtowcs)((s), (w), (n), (mbstate_t *)(q))

--- a/src/lib/libast/include/ast_std.h
+++ b/src/lib/libast/include/ast_std.h
@@ -87,7 +87,6 @@ typedef struct {
     int tmp_int;
     void *tmp_pointer;
 
-    size_t (*mb_xfrm)(char *, const char *, size_t);
     int (*mb_width)(wchar_t);
 
     uint32_t env_serial;


### PR DESCRIPTION
The `mb_xfrm` indirection var is no longer needed. The one use in the
`mbcoll()` macro can be eliminated as the test is always true and the
value is now a constant.