### PR TITLE
`whence -a` should print correct path for tracked aliases

### DIFF
--- a/src/cmd/ksh93/bltins/whence.c
+++ b/src/cmd/ksh93/bltins/whence.c
@@ -283,8 +283,9 @@ static_fn int whence(Shell_t *shp, char **argv, int flags) {
                 if (flags & V_FLAG) {
                     if (*cp != '/') {
                         if (!np && (np = nv_search(name, shp->track_tree, 0))) {
+                            const char *command_path = np->nvalue.pathcomp->name;
                             sfprintf(sfstdout, "%s %s %s/%s\n", name, sh_translate(is_talias),
-                                     path_pwd(shp), cp);
+                                     command_path, cp);
                         } else if (!np || nv_isnull(np)) {
                             sfprintf(sfstdout, "%s%s\n", name, sh_translate(is_ufunction));
                         }


### PR DESCRIPTION
`whence -a` should print path that a tracked alias refers to instead of
associating it with current directory.

This bug was reported to previous maintainers around 2 decades ago, but
it was never fixed. Original credits to @DavidMorano for finding and
reporting this bug.

Better late than never!

Resolves: #954