### PR TITLE
Sync all streams after executing a builtin

### DIFF
--- a/src/cmd/ksh93/sh/fault.c
+++ b/src/cmd/ksh93/sh/fault.c
@@ -76,7 +76,10 @@ static_fn int notify_builtin(Shell_t *shp, int sig) {
     int action = 0;
 
     if (!shp->bltinfun) return action;
-    if (error_info.flags & ERROR_NOTIFY) action = (*shp->bltinfun)(-sig, NULL, NULL);
+    if (error_info.flags & ERROR_NOTIFY) {
+        action = (*shp->bltinfun)(-sig, NULL, NULL);
+        sfsync(NULL);
+    }
     if (action > 0) return action;
     if (shp->bltindata.notify) shp->bltindata.sigset = 1;
     return action;

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1099,7 +1099,10 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                                     (fd != shp->pwdfd))
                                     sh_close(fd);
                         }
-                        if (argn) shp->exitval = (*shp->bltinfun)(argn, com, (void *)bp);
+                        if (argn) {
+                            shp->exitval = (*shp->bltinfun)(argn, com, (void *)bp);
+                            sfsync(NULL);
+                        }
                         if (error_info.flags & ERROR_INTERACTIVE) tty_check(ERRIO);
                         ((Shnode_t *)t)->com.comstate = shp->bltindata.data;
                         bp->data = (void *)save_data;
@@ -1122,6 +1125,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                         }
                         if (shp->bltinfun && (error_info.flags & ERROR_NOTIFY)) {
                             (*shp->bltinfun)(-2, com, (void *)bp);
+                            sfsync(NULL);
                         }
                         // Failure on special built-ins fatal.
                         if (jmpval <= SH_JMPCMD && (!nv_isattr(np, BLT_SPC) || command)) {


### PR DESCRIPTION
After executing a builtin, all streams should be synced to avoid any
delay in output.

Resolves: #1069