### PR TITLE
Return 1 from `signbit` function if sign bit is set

### DIFF
--- a/src/cmd/ksh93/bltins/math.c
+++ b/src/cmd/ksh93/bltins/math.c
@@ -113,7 +113,7 @@ static Sfdouble_t local_nexttoward(int type_1, Sfdouble_t arg_1, int type_2, Sfd
 }
 
 static int local_signbit(Sfdouble_t a1) {
-    return signbit(a1);  //!OCLINT(constant conditional operator)
+    return signbit(a1) != 0;  //!OCLINT(constant conditional operator)
 }
 
 static Sfdouble_t local_y0(Sfdouble_t a1) { return y0(a1); }

--- a/src/cmd/ksh93/tests/math.sh
+++ b/src/cmd/ksh93/tests/math.sh
@@ -411,7 +411,13 @@ actual=$(( round(99.9) ))
 
 # ==========
 # signbit
-# TODO: It returns 512 if number is negative. Is that expected behavior ?
+expect=0
+actual=$(( signbit(1) ))
+[[ $actual -eq $expect ]] || log_error "signbit(1) failed" "$expect" "$actual"
+
+expect=1
+actual=$(( signbit(-1) ))
+[[ $actual -eq $expect ]] || log_error "signbit(-1) failed" "$expect" "$actual"
 
 # ==========
 # sin


### PR DESCRIPTION
`signbit` function prints 512 on Linux if sign bit is set. It should
print 1 to make the result more clear.

Resolves: #967