### PR TITLE
Use correct filename for audit file

### DIFF
--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -45,8 +45,6 @@
 #include "stk.h"
 #include "tv.h"
 
-#define stringify(s) #s
-
 //
 // Each command in the history file starts on an even byte is null terminated. The first byte must
 // contain the special character HIST_UNDO and the second byte is the version number.  The sequence
@@ -281,7 +279,7 @@ retry:
 
     char buff[SF_BUFSIZE];
     if (!sh_isstate(shp, SH_INTERACTIVE)) return 1;
-    hp->auditmask = sh_checkaudit(hp, stringify(AUDIT_FILE), buff, sizeof(buff));
+    hp->auditmask = sh_checkaudit(hp, AUDIT_FILE, buff, sizeof(buff));
     if (!hp->auditmask) return 1;
 
     if ((fd = sh_open(buff, O_BINARY | O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC,


### PR DESCRIPTION
`AUDIT_FILE` contains name of the file that should be used as audit
file. Use it's value instead of stringifying it. Also, remove unused
macro `stringify`.

Related: #240