### PR TITLE
Change OS X and Mac OS X to macOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ To help enforce this rule the `bin/lint` command will run the
 tool. You can find the IWYU project on
 [github](https://github.com/include-what-you-use/include-what-you-use).
 
-To install the tool on OS X you'll need to add a
+To install the tool on macOS you'll need to add a
 [formula](https://github.com/jasonmp85/homebrew-iwyu) then install it:
 
 ```sh
@@ -383,7 +383,7 @@ Coverity scans are run everyday on `master` branch. Latest results can be viewed
 
 ### Installing the Linting Tools
 
-To install the lint checkers on Mac OS X using HomeBrew:
+To install the lint checkers on macOS using HomeBrew:
 
 ```sh
 brew tap oclint/formulae
@@ -401,7 +401,7 @@ sudo apt-get install cppcheck
 
 ### Installing the Reformatting Tools
 
-To install the reformatting tool on Mac OS X using HomeBrew:
+To install the reformatting tool on macOS using HomeBrew:
 
 ```sh
 brew install clang-format

--- a/etc/iwyu.bsd.map
+++ b/etc/iwyu.bsd.map
@@ -1,4 +1,4 @@
-# Map file for the include-what-you-use tool on OS X. For some reason
+# Map file for the include-what-you-use tool on macOS. For some reason
 # the version installed by HomeBrew doesn't have useful mappings for the
 # system provided headers. This also has mappings for FreeBSD.
 [

--- a/src/cmd/ksh93/ksh.1
+++ b/src/cmd/ksh93/ksh.1
@@ -30,7 +30,7 @@ Currently,
 .I rksh
 and
 .I pfksh
-are not available on Mac OS X / Darwin.
+are not available on macOS / Darwin.
 .if \nZ=2 \{\
 ksh93, rksh93, pfksh93 \- KornShell, a standard/restricted command and programming language
 .\}


### PR DESCRIPTION
The operating system name changed a couple years ago. Most of the project already references "macOS"; this just cleans up a few remaining old references.