### PR TITLE
Lint: SFOPEN() definition is confusing

### DIFF
--- a/src/lib/libast/sfio/_sfputd.c
+++ b/src/lib/libast/sfio/_sfputd.c
@@ -65,7 +65,7 @@ int _sfputd(Sfio_t *f, Sfdouble_t v) {
     }
 
     /* write out the signs and the exp */
-    SFOPEN(f, 0);
+    SFOPEN(f);
     if (sfputc(f, n) < 0 || (w = sfputu(f, w)) < 0) SFMTXRETURN(f, -1);
     SFLOCK(f, 0);
     w += 1;
@@ -86,6 +86,6 @@ int _sfputd(Sfio_t *f, Sfdouble_t v) {
     n = ends - s + 1;
     w = SFWRITE(f, (void *)s, n) == n ? w + n : -1;
 
-    SFOPEN(f, 0);
+    SFOPEN(f);
     SFMTXRETURN(f, w);
 }

--- a/src/lib/libast/sfio/_sfputl.c
+++ b/src/lib/libast/sfio/_sfputl.c
@@ -88,6 +88,6 @@ int _sfputl(Sfio_t *f, Sflong_t v) {
         f->next = ps;
     }
 
-    SFOPEN(f, 0);
+    SFOPEN(f);
     SFMTXRETURN(f, n);
 }

--- a/src/lib/libast/sfio/_sfputm.c
+++ b/src/lib/libast/sfio/_sfputm.c
@@ -84,6 +84,6 @@ int _sfputm(Sfio_t *f, Sfulong_t v, Sfulong_t m) {
         f->next = ps;
     }
 
-    SFOPEN(f, 0);
+    SFOPEN(f);
     SFMTXRETURN(f, (int)n);
 }

--- a/src/lib/libast/sfio/_sfputu.c
+++ b/src/lib/libast/sfio/_sfputu.c
@@ -81,6 +81,6 @@ int _sfputu(Sfio_t *f, Sfulong_t v) {
         f->next = ps;
     }
 
-    SFOPEN(f, 0);
+    SFOPEN(f);
     SFMTXRETURN(f, (int)n);
 }

