### PR TITLE
Don't return a pointer to a stack var

### DIFF
--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -1666,7 +1666,7 @@ void nv_putval(Namval_t *np, const void *vp, int flags) {
                 if (oldsize) memcpy((void *)cp, (void *)up->cp, oldsize);
                 up->sp = cp;
                 if (size <= oldsize) return;
-                dot = base64decode(sp, dot, NULL, cp + oldsize, size - oldsize, NULL);
+                dot = base64decode(sp, dot, NULL, cp + oldsize, size - oldsize);
                 dot += oldsize;
                 if (!nv_isattr(np, NV_ZFILL) || nv_size(np) == 0) {
                     nv_setsize(np, dot);
@@ -2425,8 +2425,7 @@ done:
     if (up->cp && nv_isattr(np, NV_BINARY) && !nv_isattr(np, NV_RAW)) {
         int size = nv_size(np), insize = (4 * size) / 3 + size / 45 + 8;
         char *cp = getbuf(insize);
-        char *ep;
-        base64encode(up->cp, size, NULL, cp, insize, (void **)&ep);
+        base64encode(up->cp, size, NULL, cp, insize);
         return cp;
     }
 

--- a/src/cmd/tests/base64.c
+++ b/src/cmd/tests/base64.c
@@ -25,7 +25,7 @@
 #include <string.h>
 #include <sys/types.h>
 
-#include "ast.h"
+#include "ast.h"  // IWYU pragma: keep
 #include "sfio.h"
 
 int main() {
@@ -49,13 +49,13 @@ int main() {
     for (i = 0; i < sizeof(dat) - 1; i++) {
         testno++;
         if (i > 0) {
-            l = base64encode(dat, i, NULL, buf, sizeof(buf), NULL);
+            l = base64encode(dat, i, NULL, buf, sizeof(buf));
             if (l < 0 || l > sizeof(buf)) {
                 errors++;
                 sfprintf(sfstdout, "test %02d left buffer encode size %ld failed\n", testno, l);
                 continue;
             }
-            t = base64decode(buf, l, NULL, tst, sizeof(tst), NULL);
+            t = base64decode(buf, l, NULL, tst, sizeof(tst));
             if (t != i) {
                 errors++;
                 sfprintf(sfstdout, "test %02d left buffer decode size %ld failed\n", testno, t);
@@ -68,13 +68,13 @@ int main() {
             }
         } else
             l = 0;
-        r = base64encode(dat + i, sizeof(dat) - i, NULL, buf + l, sizeof(buf) - l, NULL);
+        r = base64encode(dat + i, sizeof(dat) - i, NULL, buf + l, sizeof(buf) - l);
         if (r < 0 || r > sizeof(buf) - l) {
             errors++;
             sfprintf(sfstdout, "test %02d right buffer encode size %ld failed\n", testno, r);
             continue;
         }
-        t = base64decode(buf + l, r, NULL, tst, sizeof(tst), NULL);
+        t = base64decode(buf + l, r, NULL, tst, sizeof(tst));
         if (t != (sizeof(dat) - i)) {
             errors++;
             sfprintf(sfstdout, "test %02d total buffer decode size %ld failed\n", testno, t);
@@ -85,7 +85,7 @@ int main() {
             sfprintf(sfstdout, "test %02d right buffer decode failed\n", testno);
             continue;
         }
-        t = base64decode(buf, l + r, NULL, tst, sizeof(tst), NULL);
+        t = base64decode(buf, l + r, NULL, tst, sizeof(tst));
         if (t != sizeof(dat)) {
             errors++;
             sfprintf(sfstdout, "test %02d total buffer decode size %ld failed\n", testno, t);
@@ -101,7 +101,7 @@ int main() {
         testno++;
         memset(tst, '*', sizeof(pat));
         tst[sizeof(pat) - 1] = 0;
-        t = base64decode(en, sizeof(en) - 1, NULL, tst, r, NULL);
+        t = base64decode(en, sizeof(en) - 1, NULL, tst, r);
         if (t != (sizeof(de) - 1)) {
             sfprintf(sfstdout, "decode size %r failed, %r expected\n", t, sizeof(de) - 1);
             errors++;

--- a/src/cmd/tests/meson.build
+++ b/src/cmd/tests/meson.build
@@ -1,18 +1,20 @@
-test_files = [ 'base64.c', 'opt.c', 'strelapsed.c' ]
+misc_test_files = [ 'base64.c', 'opt.c', 'strelapsed.c' ]
 
 incdir = include_directories('../../lib/libast/include/')
 
-foreach file: test_files
-    test_target = executable(file, file, c_args: shared_c_args,
-                             include_directories: [configuration_incdir, incdir],
-                             link_with: [libast, libenv],
-                             install: false)
-    # TODO: Enable these test cases.
+foreach file: misc_test_files
+    misc_test_target = executable(file, file, c_args: shared_c_args,
+                                  include_directories: [configuration_incdir, incdir],
+                                  link_with: [libast, libenv],
+                                  install: false)
+    # TODO: Enable all these test cases.
     #
     # For the moment we only build the programs to verify they can be built and to enable linting
     # them. Running the tests will require converting the *.rt and *.tst files into scripts.
     #
-    # test('API/' + file, test_target)
+    if file == 'base64.c'
+        test('API/' + file, misc_test_target)
+    endif
 endforeach
 
 subdir('aso')

--- a/src/lib/libast/include/ast.h
+++ b/src/lib/libast/include/ast.h
@@ -197,8 +197,8 @@ extern Ast_confdisc_f astconfdisc(Ast_confdisc_f);
 extern void astconflist(Sfio_t *, const char *, int, const char *);
 extern void astwinsize(int, int *, int *);
 
-extern ssize_t base64encode(const void *, size_t, void **, void *, size_t, void **);
-extern ssize_t base64decode(const void *, size_t, void **, void *, size_t, void **);
+extern ssize_t base64encode(const void *, size_t, void **, void *, size_t);
+extern ssize_t base64decode(const void *, size_t, void **, void *, size_t);
 extern int chresc(const char *, char **);
 extern int chrexp(const char *, char **, int *, int);
 extern char *conformance(const char *, size_t);

--- a/src/lib/libast/string/base64.c
+++ b/src/lib/libast/string/base64.c
@@ -32,6 +32,8 @@
 #include <string.h>
 #include <sys/types.h>
 
+#include "ast.h"  // IWYU pragma: keep
+
 #define PAD '='
 
 #define B64_UC 3
@@ -49,7 +51,7 @@ static const char alp[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0
  * mime base64 encode
  */
 
-ssize_t base64encode(const void *fb, size_t fz, void **fn, void *tb, size_t tz, void **tn) {
+ssize_t base64encode(const void *fb, size_t fz, void **fn, void *tb, size_t tz) {
     unsigned char *fp;
     unsigned char *tp;
     unsigned char *fe;
@@ -73,7 +75,6 @@ ssize_t base64encode(const void *fb, size_t fz, void **fn, void *tb, size_t tz, 
         n = 0;
     } else {
         if (fn) *fn = fp;
-        if (tn) *tn = 0;
         tp = tmp;
         te = tp + sizeof(tmp) - B64_EC + 1;
         n = 1;
@@ -84,7 +85,6 @@ ssize_t base64encode(const void *fb, size_t fz, void **fn, void *tb, size_t tz, 
             if (fp >= fe) goto done;
             if (tp >= te) {
                 if (fn) *fn = fp;
-                if (tn) *tn = tp;
                 n = tp - (unsigned char *)tb + 1;
                 tp = tmp;
                 te = tp + sizeof(tmp) - B64_EC + 1;
@@ -107,7 +107,6 @@ done:
     if (fz) {
         if (tp >= te) {
             if (fn) *fn = fp;
-            if (tn) *tn = tp;
             n = tp - (unsigned char *)tb + 1;
             tp = tmp;
             te = tp + sizeof(tmp) - B64_EC + 1;
@@ -119,13 +118,12 @@ done:
         *tp++ = (fz == 2) ? m[(b >> 6) & 077] : PAD;
         *tp++ = PAD;
     }
-    if (n)
+    if (n) {
         n += (tp - tmp) - 1;
-    else {
-        if (tp > (unsigned char *)tb && *(tp - 1) == '\n') tp--;
+    } else {
+        if (tp != tmp && tp > (unsigned char *)tb && *(tp - 1) == '\n') tp--;
         if (tp < te) *tp = 0;
         n = tp - (unsigned char *)tb;
-        if (tn) *tn = tp;
         if (fn) *fn = fp;
     }
     return n;
@@ -135,7 +133,7 @@ done:
  * mime base64 decode
  */
 
-ssize_t base64decode(const void *fb, size_t fz, void **fn, void *tb, size_t tz, void **tn) {
+ssize_t base64decode(const void *fb, size_t fz, void **fn, void *tb, size_t tz) {
     unsigned char *fp;
     unsigned char *tp;
     unsigned char *fe;
@@ -187,7 +185,6 @@ ssize_t base64decode(const void *fb, size_t fz, void **fn, void *tb, size_t tz, 
                                     if (tp < te) *tp++ = (v);
                                 }
                             }
-                            if (tn) *tn = tp;
                             if (fn) *fn = fc;
                         }
                     } else {
@@ -212,7 +209,6 @@ ssize_t base64decode(const void *fb, size_t fz, void **fn, void *tb, size_t tz, 
                     n++;
                 else {
                     n = tp - (unsigned char *)tb + 2;
-                    if (tn) *tn = tp;
                     if (fn) *fn = fc;
                 }
                 break;
@@ -223,14 +219,12 @@ ssize_t base64decode(const void *fb, size_t fz, void **fn, void *tb, size_t tz, 
                         *tp++ = v >> 2;
                     else {
                         n = tp - (unsigned char *)tb + 2;
-                        if (tn) *tn = tp;
                         if (fn) *fn = fc;
                     }
                 } else if (n)
                     n += 2;
                 else {
                     n = tp - (unsigned char *)tb + 3;
-                    if (tn) *tn = tp;
                     if (fn) *fn = fc;
                 }
                 break;
@@ -247,7 +241,6 @@ done:
         if (tp < te) *tp = 0;
         n = tp - (unsigned char *)tb;
         if (fn) *fn = fp;
-        if (tn) *tn = tp;
     }
     return n;
 }


### PR DESCRIPTION
Coverity Scan pointed out that it is possible for `base64encode()` to
assign the address of `tmp` to the `tn` argument. Since no users of this
function actually use the `tn` parameter just remove it.

This also fixes a related failure mode that clang static analysis
identified after removing `tn`:

src/lib/libast/string/base64.c:124:51: The left operand of '==' is a
garbage value

So predicate that test on `tp != tmp`.

This also enables running the API/base64.c unit test.

CID#253637
Fixes #890