### PR TITLE
Remove preprocessor symbol ERROR_CATALOG

### DIFF
--- a/src/cmd/ksh93/bltins/enum.c
+++ b/src/cmd/ksh93/bltins/enum.c
@@ -274,7 +274,7 @@ int b_enum(int argc, char **argv, Shbltin_t *context) {
         Namval_t *np;
     } optdisc;
 
-    if (cmdinit(argc, argv, context, ERROR_CATALOG, ERROR_NOTIFY)) return -1;
+    if (cmdinit(argc, argv, context, ERROR_NOTIFY)) return -1;
     for (;;) {
         switch (optget(argv, enum_usage)) {
             case 'p': {

--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -25,24 +25,13 @@ shared_c_args += [
     '-DAUDIT_FILE=' + '"@0@"'.format(get_option('audit-file'))
 ]
 
-# TODO: Figure out why there is a different definition of these symbols for
-# ksh93 versus shcomp and if there is a good reason add a comment why they are
-# defined differently.
-ksh93_c_args = shared_c_args + [
-    '-DERROR_CATALOG=NULL',
-]
-
-shcomp_c_args = shared_c_args + [
-    '-DERROR_CATALOG="libshell"',
-]
-
-ksh93_exe = executable('ksh', ksh93_files, c_args: ksh93_c_args,
+ksh93_exe = executable('ksh', ksh93_files, c_args: shared_c_args,
     include_directories: [configuration_incdir, ksh93_incdir],
     link_with: [libast, libcmd, libcoshell, libdll],
     dependencies: [libm_dep, libexecinfo_dep, libdl_dep],
     install: true)
 
-shcomp_exe = executable('shcomp', shcomp_files, c_args: shcomp_c_args ,
+shcomp_exe = executable('shcomp', shcomp_files, c_args: shared_c_args,
     include_directories: [configuration_incdir, ksh93_incdir],
     link_with: [ libast, libcmd, libcoshell, libdll],
     dependencies: [libm_dep, libexecinfo_dep, libdl_dep],

--- a/src/lib/libast/include/shcmd.h
+++ b/src/lib/libast/include/shcmd.h
@@ -84,6 +84,6 @@ struct Shbltin_s {
 #endif  // defined(SFIO_VERSION) || defined(_AST_H)
 #endif  // defined(SH_VERSION) || defined(_SH_PRIVATE)
 
-extern int cmdinit(int, char **, Shbltin_t *, const char *, int);
+extern int cmdinit(int, char **, Shbltin_t *, int);
 
 #endif  // _SHCMD_H

--- a/src/lib/libast/misc/error.c
+++ b/src/lib/libast/misc/error.c
@@ -98,7 +98,6 @@ static struct State_s {
     regex_t *match;
 } error_state;
 
-#undef ERROR_CATALOG
 #define ERROR_CATALOG (ERROR_LIBRARY << 1)
 
 #define OPT_BREAK 1

--- a/src/lib/libcmd/basename.c
+++ b/src/lib/libcmd/basename.c
@@ -100,7 +100,7 @@ int b_basename(int argc, char **argv, Shbltin_t *context) {
     char *suffix = 0;
     int all = 0;
 
-    if (cmdinit(argc, argv, context, ERROR_CATALOG, 0)) return -1;
+    if (cmdinit(argc, argv, context, 0)) return -1;
     for (;;) {
         switch (optget(argv, usage)) {
             case 'a':

--- a/src/lib/libcmd/cat.c
+++ b/src/lib/libcmd/cat.c
@@ -365,7 +365,7 @@ int b_cat(int argc, char **argv, Shbltin_t *context) {
     int dovcat = 0;
     char states[UCHAR_MAX + 1];
 
-    if (cmdinit(argc, argv, context, ERROR_CATALOG, 0)) return -1;
+    if (cmdinit(argc, argv, context, 0)) return -1;
     att = !strcmp(astconf("UNIVERSE", NULL, NULL), "att");
     mode = "r";
     for (;;) {

--- a/src/lib/libcmd/chmod.c
+++ b/src/lib/libcmd/chmod.c
@@ -171,7 +171,7 @@ int b_chmod(int argc, char **argv, Shbltin_t *context) {
     struct stat st;
     int recursive = 0;
 
-    if (cmdinit(argc, argv, context, ERROR_CATALOG, ERROR_NOTIFY)) return -1;
+    if (cmdinit(argc, argv, context, ERROR_NOTIFY)) return -1;
     flags = fts_flags() | FTS_COMFOLLOW;
 
     /*

--- a/src/lib/libcmd/cmdinit.c
+++ b/src/lib/libcmd/cmdinit.c
@@ -29,7 +29,7 @@
 #include "option.h"
 #include "shcmd.h"
 
-int cmdinit(int argc, char **argv, Shbltin_t *context, const char *catalog, int flags) {
+int cmdinit(int argc, char **argv, Shbltin_t *context, int flags) {
     char *cp;
 
     if (argc <= 0) return -1;
@@ -47,7 +47,6 @@ int cmdinit(int argc, char **argv, Shbltin_t *context, const char *catalog, int 
         cp = argv[0];
     }
     error_info.id = cp;
-    if (!error_info.catalog) error_info.catalog = catalog;
     opt_info.index = 0;
     return 0;
 }

--- a/src/lib/libcmd/cmp.c
+++ b/src/lib/libcmd/cmp.c
@@ -246,7 +246,7 @@ int b_cmp(int argc, char **argv, Shbltin_t *context) {
     Sfoff_t differences = -1;
     int flags = 0;
 
-    if (cmdinit(argc, argv, context, ERROR_CATALOG, 0)) return -1;
+    if (cmdinit(argc, argv, context, 0)) return -1;
     for (;;) {
         switch (optget(argv, usage)) {
             case 'b':

--- a/src/lib/libcmd/cut.c
+++ b/src/lib/libcmd/cut.c
@@ -519,7 +519,7 @@ int b_cut(int argc, char **argv, Shbltin_t *context) {
     Delim_t ldelim = {NULL, 0, 0};
     size_t reclen = 0;
 
-    if (cmdinit(argc, argv, context, ERROR_CATALOG, 0)) return -1;
+    if (cmdinit(argc, argv, context, 0)) return -1;
     wdelim.chr = '\t';
     ldelim.chr = '\n';
     wdelim.len = ldelim.len = 1;

--- a/src/lib/libcmd/dirname.c
+++ b/src/lib/libcmd/dirname.c
@@ -103,7 +103,7 @@ int b_dirname(int argc, char **argv, Shbltin_t *context) {
     int mode = 0;
     char buf[PATH_MAX];
 
-    if (cmdinit(argc, argv, context, ERROR_CATALOG, 0)) return -1;
+    if (cmdinit(argc, argv, context, 0)) return -1;
     for (;;) {
         switch (optget(argv, usage)) {
             case 'f':

--- a/src/lib/libcmd/getconf.c
+++ b/src/lib/libcmd/getconf.c
@@ -164,7 +164,7 @@ int b_getconf(int argc, char **argv, Shbltin_t *context) {
     static const char empty[] = "-";
     static const Path_t equiv[] = {{"/bin", 4}, {"/usr/bin", 8}};
 
-    if (cmdinit(argc, argv, context, ERROR_CATALOG, 0)) return -1;
+    if (cmdinit(argc, argv, context, 0)) return -1;
     oargv = argv;
     native = astconf("GETCONF", NULL, NULL);
     if (*native != '/') native = 0;

--- a/src/lib/libcmd/head.c
+++ b/src/lib/libcmd/head.c
@@ -84,7 +84,7 @@ int b_head(int argc, char **argv, Shbltin_t *context) {
     int header = 1;
     char *format = (char *)header_fmt + 1;
 
-    if (cmdinit(argc, argv, context, ERROR_CATALOG, 0)) return -1;
+    if (cmdinit(argc, argv, context, 0)) return -1;
     for (;;) {
         switch (optget(argv, usage)) {
             case 'c':

--- a/src/lib/libcmd/logname.c
+++ b/src/lib/libcmd/logname.c
@@ -55,7 +55,7 @@ int b_logname(int argc, char **argv, Shbltin_t *context) {
     char *logname;
     char buf[12];
 
-    if (cmdinit(argc, argv, context, ERROR_CATALOG, 0)) return -1;
+    if (cmdinit(argc, argv, context, 0)) return -1;
     for (;;) {
         switch (optget(argv, usage)) {
             case ':':

--- a/src/lib/libcmd/meson.build
+++ b/src/lib/libcmd/meson.build
@@ -6,7 +6,6 @@ libcmd_files += [ 'basename.c', 'chmod.c', 'dirname.c', 'head.c', 'getconf.c', '
 
 libcmd_c_args = shared_c_args + [
     '-DUSAGE_LICENSE=""',
-    '-DERROR_CATALOG=0',
 ]
 
 incdir = include_directories('../libast/include')

--- a/src/lib/libcmd/mkdir.c
+++ b/src/lib/libcmd/mkdir.c
@@ -78,7 +78,7 @@ int b_mkdir(int argc, char **argv, Shbltin_t *context) {
     mode_t dmode;
     struct stat st;
 
-    if (cmdinit(argc, argv, context, ERROR_CATALOG, 0)) return -1;
+    if (cmdinit(argc, argv, context, 0)) return -1;
     for (;;) {
         switch (optget(argv, usage)) {
             case 'm':

--- a/src/lib/libcmd/sync.c
+++ b/src/lib/libcmd/sync.c
@@ -74,7 +74,7 @@ int b_sync(int argc, char **argv, Shbltin_t *context) {
     bool do_sfsync = 0;
     bool do_sync = 0;
 
-    if (cmdinit(argc, argv, context, ERROR_CATALOG, 0)) return -1;
+    if (cmdinit(argc, argv, context, 0)) return -1;
     for (;;) {
         switch (optget(argv, optsync)) {
             case 'f':

--- a/src/lib/libcmd/uname.c
+++ b/src/lib/libcmd/uname.c
@@ -158,7 +158,7 @@ int b_uname(int argc, char **argv, Shbltin_t *context) {
     struct utsname ut;
     char buf[257];
 
-    if (cmdinit(argc, argv, context, ERROR_CATALOG, 0)) return -1;
+    if (cmdinit(argc, argv, context, 0)) return -1;
     for (;;) {
         switch (optget(argv, usage)) {
             case 'a':

--- a/src/lib/libcmd/wc.c
+++ b/src/lib/libcmd/wc.c
@@ -90,7 +90,7 @@ int b_wc(int argc, char **argv, Shbltin_t *context) {
     Sfoff_t tlines = 0, twords = 0, tchars = 0;
     struct stat statb;
 
-    if (cmdinit(argc, argv, context, ERROR_CATALOG, 0)) return -1;
+    if (cmdinit(argc, argv, context, 0)) return -1;
     for (;;) {
         switch (optget(argv, usage)) {
             case 'c':


### PR DESCRIPTION
This symbol no longer has any effect on either the ksh or shcomp
programs. Remove it.

Related #866