--- a/src/lib/libast/sfio/sfclose.c
+++ b/src/lib/libast/sfio/sfclose.c
@@ -88,7 +88,7 @@ int sfclose(Sfio_t *f) {
             f->mode &= ~SF_LOCK; /**/
             ASSERT(_Sfpmove);
             if ((*_Sfpmove)(f, -1) < 0) {
-                SFOPEN(f, 0);
+                SFOPEN(f);
                 SFMTXRETURN(f, -1);
             }
             f->mode |= SF_LOCK;

--- a/src/lib/libast/sfio/sfdisc.c
+++ b/src/lib/libast/sfio/sfdisc.c
@@ -134,13 +134,13 @@ Sfdisc_t *sfdisc(Sfio_t *f, Sfdisc_t *disc) {
             int rv = 0;
             if (rv == 0 && f->disc && f->disc->exceptf) /* ask current discipline */
             {
-                SFOPEN(f, 0);
+                SFOPEN(f);
                 rv = (*f->disc->exceptf)(f, SF_DBUFFER, &n, f->disc);
                 SFLOCK(f, 0);
             }
             if (rv == 0 && disc && disc->exceptf) /* ask discipline being pushed */
             {
-                SFOPEN(f, 0);
+                SFOPEN(f);
                 rv = (*disc->exceptf)(f, SF_DBUFFER, &n, disc);
                 SFLOCK(f, 0);
             }
@@ -178,7 +178,7 @@ Sfdisc_t *sfdisc(Sfio_t *f, Sfdisc_t *disc) {
         if (!(d = f->disc)) goto done;
         disc = d->disc;
         if (d->exceptf) {
-            SFOPEN(f, 0);
+            SFOPEN(f);
             if ((*(d->exceptf))(f, SF_DPOP, (void *)disc, d) < 0) goto done;
             SFLOCK(f, 0);
         }
@@ -188,7 +188,7 @@ Sfdisc_t *sfdisc(Sfio_t *f, Sfdisc_t *disc) {
         do { /* loop to handle the case where d may pop itself */
             d = f->disc;
             if (d && d->exceptf) {
-                SFOPEN(f, 0);
+                SFOPEN(f);
                 if ((*(d->exceptf))(f, SF_DPUSH, (void *)disc, d) < 0) goto done;
                 SFLOCK(f, 0);
             }
@@ -239,6 +239,6 @@ Sfdisc_t *sfdisc(Sfio_t *f, Sfdisc_t *disc) {
     }
 
 done:
-    SFOPEN(f, 0);
+    SFOPEN(f);
     SFMTXRETURN(f, rdisc);
 }

--- a/src/lib/libast/sfio/sfexcept.c
+++ b/src/lib/libast/sfio/sfexcept.c
@@ -47,7 +47,7 @@ int _sfexcept(Sfio_t *f, int type, ssize_t io, Sfdisc_t *disc) {
     if (local && io <= 0) f->flags |= io < 0 ? SF_ERROR : SF_EOF;
 
     if (disc && disc->exceptf) { /* let the stream be generally accessible for this duration */
-        if (local && lock) SFOPEN(f, 0);
+        if (local && lock) SFOPEN(f);
 
         /* so that exception handler knows what we are asking for */
         _Sfi = f->val = io;
@@ -102,7 +102,7 @@ chk_stack:
          (type == SF_WRITE && f->next <= f->data))) { /* pop the stack */
         Sfio_t *pf;
 
-        if (lock) SFOPEN(f, 0);
+        if (lock) SFOPEN(f);
 
         /* pop and close */
         pf = (*_Sfstack)(f, NULL);

--- a/src/lib/libast/sfio/sffilbuf.c
+++ b/src/lib/libast/sfio/sffilbuf.c
@@ -100,7 +100,7 @@ int _sffilbuf(Sfio_t *f, int n) {
         }
     }
 
-    SFOPEN(f, local);
+    if (!local) SFOPEN(f);
 
     rcrv = (n == 0) ? (r > 0 ? (int)(*f->next++) : EOF) : (int)r;
 

--- a/src/lib/libast/sfio/sfflsbuf.c
+++ b/src/lib/libast/sfio/sfflsbuf.c
@@ -61,7 +61,7 @@ int _sfflsbuf(Sfio_t *f, int c) {
             if (f->next < f->endb || !(f->flags & SF_STRING))
                 n = f->next - (data = f->data);
             else {
-                SFOPEN(f, local);
+                if (!local) SFOPEN(f);
                 SFMTXRETURN(f, -1);
             }
         }
@@ -96,7 +96,7 @@ int _sfflsbuf(Sfio_t *f, int c) {
                 break;       /* do normal exit below */
             else             /* nothing was done, returning failure */
             {
-                SFOPEN(f, local);
+                if (!local) SFOPEN(f);
                 SFMTXRETURN(f, -1);
             }
         } else /* w < 0 means SF_EDISC or SF_ESTACK in sfwr() */
@@ -108,7 +108,7 @@ int _sfflsbuf(Sfio_t *f, int c) {
         }
     }
 
-    SFOPEN(f, local);
+    if (!local) SFOPEN(f);
 
     if (inpc < 0) inpc = f->endb - f->next;
 

--- a/src/lib/libast/sfio/sfgetd.c
+++ b/src/lib/libast/sfio/sfgetd.c
@@ -68,6 +68,6 @@ done:
     v = ldexpl(v, (sign & 02) ? -exp : exp);
     if (sign & 01) v = -v;
 
-    SFOPEN(f, 0);
+    SFOPEN(f);
     SFMTXRETURN(f, v);
 }

--- a/src/lib/libast/sfio/sfgetl.c
+++ b/src/lib/libast/sfio/sfgetl.c
@@ -61,6 +61,6 @@ Sflong_t sfgetl(Sfio_t *f) {
         f->next = s;
     }
 done:
-    SFOPEN(f, 0);
+    SFOPEN(f);
     SFMTXRETURN(f, v);
 }

--- a/src/lib/libast/sfio/sfgetm.c
+++ b/src/lib/libast/sfio/sfgetm.c
@@ -59,6 +59,6 @@ Sfulong_t sfgetm(Sfio_t *f, Sfulong_t m) {
         f->next = s;
     }
 done:
-    SFOPEN(f, 0);
+    SFOPEN(f);
     SFMTXRETURN(f, v);
 }

--- a/src/lib/libast/sfio/sfgetr.c
+++ b/src/lib/libast/sfio/sfgetr.c
@@ -147,7 +147,7 @@ done:
     /* prepare for a call to get the broken record */
     if (rsrv) rsrv->slen = found ? 0 : -un;
 
