### PR TITLE
Use builtins in unit tests by default

### DIFF
--- a/src/cmd/ksh93/tests/coprocess.sh
+++ b/src/cmd/ksh93/tests/coprocess.sh
@@ -25,8 +25,6 @@ then
     exit 99
 fi
 
-bintrue=$(whence -p true)
-
 function ping # id
 {
     integer x=0
@@ -37,10 +35,7 @@ function ping # id
     done
 }
 
-bincat=$(whence -p cat)
-builtin cat
-
-for cat in cat $bincat
+for cat in cat $bin_cat
 do
 
     $cat |&
@@ -351,7 +346,7 @@ function mypipe
 
 mypipe |&
 print -p "hello"
-z="$( $bintrue $($bintrue) )"
+z="$( $bin_true $($bin_true) )"
 { print -p "world";} 2> /dev/null
 read -p
 [[ $REPLY == world ]] ||  log_error "expected 'world' got '$REPLY'"
@@ -379,10 +374,9 @@ fi
 kill $pid 2>/dev/null
 wait
 
-tee=$(whence -p tee)
 ls -l |&
 pid=$!
-$tee -a /dev/null <&p > /dev/null
+$bin_tee -a /dev/null <&p > /dev/null
 wait $pid
 x=$?
 [[ $x == 0 ]] || log_error "coprocess exitval should be 0, not $x"

--- a/src/cmd/ksh93/tests/functions.sh
+++ b/src/cmd/ksh93/tests/functions.sh
@@ -1214,10 +1214,9 @@ function foo
 bar=bam
 foo
 
-sleep=$(whence -p sleep)
 function gosleep
 {
-    $sleep 4
+    $bin_sleep 4
 }
 x=$(
     (sleep 2; pid=; ps | grep sleep | read pid extra; [[ $pid ]] && kill -- $pid) &

--- a/src/cmd/ksh93/tests/heredoc.sh
+++ b/src/cmd/ksh93/tests/heredoc.sh
@@ -513,21 +513,19 @@ $SHELL 2> /dev/null -c 'true <<- ++EOF++ || true "$(true)"
 ++EOF++' || log_error 'command substitution on heredoc line causes syntax error'
 
 (
-    cat=$(whence -p cat)
     function foobar
     {
-        $cat <<- XXX
+        $bin_cat <<- XXX
 		hello
 	XXX
     }
-    $cat > $f <<- EOF
+    $bin_cat > $f <<- EOF
 		$(foobar)
 		world
 	EOF
 ) > $f > /dev/null
 [[ $(<$f) == $'hello\nworld' ]] || log_error 'nested here-document fails'
 
-builtin cat
 exp='foo bar baz bork blah blarg'
 got=$(cat <<<"foo bar baz" 3<&0 <<<"$(</dev/fd/3) bork blah blarg")
 [[ $got == "$exp" ]] || '3<%0 not working when 0 is <<< here-doc'

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -110,11 +110,12 @@ exec 0<&-
 echo $(./close1)
 !
 print "echo abc" > close1
-chmod +x close0 close1
+chmod +x close0
+chmod +x close1
 x=$(./close0)
 if [[ $x != "abc" ]]
 then
-    log_error "picked up file descriptor zero for opening script file"
+    log_error "picked up file descriptor zero for opening script file" "abc" "$x"
 fi
 
 cat > close0 <<\!

--- a/src/cmd/ksh93/tests/namespace.sh
+++ b/src/cmd/ksh93/tests/namespace.sh
@@ -48,10 +48,12 @@ cat > $TEST_DIR/local/xfun <<- \EOF
     }
 EOF
 
-chmod +x "$TEST_DIR/global/xfun" "$TEST_DIR/local/xfun"
+chmod +x "$TEST_DIR/global/xfun"
+chmod +x "$TEST_DIR/local/xfun"
 print 'print local prog $1' >  $TEST_DIR/local/bin/run
 print 'print global prog $1' >  $TEST_DIR/global/bin/run
