### PR TITLE
Add an `abort()` call in `return` builtin

### DIFF
--- a/src/cmd/ksh93/bltins/cflow.c
+++ b/src/cmd/ksh93/bltins/cflow.c
@@ -82,7 +82,8 @@ done:
 
     shp->savexit = n;
     sh_exit(shp, shp->savexit);
-    return 1;
+
+    abort();
 }
 
 //


### PR DESCRIPTION
This code is unreachable, so it should never execute.