-    SFOPEN(f, 0);
+    SFOPEN(f);
 
     if (us && (type & SF_LOCKR)) {
         f->mode |= SF_PEEK | SF_GETR;

--- a/src/lib/libast/sfio/sfgetu.c
+++ b/src/lib/libast/sfio/sfgetu.c
@@ -59,6 +59,6 @@ Sfulong_t sfgetu(Sfio_t *f) {
         f->next = s;
     }
 done:
-    SFOPEN(f, 0);
+    SFOPEN(f);
     SFMTXRETURN(f, v);
 }

--- a/src/lib/libast/sfio/sfgetwc.c
+++ b/src/lib/libast/sfio/sfgetwc.c
@@ -85,6 +85,6 @@ int sfgetwc(Sfio_t *f) {
             }
         }
     }
-    SFOPEN(f, 0);
+    SFOPEN(f);
     SFMTXRETURN(f, c);
 }

--- a/src/lib/libast/sfio/sfhdr.h
+++ b/src/lib/libast/sfio/sfhdr.h
@@ -678,7 +678,7 @@ typedef struct _sfextern_s {
     ((f)->mode == SF_READ \
          ? _SFOPENRD(f)   \
          : (f)->mode == SF_WRITE ? _SFOPENWR(f) : ((f)->endw = (f)->endr = (f)->data))
-#define SFOPEN(f, l) (void)((l) ? 0 : ((f)->mode &= ~(SF_LOCK | SF_RC | SF_RV), _SFOPEN(f), 0))
+#define SFOPEN(f) do { (f)->mode &= ~(SF_LOCK | SF_RC | SF_RV); _SFOPEN(f); } while (0)
 
 /* check to see if the stream can be accessed */
 #define SFFROZEN(f)                              \

--- a/src/lib/libast/sfio/sfmode.c
+++ b/src/lib/libast/sfio/sfmode.c
@@ -104,7 +104,7 @@ static_fn void _sfcleanup(void) {
             f->mode |= pool;
 
             SFMTXUNLOCK(f);
-            SFOPEN(f, 0);
+            SFOPEN(f);
         }
     }
 }
@@ -494,6 +494,6 @@ int _sfmode(Sfio_t *f, int wanted, int local) {
     }
 
 done:
-    SFOPEN(f, local);
+    if (!local) SFOPEN(f);
     return rv;
 }

--- a/src/lib/libast/sfio/sfmove.c
+++ b/src/lib/libast/sfio/sfmove.c
@@ -193,8 +193,8 @@ Sfoff_t sfmove(Sfio_t *fr, Sfio_t *fw, Sfoff_t n, int rc) {
         }
 
     again:
-        SFOPEN(fr, 0);
-        if (fw) SFOPEN(fw, 0);
+        SFOPEN(fr);
+        if (fw) SFOPEN(fw);
     }
 
     if (n < 0 && (fr->bits & SF_MMAP) && (fr->bits & SF_MVSIZE)) { /* back to normal access mode */
@@ -206,10 +206,10 @@ Sfoff_t sfmove(Sfio_t *fr, Sfio_t *fw, Sfoff_t n, int rc) {
     if (rbuf) free(rbuf);
 
     if (fw) {
-        SFOPEN(fw, 0);
+        SFOPEN(fw);
         SFMTXEND2(fw);
     }
 
-    SFOPEN(fr, 0);
+    SFOPEN(fr);
     SFMTXRETURN(fr, n_move);
 }

--- a/src/lib/libast/sfio/sfnputc.c
+++ b/src/lib/libast/sfio/sfnputc.c
@@ -68,6 +68,6 @@ ssize_t sfnputc(Sfio_t *f, int c, size_t n) {
         if ((size_t)p > n) p = n;
     }
 done:
-    SFOPEN(f, local);
+    if (!local) SFOPEN(f);
     SFMTXRETURN(f, w);
 }

