### PR TITLE
Fix a memory corruption issue in default path

### DIFF
--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -394,7 +394,13 @@ Pathcomp_t *path_nextcomp(Shell_t *shp, Pathcomp_t *pp, const char *name, Pathco
 static_fn Pathcomp_t *defpath_init(Shell_t *shp) {
     if (!std_path) {
         std_path = astconf("PATH", NULL, NULL);
-        if (!std_path) std_path = e_defpath;
+        if (std_path) {
+            // Value returned by astconf() is short lived, duplicate the string.
+            // https://github.com/att/ast/issues/959
+            std_path = strdup(std_path);
+        } else {
+            std_path = e_defpath;
+        }
     }
     return path_addpath(shp, NULL, std_path, PATH_PATH);
 }


### PR DESCRIPTION
`astconf()` function internally uses `fmtbuf()` to allocate memory.
Memory allocated by this function is short-lived and should not be
directly used in global variables, so duplicate the string returned by
`astconf()` function.

Resolves: #959