### PR TITLE
Fix a bug found by ASAN after enabling builtins

### DIFF
--- a/src/lib/libdll/dllscan.c
+++ b/src/lib/libdll/dllscan.c
@@ -237,6 +237,7 @@ Dllscan_t *dllsopen(const char *lib, const char *name, const char *version) {
             scan->pb = malloc(t - name + 2);
             if (!scan->pb) goto bad;
             memcpy(scan->pb, name, t - name);
+            scan->pb[t - name + 1] = 0;
             name = (const char *)(t + 1);
         }
     }


### PR DESCRIPTION
Properly null terminate the dynamically allocated string. This reduces
unit test failures under ASAN on my system from 128 to 43.

Related #969