### PR TITLE
Remove irrelevant symbol `ERROR_VERSION`

### DIFF
--- a/src/cmd/ksh93/include/fault.h
+++ b/src/cmd/ksh93/include/fault.h
@@ -95,11 +95,7 @@ struct checkpt {
     int mode;
     int vexi;
     struct openlist *olist;
-#if (ERROR_VERSION >= 20030214L)
     Error_context_t err;
-#else
-    struct errorcontext err;
-#endif
 };
 
 struct siginfo_ll {

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -338,19 +338,11 @@ static_fn void put_cdpath(Namval_t *np, const void *val, int flags, Namfun_t *fp
 // This function needs to be modified to handle international
 // error message translations
 //
-#if ERROR_VERSION >= 20000101L
 static_fn char *msg_translate(const char *catalog, const char *message) {
     UNUSED(catalog);
 
     return (char *)message;
 }
-#else
-static_fn char *msg_translate(const char *message, int type) {
-    UNUSED(type);
-
-    return (char *)message;
-}
-#endif
 #endif
 
 // Trap for LC_ALL, LC_CTYPE, LC_MESSAGES, LC_COLLATE and LANG.
@@ -395,9 +387,6 @@ static_fn void put_lang(Namval_t *np, const void *val, int flags, Namfun_t *fp) 
     }
 
     nv_putv(np, val, flags, fp);
-#if ERROR_VERSION < 20000101L
-    if (type == LC_ALL || type == LC_MESSAGES) error_info.translate = msg_translate;
-#endif
 }
 
 // Trap for IFS assignment and invalidates state table.
@@ -1269,9 +1258,7 @@ Shell_t *sh_init(int argc, char *argv[], Shinit_f userinit) {
     shp->stk = stkstd;
     sfsetbuf(shp->strbuf, NULL, 64);
     sh_onstate(shp, SH_INIT);
-#if ERROR_VERSION >= 20000102L
     error_info.catalog = e_dict;
-#endif
     shp->cpipe[0] = -1;
     shp->coutpipe = -1;
     for (n = 0; n < 10; n++) {

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -2022,15 +2022,7 @@ struct argnod *sh_endword(Shell_t *shp, int mode) {
                         break;
                     }
                     *--dp = 0;
-#if ERROR_VERSION >= 20000317L
                     msg = ERROR_translate(0, error_info.id, 0, ep);
-#else
-#if ERROR_VERSION >= 20000101L
-                    msg = ERROR_translate(error_info.id, ep);
-#else
-                    msg = ERROR_translate(ep, 2);
-#endif
-#endif
                     n = strlen(msg);
                     dp = ep + n;
                     if (sp - dp <= 1) {

--- a/src/cmd/ksh93/sh/string.c
+++ b/src/cmd/ksh93/sh/string.c
@@ -639,15 +639,7 @@ int sh_strchr(const char *string, const char *dp, size_t size) {
 }
 
 const char *_sh_translate(const char *message) {
-#if ERROR_VERSION >= 20000317L
     return ERROR_translate(0, 0, e_dict, message);
-#else
-#if ERROR_VERSION >= 20000101L
-    return ERROR_translate(e_dict, message);
-#else
-    return ERROR_translate(message, 1);
-#endif
-#endif
 }
 
 //

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -81,11 +81,7 @@ static struct subshell {
     Dt_t *sfun;             // function scope for subshell
     Dt_t *salias;           // alias scope for subshell
     Pathcomp_t *pathlist;   // for PATH variable
-#if (ERROR_VERSION >= 20030214L)
     struct Error_context_s *errcontext;
-#else
-    struct errorcontext *errcontext;
-#endif
     Shopt_t options;    // save shell options
     pid_t subpid;       // child process id
     Sfio_t *saveout;    // saved standard output

--- a/src/lib/libast/include/error.h
+++ b/src/lib/libast/include/error.h
@@ -34,8 +34,6 @@
 
 #include "option.h"
 
-#define ERROR_VERSION 20070319L
-
 #define ERROR_debug(n) (-(n))
 #define ERROR_exit(n) ((n) + ERROR_ERROR)
 #define ERROR_system(n) (((n) + ERROR_ERROR) | ERROR_SYSTEM)


### PR DESCRIPTION
Symbol `ERROR_VERSION` is a constant. The places it is tested are
therefore known to be true or false at compile time and those tests can
be eliminated.

Resolves #922