--- a/src/lib/libast/sfio/sfpool.c
+++ b/src/lib/libast/sfio/sfpool.c
@@ -300,19 +300,19 @@ Sfio_t *sfpool(Sfio_t *f, Sfio_t *pf, int mode) {
     if (_sfsetpool(f) < 0) goto done;
 
     /**/ ASSERT(p->sf[0] == pf && p->sf[p->n_sf - 1] == f);
-    SFOPEN(pf, 0);
-    SFOPEN(f, 0);
+    SFOPEN(pf);
+    SFOPEN(f);
     if (_sfpmove(f, 0) < 0) /* make f head of pool */
         goto done;
     rv = pf;
 
 done:
     if (f) {
-        SFOPEN(f, 0);
+        SFOPEN(f);
         SFMTXUNLOCK(f);
     }
     if (pf) {
-        SFOPEN(pf, 0);
+        SFOPEN(pf);
         SFMTXUNLOCK(pf);
     }
     return rv;

--- a/src/lib/libast/sfio/sfpurge.c
+++ b/src/lib/libast/sfio/sfpurge.c
@@ -56,13 +56,13 @@ int sfpurge(Sfio_t *f) {
             SFMUNMAP(f, f->data, f->endb - f->data);
             (void)SFSK(f, f->here, SEEK_SET, f->disc);
         }
-        SFOPEN(f, 0);
+        SFOPEN(f);
         SFMTXRETURN(f, 0);
     }
 
     switch (f->mode & ~SF_LOCK) {
         default:
-            SFOPEN(f, 0);
+            SFOPEN(f);
             SFMTXRETURN(f, -1);
         case SF_WRITE:
             f->next = f->data;
@@ -80,7 +80,7 @@ int sfpurge(Sfio_t *f) {
             break;
     }
 
-    SFOPEN(f, 0);
+    SFOPEN(f);
 
 done:
     if ((f->flags & SF_IOCHECK) && f->disc && f->disc->exceptf)

--- a/src/lib/libast/sfio/sfputr.c
+++ b/src/lib/libast/sfio/sfputr.c
@@ -117,6 +117,6 @@ ssize_t sfputr(Sfio_t *f, const char *s, int rc) {
         (void)SFWRITE(f, (void *)f->next, n);
     }
 
-    SFOPEN(f, 0);
+    SFOPEN(f);
     SFMTXRETURN(f, w);
 }

--- a/src/lib/libast/sfio/sfputwc.c
+++ b/src/lib/libast/sfio/sfputwc.c
@@ -115,6 +115,6 @@ int sfputwc(Sfio_t *f, int w) {
         f->next = s;
     }
 
-    SFOPEN(f, 0);
+    SFOPEN(f);
     SFMTXRETURN(f, (int)n);
 }

--- a/src/lib/libast/sfio/sfraise.c
+++ b/src/lib/libast/sfio/sfraise.c
@@ -69,7 +69,7 @@ int sfraise(Sfio_t *f, int type, void *data) {
         if (type == SF_FINAL) f->disc = next;
 
         if (disc->exceptf) {
-            SFOPEN(f, 0);
+            SFOPEN(f);
             // We do not return the value from the disc->exceptf function. That's because it can
             // return a negative or positive value to indicate a problem. This function, however,
             // must only return -1 on error. See issue #398.
@@ -84,6 +84,6 @@ int sfraise(Sfio_t *f, int type, void *data) {
         }
     }
 
-    SFOPEN(f, local);
+    if (!local) SFOPEN(f);
     SFMTXRETURN(f, 0);
 }

--- a/src/lib/libast/sfio/sfread.c
+++ b/src/lib/libast/sfio/sfread.c
@@ -119,7 +119,7 @@ ssize_t sfread(Sfio_t *f, void *buf, size_t n) {
         }
     }
 
-    SFOPEN(f, local);
+    if (!local) SFOPEN(f);
     r = s - begs;
     SFMTXRETURN(f, r);
 }

--- a/src/lib/libast/sfio/sfreserve.c
+++ b/src/lib/libast/sfio/sfreserve.c
@@ -86,7 +86,7 @@ void *sfreserve(Sfio_t *f, ssize_t size, int type) {
 
         if (!mode && !(mode = f->flags & SF_READ)) mode = SF_WRITE;
         if ((int)f->mode != mode && _sfmode(f, mode, local) < 0) {
-            SFOPEN(f, 0);
+            SFOPEN(f);
             SFMTXRETURN(f, NULL);
         }
 
@@ -170,7 +170,7 @@ done: /* compute the buffer to be returned */
             rsrv->slen = -n;
     }
 
