### PR TITLE
Lint: signConversion

### DIFF
--- a/src/lib/libast/regex/regnexec.c
+++ b/src/lib/libast/regex/regnexec.c
@@ -265,12 +265,14 @@ static_fn int _matchpush(Env_t *env, Rex_t *rex) {
     regmatch_t *m;
     regmatch_t *e;
     regmatch_t *s;
-    int num;
+    int num = 0;
 
-    if (rex->re.group.number <= 0 || (num = rex->re.group.last - rex->re.group.number + 1) <= 0)
-        num = 0;
-    if (!(f = (Match_frame_t *)stkpush(env->mst,
-                                       sizeof(Match_frame_t) + (num - 1) * sizeof(regmatch_t)))) {
+    if (rex->re.group.number > 0) {
+        num = rex->re.group.last - rex->re.group.number + 1;
+        if (num < 0) num = 0;
+    }
+    f = stkpush(env->mst, sizeof(Match_frame_t) + ((size_t)num - 1) * sizeof(regmatch_t));
+    if (!f) {
         env->error = REG_ESPACE;
         return 1;
     }


### PR DESCRIPTION
Cppcheck warns about a potentially dangerous signed to unsigned
conversion:

[src/lib/libast/regex/regnexec.c:273] warning (signConversion):
 Suspicious code: sign conversion of - in calculation, even though - can
 have a negative value