### PR TITLE
Fix definition of ERROR_translating macro

### DIFF
--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -78,7 +78,7 @@ all_tests = [
     ['alias'], ['append'], ['arith'], ['arrays'], ['arrays2'], ['attributes'],
     ['basic', 90], ['bracket'], ['builtins'], ['case'], ['comvar'],
     ['comvario'], ['coprocess', 50], ['cubetype'], ['directoryfd'], ['enum'],
-    ['exit'], ['expand'], ['functions'], ['glob'], ['grep'], ['heredoc'], ['ifs'],
+    ['exit'], ['expand'], ['functions'], ['glob'], ['grep'], ['getopts'], ['heredoc'], ['ifs'],
     ['io'], ['jobs'], ['leaks'], ['locale'], ['math', 50], ['nameref'], ['namespace'],
     ['modifiers'], ['options'], ['path'], ['pointtype'], ['printf'], ['quoting'],
     ['quoting2'], ['read'], ['readcsv'], ['recttype'], ['restricted'], ['return'],

--- a/src/cmd/ksh93/tests/getopts.sh
+++ b/src/cmd/ksh93/tests/getopts.sh
@@ -1,0 +1,14 @@
+# Regression tests
+# https://github.com/att/ast/issues/851
+out=$(getopts -a test $'
+[-]
+[foo?option 1]
+[bar?option 2]
+
+Use option 1
+Use option 2
+
+' baz '--help' 2>&1)
+
+[[ "$out" = $'Usage: test [ options ] Use option 1\n   Or: test [ options ] Use option 2' ]] ||
+    log_error "getopts shows wrong text for self documenting options"

--- a/src/cmd/tests/opt.c
+++ b/src/cmd/tests/opt.c
@@ -101,6 +101,7 @@ int main(int argc, char **argv) {
             str = 1;
         } else if (!strcmp(command, "-+")) {
             argv++;
+            ast.locale.set |= (1 << LC_MESSAGES);
             error_info.translate = translate;
         } else if (!strcmp(command, "+") && *(argv + 2)) {
             ext += 2;

--- a/src/lib/libast/include/error.h
+++ b/src/lib/libast/include/error.h
@@ -50,7 +50,7 @@
 #endif
 
 #ifndef ERROR_translate
-#define ERROR_translating() error_info.translate
+#define ERROR_translating() (error_info.translate && (ast.locale.set & (1 << LC_MESSAGES)))
 #define ERROR_translate(l, i, d, m)                                                           \
     (ERROR_translating()                                                                      \
          ? errorx((const char *)(l), (const char *)(i), (const char *)(d), (const char *)(m)) \


### PR DESCRIPTION
There was a regression introduced by changes in ce5dabe and d2aa35f that
deal with removing AST specific locale subsystem. Fix it by using
standard `LC_MESSAGES` symbol.

Resolves: #851