### PR TITLE
Improve tests for `echo` builtin

### DIFF
--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -77,7 +77,7 @@ all_tests = [
     # Test non-special builtins; i.e., those that have to be enabled explicitly.
     ['b_chmod'],
     # These are interactive tests to be run via the `expect` utility.
-    ['emacs.exp'], ['hist.exp'], ['jobs.exp'], ['read.exp'], ['set.exp'], ['vi.exp'],
+    ['echo.exp'], ['emacs.exp'], ['hist.exp'], ['jobs.exp'], ['read.exp'], ['set.exp'], ['vi.exp'],
     # The following are tests that must be run serially after all other tests that might be run in
     # parallel. For example, the `special-dev-paths` test opens network connections on fixed TCP/IP
     # port numbers and thus cannot be run in parallel with itself (shcomp and non-shcomp variants).

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -100,9 +100,6 @@ then
     log_error 'break labels not working'
 fi
 
-[[ $(echo -n hello) = "hello" ]] || log_error "echo -n should not print a newline"
-[[ $(echo -e "hello\tworld") = $'hello\tworld' ]] || log_error "echo -e should interpret escape sequences"
-
 mkdir -p $TEST_DIR/a/b/c 2>/dev/null || log_error  "mkdir -p failed"
 $SHELL -c "cd $TEST_DIR/a/b; cd c" || log_error "initial script relative cd fails"
 

--- a/src/cmd/ksh93/tests/echo.exp
+++ b/src/cmd/ksh93/tests/echo.exp
@@ -1,0 +1,44 @@
+# Test for echo builtin
+set pid [spawn $ksh]
+expect_prompt
+
+# ==========
+log_test_entry
+send "echo -n hello world; echo EOT\r"
+expect "\r\nhello worldEOT\r\n" {
+    puts "echo -n does not print new line"
+}
+expect_prompt
+
+# ==========
+log_test_entry
+send "echo -e 'hello\nworld'\r"
+expect "\r\nhello\r\nworld\r\n" {
+    puts "echo -e interprets escape sequences"
+}
+expect_prompt
+
+# ==========
+log_test_entry
+send "echo -ne 'hello\nworld'; echo EOT\r"
+expect "\r\nhello\r\nworldEOT\r\n" {
+    puts "echo -ne does not print new line and interprets escape sequences"
+}
+expect_prompt
+
+# ==========
+log_test_entry
+send "echo -en 'hello\nworld'; echo EOT\r"
+expect "\r\nhello\r\nworldEOT\r\n" {
+    puts "echo -en does not print new line and interprets escape sequences"
+}
+expect_prompt
+
+# Exit shell with ctrl-d
+log_test_entry
+send [ctrl D]
+catch {expect default exp_continue} output
+log_debug "EOF output: $output"
+
+catch {wait}
+exit 0

--- a/src/cmd/ksh93/tests/echo.exp.out
+++ b/src/cmd/ksh93/tests/echo.exp.out
@@ -1,0 +1,4 @@
+echo -n does not print new line
+echo -e interprets escape sequences
+echo -ne does not print new line and interprets escape sequences
+echo -en does not print new line and interprets escape sequences


### PR DESCRIPTION
Running `echo` builtin inside subshell eats last newline character.
Instead use expect based tests to check for newline characters.