### PR TITLE
Remove preprocessor symbol USE_REALLOC

### DIFF
--- a/features/meson.build
+++ b/features/meson.build
@@ -56,6 +56,8 @@ feature_data.set10('_hdr_execinfo', cc.has_header('execinfo.h', args: feature_te
 feature_data.set10('_hdr_unistd', cc.has_header('unistd.h', args: feature_test_args))
 feature_data.set10('_hdr_stdlib', cc.has_header('stdlib.h', args: feature_test_args))
 feature_data.set10('_hdr_malloc', cc.has_header('malloc.h', args: feature_test_args))
+feature_data.set10('_hdr_filio', cc.has_header('filio.h', args: feature_test_args))
+feature_data.set10('_sys_filio', cc.has_header('sys/filio.h', args: feature_test_args))
 
 feature_data.set10('_lib_sigqueue',
     cc.has_function('sigqueue', prefix: '#include <signal.h>', args: feature_test_args))

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -154,6 +154,7 @@ static_fn bool iousepipe(Shell_t *shp) {
     if (!sh_iovalidfd(shp, subpipe[2])) abort();
     shp->fdstatus[subpipe[2]] = shp->fdstatus[1];
     close(fd);
+    // cppcheck-suppress deallocuse // it's okay to use fd in the fcntl() even though it is closed
     fcntl(subpipe[1], F_DUPFD, fd);
     shp->fdstatus[1] = shp->fdstatus[subpipe[1]] & ~IOCLEX;
     sh_close(subpipe[1]);
@@ -183,6 +184,7 @@ void sh_iounpipe(Shell_t *shp) {
         goto done;
     }
     close(fd);
+    // cppcheck-suppress deallocuse // it's okay to use fd in the fcntl() even though it is closed
     fcntl(subpipe[2], F_DUPFD, fd);
     shp->fdstatus[1] = shp->fdstatus[subpipe[2]];
     if (subdup) {

--- a/src/cmd/ksh93/tests/types.sh
+++ b/src/cmd/ksh93/tests/types.sh
@@ -711,7 +711,8 @@ typeset -T baz_t=(
 )
 baz_t z
 [[ ${z.z} == 789 ]] || log_error "z.z is ${z.z} should be 789"
-[[ ${ z.out } == "$out" ]] 2> /dev/null || log_error "z.out should be $out"
+[[ ${ z.out } == "$out" ]] 2> /dev/null || log_error "z.out wrong" "$out" "${ z.out }"
+typeset -p z >&2
 
 $SHELL  2> /dev/null <<- \EOF || log_error 'typeset -p with types not working'
 	typeset -T Man_t=( typeset X)

--- a/src/lib/libast/sfio/sfclose.c
+++ b/src/lib/libast/sfio/sfclose.c
@@ -24,6 +24,7 @@
 #include <errno.h>
 #include <stdlib.h>
 
+#include "ast_assert.h"
 #include "sfhdr.h"
 #include "vthread.h"
 
@@ -86,7 +87,7 @@ int sfclose(Sfio_t *f) {
             POOLMTXUNLOCK(&_Sfpool);
         } else {
             f->mode &= ~SF_LOCK; /**/
-            ASSERT(_Sfpmove);
+            assert(_Sfpmove);
             if ((*_Sfpmove)(f, -1) < 0) {
                 SFOPEN(f)
                 SFMTXRETURN(f, -1)

--- a/src/lib/libast/sfio/sfhdr.h
+++ b/src/lib/libast/sfio/sfhdr.h
@@ -211,9 +211,6 @@
 #define X_OK 01
 #endif
 
-/* to get rid of pesky compiler warnings */
-#define NOTUSED(x) (void)(x)
-
 /* Private flags in the "bits" field */
 #define SF_MMAP 00000001       /* in memory mapping mode		*/
 #define SF_BOTH 00000002       /* both read/write			*/
@@ -561,13 +558,6 @@ typedef struct _sfextern_s {
 #define SF_NMAP 1024
 #else
 #define SF_NMAP 32
-#endif
-
-#ifndef MAP_VARIABLE
-#define MAP_VARIABLE 0
-#endif
-#ifndef _mmap_fixed
-#define _mmap_fixed 0
 #endif
 
 /* set/unset sequential states for mmap */

--- a/src/lib/libast/sfio/sfhdr.h
+++ b/src/lib/libast/sfio/sfhdr.h
@@ -252,12 +252,6 @@
 #define SF_AVAIL 00020000  /* was closed, available for reuse	*/
 #define SF_LOCAL 00100000  /* sentinel for a local call		*/
 
-#ifdef DEBUG
-#define ASSERT(p) ((p) ? 0 : (abort(), 0))
-#else
-#define ASSERT(p)
-#endif
-
 /* short-hands */
 #ifndef uchar
 #define uchar unsigned char
@@ -271,8 +265,6 @@
 #ifndef ushort
 #define ushort unsigned short
 #endif
-
-#define SECOND 1000 /* millisecond units */
 
 /* macros do determine stream types from sfstat_t data */
 #ifndef S_IFDIR

--- a/src/lib/libast/sfio/sfmutex.c
+++ b/src/lib/libast/sfio/sfmutex.c
@@ -32,8 +32,8 @@
 /* the main locking/unlocking interface */
 int sfmutex(Sfio_t *f, int type) {
 #if !vt_threaded
-    NOTUSED(f);
-    NOTUSED(type);
+    UNUSED(f);
+    UNUSED(type);
     return 0;
 #else
 

--- a/src/lib/libast/sfio/sfpkrd.c
+++ b/src/lib/libast/sfio/sfpkrd.c
@@ -154,8 +154,8 @@ ssize_t sfpkrd(int fd, void *argbuf, size_t n, int rc, long tm, int action) {
                     tmp = NULL;
                 else {
                     tmp = &tmb;
-                    tmb.tv_sec = tm / SECOND;
-                    tmb.tv_usec = (tm % SECOND) * SECOND;
+                    tmb.tv_sec = tm / 1000;
+                    tmb.tv_usec = (tm % 1000) * 1000;
                 }
                 r = select(fd + 1, &rd, NULL, NULL, tmp);
                 if (r < 0) {

--- a/src/lib/libast/sfio/sfpoll.c
+++ b/src/lib/libast/sfio/sfpoll.c
@@ -182,8 +182,8 @@ int sfpoll(Sfio_t **fa, int n, int tm) {
             tmp = NULL;
         else {
             tmp = &tmb;
-            tmb.tv_sec = tm / SECOND;
-            tmb.tv_usec = (tm % SECOND) * SECOND;
+            tmb.tv_sec = tm / 1000;
+            tmb.tv_usec = (tm % 1000) * 1000;
         }
 
         while ((np = select(m + 1, &rd, &wr, NULL, tmp)) < 0) {

--- a/src/lib/libast/sfio/sfpool.c
+++ b/src/lib/libast/sfio/sfpool.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "ast_assert.h"
 #include "sfhdr.h"
 #include "vthread.h"
 
@@ -109,7 +110,7 @@ static_fn int _sfphead(Sfpool_t *p, Sfio_t *f, int n) {
     } else /* shared pool of write-streams, data can be moved among streams */
     {
         if (SFMODE(head, 1) != SF_WRITE && _sfmode(head, SF_WRITE, 1) < 0) goto done;
-        /**/ ASSERT(f->next == f->data);
+        assert(f->next == f->data);
 
         v = head->next - head->data; /* pending data		*/
         if ((k = v - (f->endb - f->data)) <= 0)
@@ -293,7 +294,7 @@ Sfio_t *sfpool(Sfio_t *f, Sfio_t *pf, int mode) {
     f->pool = p; /* add f to pf's pool */
     if (_sfsetpool(f) < 0) goto done;
 
-    /**/ ASSERT(p->sf[0] == pf && p->sf[p->n_sf - 1] == f);
+    assert(p->sf[0] == pf && p->sf[p->n_sf - 1] == f);
     SFOPEN(pf)
     SFOPEN(f)
     if (_sfpmove(f, 0) < 0) /* make f head of pool */

--- a/src/lib/libast/sfio/sftmp.c
+++ b/src/lib/libast/sfio/sftmp.c
@@ -65,7 +65,7 @@ static File_t *File; /* list pf temp files	*/
 static_fn int _tmprmfile(Sfio_t *f, int type, void *val, Sfdisc_t *disc) {
     File_t *ff, *last;
 
-    NOTUSED(val);
+    UNUSED(val);
 
     if (type == SF_DPOP) /* don't allow this to pop */
         return -1;
@@ -148,7 +148,7 @@ static_fn int _tmpexcept(Sfio_t *f, int type, void *val, Sfdisc_t *disc) {
     Sfio_t newf, savf;
     Sfnotify_f notify = _Sfnotify;
 
-    NOTUSED(val);
+    UNUSED(val);
 
     /* the discipline needs to change only under the following exceptions */
     if (type != SF_WRITE && type != SF_SEEK && type != SF_DPUSH && type != SF_DPOP &&

--- a/src/lib/libast/sfio/sfungetc.c
+++ b/src/lib/libast/sfio/sfungetc.c
@@ -33,7 +33,7 @@
 **	Written by Kiem-Phong Vo.
 */
 static_fn int _uexcept(Sfio_t *f, int type, void *val, Sfdisc_t *disc) {
-    NOTUSED(val);
+    UNUSED(val);
 
     /* hmm! This should never happen */
     if (disc != _Sfudisc) return -1;


### PR DESCRIPTION
Also simplify the code to ignore requests for small stacks and instead
just use a smaller, fixed, size to round the stack size. This leaves
the STAK_SMALL and STK_SMALL symbols just in case we decide that the
distinction really does matter.

Fixes #896