### PR TITLE
Fix a loop condition in `cat` builtin

### DIFF
--- a/src/lib/libcmd/cat.c
+++ b/src/lib/libcmd/cat.c
@@ -489,8 +489,8 @@ int b_cat(int argc, char **argv, Shbltin_t *context) {
             }
         }
         if (sferror(sfstdout)) break;
-        cp = *argv++;
-    } while (cp);
+        ;
+    } while ((cp = *argv++));
     if (sfsync(sfstdout)) error(ERROR_system(0), "write error");
     if (flags & d_FLAG) sfopen(sfstdout, NULL, "w");
     return error_info.errors;


### PR DESCRIPTION
`cat` builtin goes in an infinite loop while trying to open a
non-existent file. This is a regression introduced by e0b778397.

Resolves: #1051