### PR TITLE
Fix a crash when auditing is enabled

### DIFF
--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -293,7 +293,7 @@ retry:
     }
     if (fd >= 0) {
         (void)fcntl(fd, F_SETFD, FD_CLOEXEC);
-        hp->tty = strdup(ttyname(2));
+        hp->tty = strdup(isatty(2) ? ttyname(2) : "notty");
         hp->auditfp = sfnew(NULL, NULL, -1, fd, SF_WRITE);
     }
 


### PR DESCRIPTION
`ttyname()` returns NULL if a fd is not associated with any terminal.
This may cause a crash in `strdup()` function.

Resolves: #1028