-chmod +x "$TEST_DIR/local/bin/run" "$TEST_DIR/global/bin/run"
+chmod +x "$TEST_DIR/local/bin/run"
+chmod +x "$TEST_DIR/global/bin/run"
 PATH=$TEST_DIR/global/bin:$PATH
 FPATH=$TEST_DIR/global
 
@@ -92,7 +94,9 @@ false
 [[  ${bar.y} == 4 ]] || log_error 'global compound variable should not be affected by definiton in namespace'
 [[  ${bar.z} == ''  ]] || log_error 'global compound variable should not see elements in namespace'
 [[ $(xfun) ==  'xfun global abc' ]] || log_error 'global function on FPATH failed'
-[[ $(run $foo) ==  'global prog abc' ]] || log_error 'global binary on PATH failed'
+actual=$(run $foo)
+expect='global prog abc'
+[[ $actual ==  $expect ]] || log_error 'global binary on PATH failed' "$expect" "$actual"
 false
 [[ $(.x.runxrun) ==  'xfun local bar' ]] || log_error 'namespace function on FPATH failed'
 

--- a/src/cmd/ksh93/tests/options.sh
+++ b/src/cmd/ksh93/tests/options.sh
@@ -385,10 +385,9 @@ then
     [[ $got == $exp ]] || log_error "--pipefail -c '(sleep 0.1;false)|true|true' fails with exit status 0 (after $got/$exp iterations)"
 fi
 
-echo=$(whence -p echo)
 for ((i=0; i < 20; i++))
 do
-    if ! x=$(true | $echo 123)
+    if ! x=$(true | $bin_echo 123)
     then
         log_error 'command substitution with wrong exit status with pipefai'
         break
@@ -400,7 +399,7 @@ done
     (( $? )) || log_error 'pipe not failing in subshell with pipefail'
 ) | wc >/dev/null
 
