### PR TITLE
Remove symbol _shtest_c

### DIFF
--- a/src/cmd/ksh93/bltins/test.c
+++ b/src/cmd/ksh93/bltins/test.c
@@ -24,7 +24,6 @@
 //   David Korn
 //   AT&T Labs
 //
-#define _shtest_c
 #include "config_ast.h"  // IWYU pragma: keep
 
 #include <ctype.h>
@@ -576,8 +575,7 @@ int test_inode(const char *file1, const char *file2) {
 }
 
 //
-// This version of access checks against effective uid/gid. The static buffer statb is shared with
-// test_mode.
+// This version of access checks against effective uid/gid.
 //
 int sh_access(const char *name, int mode) {
     Shell_t *shp = sh_getinterp();

--- a/src/cmd/ksh93/include/shell.h
+++ b/src/cmd/ksh93/include/shell.h
@@ -389,12 +389,6 @@ extern Shell_t sh;
 #undef stat
 #define stat(a, b) sh_stat(a, b)
 #endif
-#ifndef _shtest_c
-#ifndef _SH_PRIVATE
-#undef access
-#define access(a, b) sh_access(a, b)
-#endif
-#endif  // !_shtest_c
 #ifndef _shio_h
 #undef chdir
 #define chdir(a) sh_chdir(a)
@@ -414,8 +408,6 @@ extern Shell_t sh;
 #endif
 #endif
 #ifndef _SH_PRIVATE
-#undef access
-#define access(a, b) sh_access(a, b)
 #undef close
 #define close(a) sh_close(a)
 #if SHELLAPI(20120720)


### PR DESCRIPTION
While working on another change I noticed preprocessor symbol
`_shtest_c`. It is completely superfluous. It's sole purpose is to
ensure calls to `access()` don't get translated to `sh_access()` inside
that function, thus creating unwanted recursion. It turns out there are
no places which need

    #define access(a, b) sh_access(a, b)

All the places which need it simply call `sh_accss()` directly. So just
remove that macro as well as the puzzling `_shtest_c` symbol.