### PR TITLE
Remove LIBICONV_PLUG

### DIFF
--- a/config_ast.h.in
+++ b/config_ast.h.in
@@ -37,7 +37,6 @@
 #mesondefine CONF_LIBPATH
 #mesondefine _PROC_PROG
 #mesondefine _DARWIN_C_SOURCE
-#mesondefine LIBICONV_PLUG
 
 #mesondefine _ast_sizeof_int
 #mesondefine _ast_sizeof_long

--- a/features/meson.build
+++ b/features/meson.build
@@ -37,15 +37,7 @@ libexecinfo_dep = cc.find_library('execinfo', required: false, dirs: lib_dirs)
 # On some systems (e.g., OpenBSD) `iconv()` is in libiconv.
 libiconv_dep = cc.find_library('iconv', required: false, dirs: lib_dirs)
 
-# Under Cygwin the iconv shared library exports the symbols we need with a
-# `lib` prefix. So we don't want the LIBICONV_PLUG behavior on that platform.
-# On others we either want this or it's a no-op.
-if not (system == 'cygwin' or system == 'openbsd')
-    feature_data.set('LIBICONV_PLUG', 1)
-endif
-
-# On Cygwin the message catalog functions (e.g., `catopen()`) are in this
-# library.
+# On Cygwin the message catalog functions (e.g., `catopen()`) are in this library.
 libcatgets_dep = cc.find_library('catgets', required: false, dirs: lib_dirs)
 
 feature_data.set10('_hdr_execinfo', cc.has_header('execinfo.h', args: feature_test_args))


### PR DESCRIPTION
There was a period, roughly a year ago, when we needed to define
preprocessor symbol LIBICONV_PLUG on some platforms to build ksh. That
causes problems when building ksh via MacPorts. And testing on the
same platforms I was using a year ago when I introduced this hack shows
that it is apparently no longer needed. Presumably the real problem lay
elsewhere. Most likely in the various AST wrappers and `#define` symbols
that we've removed in the intervening time.

Resolves #932