-$SHELL -c 'set -o pipefail; false | $(whence -p true);' && log_error 'pipefail not returning failure with sh -c'
+$SHELL -c 'set -o pipefail; false | $bin_true;' && log_error 'pipefail not returning failure with sh -c'
 exp='1212 or 1221'
 got=$(
     set --pipefail
@@ -469,7 +468,8 @@ ADD=(    ''        '; :'        )
 cd $TEST_DIR
 print $'#!'$SHELL$'\nkill -KILL $$' > command-kill
 print $'kill -KILL $$' > script-kill
-chmod +x command-kill script-kill
+chmod +x command-kill
+chmod +x script-kill
 export PATH=.:$PATH
 exp='Killed'
 for ((S=0; S<${#SUB[@]}; S++))

--- a/src/cmd/ksh93/tests/path.sh
+++ b/src/cmd/ksh93/tests/path.sh
@@ -378,7 +378,7 @@ EOF
 x=$(FPATH= PATH=$PWD/bin $SHELL -c  ': $(whence less);myfun') 2> /dev/null
 [[ $x == myfun ]] || log_error 'function myfun not found'
 
-cp $(whence -p echo) user_to_group_relationship.hdr.query
+cp $bin_echo user_to_group_relationship.hdr.query
 FPATH=/foobar:
 PATH=$FPATH:$PATH:.
 [[ $(user_to_group_relationship.hdr.query foobar) == foobar ]] 2> /dev/null || log_error 'Cannot execute command with . in name when PATH and FPATH end in :.'
@@ -387,7 +387,7 @@ mkdir -p $TEST_DIR/new/bin
 mkdir $TEST_DIR/new/fun
 print FPATH=../fun > $TEST_DIR/new/bin/.paths
 print FPATH=../xxfun > $TEST_DIR/bin/.paths
-cp "$(whence -p echo)" $TEST_DIR/new/bin
+cp "$bin_echo" $TEST_DIR/new/bin
 PATH=$TEST_DIR/bin:$TEST_DIR/new/bin:$PATH
 x=$(whence -p echo 2> /dev/null)
 [[ $x == "$TEST_DIR/new/bin/echo" ]] ||  log_error 'nonexistant FPATH directory in .paths file causes path search to fail'

--- a/src/cmd/ksh93/tests/signal.sh
+++ b/src/cmd/ksh93/tests/signal.sh
@@ -128,7 +128,11 @@ cat $TEST_SRC_DIR/util/util.sh $TEST_SRC_DIR/signal/sigtst0 > sigtst0
 cat $TEST_SRC_DIR/util/util.sh $TEST_SRC_DIR/signal/sigtst1 > sigtst1
 cat $TEST_SRC_DIR/util/util.sh $TEST_SRC_DIR/signal/sigtst2 > sigtst2
 cat $TEST_SRC_DIR/util/util.sh $TEST_SRC_DIR/signal/sigtst3 > sigtst3
-chmod +x sigtst?
+# TODO: Remove this workaround when builtin chmod bug #949 (multiple path handling) is fixed.
+for f in sigtst?
+do
+    chmod +x $f
+done
 $SHELL sigtst0 > sigtst.out
 while read ops actual
 do
@@ -168,7 +172,6 @@ read -u9 -t0.1 x || log_error 'subcommand unexpectedly consumed fifo go signal'
 # Verify exit due to signal can be mapped to the correct signal name.
 #
 empty_fifos
-cmd_true=$(whence -p true)
 for expect in TERM VTALRM PIPE
 do
     [[ ${SIG[$expect]} ]] || continue
@@ -179,7 +182,7 @@ do
         { sleep 0.5; kill -$expect \$\$; sleep 1; kill -KILL \$\$ 2> /dev/null; } &
         while :
         do
-            ($cmd_true; sleep .1)
+            ($bin_true; sleep .1)
         done
         EOF
     status=$?

--- a/src/cmd/ksh93/tests/util/preamble.sh
+++ b/src/cmd/ksh93/tests/util/preamble.sh
@@ -5,6 +5,25 @@ readonly test_file=${0##*/}
 readonly test_name=$1
 
 #
+# Ensure we use ksh builtins where traditionally an external command would be used. This helps
+# ensure that a) our builtins get tested even if only indirectly, and b) our unit tests can rely
+# on predictable behavior from external commands that may have different behavior on different
+# platforms. A few tests need to use external variants of builtins so find them first.
+#
+bin_basename=$(whence -p basename)
+bin_cat=$(whence -p cat)
+bin_cmp=$(whence -p cmp)
+bin_date=$(whence -p date)
+bin_echo=$(whence -p echo)
+bin_false=$(whence -p false)
+bin_printf=$(whence -p printf)
+bin_sleep=$(whence -p sleep)
+bin_tee=$(whence -p tee)
+bin_true=$(whence -p true)
+PATH=/opt/ast/bin:$PATH
+FULL_PATH=$PATH
+
+#
 # Make sure the unit test can't inadvertantly modify several critical env vars.
 #
 readonly FULL_PATH

--- a/src/cmd/ksh93/tests/util/run_test.sh
+++ b/src/cmd/ksh93/tests/util/run_test.sh
@@ -72,8 +72,8 @@ export BUILD_DIR=$PWD
 #
 export TEST_DIR=$(mktemp -dt ksh.${test_name}.XXXXXX) ||
     { log_error "mktemp -dt failed"; exit 99; }
-    cd $TEST_DIR || { print -u2 "<E> 'cd $TEST_DIR' failed with status $?"; exit 99; }
-    log_info "TEST_DIR=$TEST_DIR"
+cd $TEST_DIR || { print -u2 "<E> 'cd $TEST_DIR' failed with status $?"; exit 99; }
+log_info "TEST_DIR=$TEST_DIR"
 
 #
 # Make sure we search for external commands in the temporary test dir, then the test source dir,


### PR DESCRIPTION
The default behavior of unit tests should be to use builtins when
available and using external commands of the same name should be done
explicitly. This will help ensure builtins behave sensibly even if there
are insufficient explicit tests of each builtin.

Resolves #944