-    SFOPEN(f, 0);
+    SFOPEN(f);
 
     if (data) {
         if (type == SF_LOCKR) {

--- a/src/lib/libast/sfio/sfresize.c
+++ b/src/lib/libast/sfio/sfresize.c
@@ -66,7 +66,7 @@ int sfresize(Sfio_t *f, Sfoff_t size) {
 
     f->extent = size;
 
-    SFOPEN(f, 0);
+    SFOPEN(f);
 
     SFMTXRETURN(f, 0);
 }

--- a/src/lib/libast/sfio/sfseek.c
+++ b/src/lib/libast/sfio/sfseek.c
@@ -238,7 +238,7 @@ done:
 
     f->lpos = p;
 
-    SFOPEN(f, local);
+    if (!local) SFOPEN(f);
 
     if (mustsync) sfsync(f);
     SFMTXRETURN(f, p);

--- a/src/lib/libast/sfio/sfset.c
+++ b/src/lib/libast/sfio/sfset.c
@@ -82,6 +82,6 @@ int sfset(Sfio_t *f, int flags, int set) {
     /* if not shared or unseekable, public means nothing */
     if (!(f->flags & SF_SHARE) || f->extent < 0) f->flags &= ~SF_PUBLIC;
 
-    SFOPEN(f, 0);
+    SFOPEN(f);
     SFMTXRETURN(f, (oflags & SFIO_FLAGS));
 }

--- a/src/lib/libast/sfio/sfsetbuf.c
+++ b/src/lib/libast/sfio/sfsetbuf.c
@@ -225,7 +225,7 @@ void *sfsetbuf(Sfio_t *f, void *buf, size_t size) {
         /* synchronize first */
         SFLOCK(f, local);
         rv = SFSYNC(f);
-        SFOPEN(f, local);
+        if (!local) SFOPEN(f);
         if (rv < 0) SFMTXRETURN(f, NULL);
 
         /* turn off the SF_SYNCED bit because buffer is changing */
@@ -465,7 +465,7 @@ done:
     while (blksz > f->size / 2) blksz /= 2;
     f->blksz = blksz;
 
-    SFOPEN(f, local);
+    if (!local) SFOPEN(f);
 
     SFMTXRETURN(f, (void *)obuf);
 }

--- a/src/lib/libast/sfio/sfsetfd.c
+++ b/src/lib/libast/sfio/sfsetfd.c
@@ -71,7 +71,7 @@ int sfsetfd(Sfio_t *f, int newfd) {
         if (oldfd >= 0) {
             if (newfd >= 0) {
                 if ((newfd = _sfdup(oldfd, newfd)) < 0) {
-                    SFOPEN(f, 0);
+                    SFOPEN(f);
                     SFMTXRETURN(f, -1);
                 }
                 CLOSE(oldfd);
@@ -79,14 +79,14 @@ int sfsetfd(Sfio_t *f, int newfd) {
                 if (((f->mode & SF_WRITE) && f->next > f->data) || (f->mode & SF_READ) ||
                     f->disc == _Sfudisc) {
                     if (SFSYNC(f) < 0) {
-                        SFOPEN(f, 0);
+                        SFOPEN(f);
                         SFMTXRETURN(f, -1);
                     }
                 }
 
                 if (((f->mode & SF_WRITE) && f->next > f->data) ||
                     ((f->mode & SF_READ) && f->extent < 0 && f->next < f->endb)) {
-                    SFOPEN(f, 0);
+                    SFOPEN(f);
                     SFMTXRETURN(f, -1);
                 }
 
@@ -103,7 +103,7 @@ int sfsetfd(Sfio_t *f, int newfd) {
             }
         }
 
-        SFOPEN(f, 0);
+        SFOPEN(f);
     }
 
     /* notify changes */

--- a/src/lib/libast/sfio/sfsize.c
+++ b/src/lib/libast/sfio/sfsize.c
@@ -97,6 +97,6 @@ Sfoff_t sfsize(Sfio_t *f) {
         }
     }
 
-    SFOPEN(f, 0);
+    SFOPEN(f);
     SFMTXRETURN(f, s);
 }

--- a/src/lib/libast/sfio/sfstack.c
+++ b/src/lib/libast/sfio/sfstack.c
@@ -101,8 +101,8 @@ Sfio_t *sfstack(Sfio_t *f1, Sfio_t *f2) {
         rf = f2;
     }
 
-    SFOPEN(f1, 0);
-    SFOPEN(f2, 0);
+    SFOPEN(f1);
+    SFOPEN(f2);
 
     STKMTXRETURN(f1, f2, rf);
 }

--- a/src/lib/libast/sfio/sfswap.c
+++ b/src/lib/libast/sfio/sfswap.c
@@ -55,7 +55,7 @@ Sfio_t *sfswap(Sfio_t *f1, Sfio_t *f2) {
         if ((!f2 || !(f2->mode & SF_AVAIL))) {
             if (!(f2 = (Sfio_t *)malloc(sizeof(Sfio_t)))) {
                 f1->mode = f1mode;
-                SFOPEN(f1, 0);
+                SFOPEN(f1);
                 return NULL;
             }
 
@@ -101,10 +101,10 @@ Sfio_t *sfswap(Sfio_t *f1, Sfio_t *f2) {
         if (!(f1->flags & SF_STATIC)) free(f1);
     } else {
         f1->mode = f2mode;
-        SFOPEN(f1, 0);
+        SFOPEN(f1);
     }
 
     f2->mode = f1mode;
-    SFOPEN(f2, 0);
+    SFOPEN(f2);
     return f2;
 }

--- a/src/lib/libast/sfio/sfsync.c
+++ b/src/lib/libast/sfio/sfsync.c
@@ -138,7 +138,7 @@ int sfsync(Sfio_t *f) {
 
     next:
         f->mode |= mode;
-        SFOPEN(f, local);
+        if (!local) SFOPEN(f);
 
         if ((f->flags & SF_IOCHECK) && f->disc && f->disc->exceptf)
             (void)(*f->disc->exceptf)(f, SF_SYNC, (void *)((int)0), f->disc);

--- a/src/lib/libast/sfio/sfungetc.c
+++ b/src/lib/libast/sfio/sfungetc.c
@@ -67,7 +67,7 @@ int sfungetc(Sfio_t *f, int c) {
         }
         _Sfudisc->exceptf = _uexcept;
         sfdisc(uf, _Sfudisc);
-        SFOPEN(f, 0);
+        SFOPEN(f);
         (void)sfstack(f, uf);
         SFLOCK(f, 0);
     }
@@ -90,6 +90,6 @@ int sfungetc(Sfio_t *f, int c) {
 
     *--f->next = (uchar)c;
 done:
-    SFOPEN(f, 0);
+    SFOPEN(f);
     SFMTXRETURN(f, c);
 }

--- a/src/lib/libast/sfio/sfvprintf.c
+++ b/src/lib/libast/sfio/sfvprintf.c
@@ -545,7 +545,7 @@ loop_fmt:
         {
             FMTSET(ft, form, args, fmt, size, flags, width, precis, base, t_str, n_str);
             SFEND(f);
-            SFOPEN(f, 0);
+            SFOPEN(f);
             v = (*ft->extf)(f, (void *)(&argv), ft);
             SFLOCK(f, 0);
             SFBUF(f);
@@ -1377,6 +1377,6 @@ done:
     else
         f->next += n;
 
-    SFOPEN(f, 0);
+    SFOPEN(f);
     SFMTXRETURN(f, n_output);
 }

--- a/src/lib/libast/sfio/sfvscanf.c
+++ b/src/lib/libast/sfio/sfvscanf.c
@@ -599,7 +599,7 @@ loop_fmt:
         } else if (ft && ft->extf) {
             FMTSET(ft, form, args, fmt, size, flags, width, 0, base, t_str, n_str);
             SFend(f);
-            SFOPEN(f, 0);
+            SFOPEN(f);
             v = (*ft->extf)(f, (void *)&argv, ft);
             SFLOCK(f, 0);
             SFbuf(f);
@@ -967,7 +967,7 @@ done:
 
     SFend(f);
 
-    SFOPEN(f, 0);
+    SFOPEN(f);
 
     if (n_assign == 0 && inp < 0) n_assign = -1;
 

--- a/src/lib/libast/sfio/sfwrite.c
+++ b/src/lib/libast/sfio/sfwrite.c
@@ -145,7 +145,7 @@ ssize_t sfwrite(Sfio_t *f, const void *buf, size_t n) {
         if (n >= HIFORLINE) (void)SFFLSBUF(f, -1);
     }
 
-    SFOPEN(f, local);
+    if (!local) SFOPEN(f);
 
     w = s - begs;
     SFMTXRETURN(f, w);


### PR DESCRIPTION
The SFOPEN() macro causes lots of lint warnings like this one:

src/lib/libast/sfio/sfstack.c:104:5: constant conditional operator [basic|P2]

That's because the majority of uses pass a constant zero for the second,
`l`, parameter which turns the macro into a no-op. It also obscures the
purpose of the second parameter. Redefine the macro to take just a
single parameter and redefine the few places which don't want it to
always open a SFIO stream by turning

    SFOPEN(f, local)

into

    if (!local) SFOPEN(f);

This both eliminates the warnings and clarifies the behavior.

Fixes #898