### PR TITLE
Replace `pathtemp()` with a simpler function

### DIFF
--- a/src/cmd/ksh93/bltins/hist.c
+++ b/src/cmd/ksh93/bltins/hist.c
@@ -21,6 +21,7 @@
 
 #include <ctype.h>
 #include <fcntl.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -204,16 +205,12 @@ int b_hist(int argc, char *argv[], Shbltin_t *context) {
         outfile = sfstdout;
         arg = "\n\t";
     } else {
-        fname = pathtemp(NULL, 0, NULL, NULL, NULL);
+        fname = ast_temp_file(NULL, NULL, &fdo, O_CLOEXEC);
         if (!fname) {
             errormsg(SH_DICT, ERROR_exit(1), e_create, "");
             __builtin_unreachable();
         }
-        fdo = open(fname, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR | O_CLOEXEC);
-        if (fdo < 0) {
-            errormsg(SH_DICT, ERROR_system(1), e_create, fname);
-            __builtin_unreachable();
-        }
+
         outfile = sfnew(NULL, shp->outbuff, IOBSIZE, fdo, SF_WRITE);
         arg = "\n";
         nflag++;

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -936,8 +936,8 @@ struct argnod *sh_argprocsub(Shell_t *shp, struct argnod *argp) {
     sfputr(shp->stk, fmtbase((long)pv[fd], 10, 0), 0);
 #else   // has_dev_fd
     pv[0] = -1;
-    shp->fifo = pathtemp(0, 0, 0, "ksh.fifo", 0);
-    mkfifo(shp->fifo, S_IRUSR | S_IWUSR);
+    shp->fifo = ast_temp_file(NULL, "ksh.fifo", NULL, 0);
+    if (mkfifo(shp->fifo, S_IRUSR | S_IWUSR)) abort();
     sfputr(shp->stk, shp->fifo, 0);
 #endif  // has_dev_fd
     ap = (struct argnod *)stkfreeze(shp->stk, 0);

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -1241,7 +1241,7 @@ int sh_redirect(Shell_t *shp, struct ionod *iop, int flag) {
                     } else if ((sp = shp->sftable[dupfd])) {
                         char *tmpname;
                         if (sfset(sp, 0, 0) & SF_STRING) {
-                            tmpname = pathtemp(NULL, 0, NULL, "sf", &f);
+                            tmpname = ast_temp_file(NULL, "sf", &f, 0);
                             if (tmpname) {
                                 Sfoff_t last = sfseek(sp, 0, SEEK_END);
                                 unlink(tmpname);

--- a/src/lib/libast/include/ast.h
+++ b/src/lib/libast/include/ast.h
@@ -235,6 +235,7 @@ extern char *pathpath(const char *, const char *, int, char *, size_t);
 extern size_t pathposix(const char *, char *, size_t);
 extern size_t pathprog(const char *, char *, size_t);
 extern char *pathshell(void);
+extern char *ast_temp_file(const char *dir, const char *prefix, int *fd, int open_flags);
 extern char *pathtemp(char *, size_t, const char *, const char *, int *);
 extern char *sh_setenviron(const char *);
 extern char *strcopy(char *, const char *);

--- a/src/lib/libast/sfio/sftmp.c
+++ b/src/lib/libast/sfio/sftmp.c
@@ -132,10 +132,10 @@ static_fn int _rmtmp(Sfio_t *f, char *file) {
 }
 
 static_fn int _tmpfd(Sfio_t *f) {
-    char *file;
     int fd;
+    char *file = ast_temp_file(NULL, "sf", &fd, 0);
 
-    if (!(file = pathtemp(NULL, 0, NULL, "sf", &fd))) return -1;
+    if (!file) return -1;
     _rmtmp(f, file);
     free(file);
     return fd;


### PR DESCRIPTION
This leaves the existing implementation just to keep the focus on the
important parts of resolving issue #854. I'll follow this with a cleanup
change that removes the now unused code.

Related #854