### PR TITLE
Coverity "Dereference after null check" bug

### DIFF
--- a/src/cmd/ksh93/include/fault.h
+++ b/src/cmd/ksh93/include/fault.h
@@ -133,7 +133,7 @@ extern void set_trapinfo(Shell_t *shp, int sig, siginfo_t *info);
 #undef signal
 #define signal(a, b) ERROR("use sh_signal() not signal()")
 
-extern void sh_done(void *, int);
+extern __attribute__((noreturn)) void sh_done(void *, int);
 extern void sh_siginit(Shell_t *shp);
 extern void *sh_timeradd(unsigned long, int, void (*)(void *), void *);
 extern void timerdel(void *);

--- a/src/cmd/ksh93/sh/fault.c
+++ b/src/cmd/ksh93/sh/fault.c
@@ -39,6 +39,7 @@
 
 #include "ast.h"
 #include "ast_aso.h"
+#include "ast_assert.h"
 #include "error.h"
 #include "fault.h"
 #include "fcin.h"
@@ -432,13 +433,14 @@ void sh_chktrap(Shell_t *shp) {
 // Exit the current scope and jump to an earlier one based on pp->mode.
 //
 void sh_exit_20120720(Shell_t *shp, int xno) {
-    struct checkpt *pp = (struct checkpt *)shp->jmplist;
-    int sig = 0;
     Sfio_t *pool;
+    int sig = 0;
+    struct checkpt *pp = (struct checkpt *)shp->jmplist;
+    assert(pp);
 
     shp->exitval = xno;
     if (xno == SH_EXITSIG) shp->exitval |= (sig = shp->lastsig);
-    if (pp && pp->mode > 1) cursig = -1;
+    if (pp->mode > 1) cursig = -1;
     if (shp->procsub) *shp->procsub = 0;
 #ifdef SIGTSTP
     if ((shp->trapnote & SH_SIGTSTP) && job.jobcontrol) {
@@ -515,7 +517,7 @@ static_fn void array_notify(Namval_t *np, void *data) {
 //
 // This is the exit routine for the shell.
 //
-void sh_done(void *ptr, int sig) {
+__attribute__((noreturn)) void sh_done(void *ptr, int sig) {
     Shell_t *shp = (Shell_t *)ptr;
     char *t;
     int savxit = shp->exitval;


### PR DESCRIPTION
It appears that `shp->jmplist` has to be non-NULL and that the predicate
for it being non-NULL that this change removes is a holdover from a time
when it could be NULL.  Looking at the entire project there are a couple of
places with similar tests but far more that simply assume it is non-NULL.

Coverity CID#279531