### PR TITLE
Replace sh_lexstates with sh_lexrstates

### DIFF
--- a/src/cmd/ksh93/data/lexstates.c
+++ b/src/cmd/ksh93/data/lexstates.c
@@ -334,9 +334,9 @@ static const char sh_lexstate9[256] = {
     S_NOP,   S_NOP, S_NOP,   S_BRACE, S_PAT, S_ENDCH, S_NOP, S_NOP,  // 120 - 127
 };
 
-const char *sh_lexrstates[ST_NONE] = {sh_lexstate0, sh_lexstate1, sh_lexstate2, sh_lexstate3,
-                                      sh_lexstate4, sh_lexstate5, sh_lexstate6, sh_lexstate7,
-                                      sh_lexstate8, sh_lexstate9, sh_lexstate5};
+const char *sh_lexstates[ST_NONE] = {sh_lexstate0, sh_lexstate1, sh_lexstate2, sh_lexstate3,
+                                     sh_lexstate4, sh_lexstate5, sh_lexstate6, sh_lexstate7,
+                                     sh_lexstate8, sh_lexstate9, sh_lexstate5};
 
 const char e_lexversion[] = "%d: invalid binary script version";
 const char e_lexspace[] = "line %d: use space or tab to separate operators %c and %c";

--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -44,17 +44,17 @@
 static char *fmtx(Shell_t *shp, const char *string) {
     const char *cp = string;
     int n, c;
-    unsigned char *state = (unsigned char *)sh_lexstates[2];
+    const unsigned char *norm_state = (const unsigned char *)sh_lexstates[ST_NORM];
     int offset = stktell(shp->stk);
     if (*cp == '#' || *cp == '~') sfputc(shp->stk, '\\');
-    while ((c = mb1char(cp)), (c > UCHAR_MAX) || (n = state[c]) == 0 || n == S_EPAT) {
+    while ((c = mb1char(cp)), (c > UCHAR_MAX) || (n = norm_state[c]) == 0 || n == S_EPAT) {
         ;  // empty loop
     }
     if (n == S_EOF && *string != '#') return (char *)string;
     sfwrite(shp->stk, string, --cp - string);
     for (string = cp; (c = mb1char(cp)); string = cp) {
         if ((n = cp - string) == 1) {
-            if ((n = state[c]) && n != S_EPAT) sfputc(shp->stk, '\\');
+            if ((n = norm_state[c]) && n != S_EPAT) sfputc(shp->stk, '\\');
             sfputc(shp->stk, c);
         } else {
             sfwrite(shp->stk, string, n);

--- a/src/cmd/ksh93/include/lexstates.h
+++ b/src/cmd/ksh93/include/lexstates.h
@@ -99,8 +99,7 @@
 #define isexp(c) (sh_lexstates[ST_MACRO][c] == S_PAT || (c) == '$' || (c) == '`')
 #define ismeta(c) (sh_lexstates[ST_NAME][c] == S_BREAK)
 
-extern char *sh_lexstates[ST_NONE];
-extern const char *sh_lexrstates[ST_NONE];
+extern const char *sh_lexstates[ST_NONE];
 extern const char e_lexversion[];
 extern const char e_lexspace[];
 extern const char e_lexslash[];

--- a/src/cmd/ksh93/sh/defs.c
+++ b/src/cmd/ksh93/sh/defs.c
@@ -32,7 +32,6 @@
 #include "cdt.h"
 #include "fault.h"
 #include "jobs.h"
-#include "lexstates.h"
 #include "name.h"
 
 Shell_t sh = {.shcomp = 0};
@@ -40,9 +39,6 @@ struct jobs job = {.pwlist = NULL};
 Dtdisc_t _Nvdisc = {.key = offsetof(Namval_t, nvname), .size = -1, .comparf = nv_compare};
 struct shared *shgd = NULL;
 int32_t sh_mailchk = 600;
-
-// Reserve room for writable state table.
-char *sh_lexstates[ST_NONE] = {0};
 
 // These two magic pointers are used to distinguish the purpose of the `extra` parameter of the
 // `sh_addbuiltin()` function. It should be one of these two values, NULL, or a `Namfun_t*`.

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -1217,7 +1217,6 @@ Shell_t *sh_init(int argc, char *argv[], Shinit_f userinit) {
 
     n = strlen(e_version);
     if (e_version[n - 1] == '$' && e_version[n - 2] == ' ') e_version[n - 2] = 0;
-    memcpy(sh_lexstates, sh_lexrstates, ST_NONE * sizeof(char *));
     if (!beenhere) {
         beenhere = 1;
         shp = sh_getinterp();


### PR DESCRIPTION
After dropping support for non-ASCII character encodings (e.g., EBCDIC)
we no longer need to copy `sh_lexrstates` to `sh_lexstates`. Just
renamed the former to the latter.

This also cleans up a couple of related bogosities such as the magic
`sh_lexstates[2]` reference in src/cmd/ksh93/edit/completion.c with
`ST_NORM` in place of `2`.

Resolves #929