### PR TITLE
Introduce op types

### DIFF
--- a/src/cmd/ksh93/bltins/enum.c
+++ b/src/cmd/ksh93/bltins/enum.c
@@ -152,7 +152,7 @@ static_fn void put_enum(Namval_t *np, const void *val, int flags, Namfun_t *fp) 
     int n;
     if (!val && !(flags & NV_INTEGER)) {
         nv_putv(np, val, flags, fp);
-        nv_disc(np, &ep->hdr, NV_POP);
+        nv_disc(np, &ep->hdr, DISC_OP_POP);
         if (!ep->hdr.nofree) free(ep);
         return;
     }
@@ -356,7 +356,7 @@ int b_enum(int argc, char **argv, Shbltin_t *context) {
         ep->hdr.disc = &ENUM_disc;
         ep->hdr.type = tp;
         nv_onattr(tp, NV_RDONLY);
-        nv_disc(tp, &ep->hdr, NV_FIRST);
+        nv_disc(tp, &ep->hdr, DISC_OP_FIRST);
         memset(&optdisc, 0, sizeof(optdisc));
         optdisc.opt.infof = enuminfo;
         optdisc.np = tp;

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -759,12 +759,12 @@ static_fn int setall(char **argv, int flag, Dt_t *troot, struct tdata *tp) {
                 if (fp) {
                     if (tp->aflag == '+') {
                         if (cp && strcmp(cp, tp->wctname) == 0) {
-                            nv_disc(np, fp, NV_POP);
+                            nv_disc(np, fp, DISC_OP_POP);
                             if (!(fp->nofree & 1)) free(fp);
                             nv_offattr(np, flag & (NV_LTOU | NV_UTOL));
                         }
                     } else if (!cp || strcmp(cp, tp->wctname)) {
-                        nv_disc(np, fp, NV_LAST);
+                        nv_disc(np, fp, DISC_OP_LAST);
                         nv_onattr(np, flag & (NV_LTOU | NV_UTOL));
                     }
                 }

--- a/src/cmd/ksh93/include/name.h
+++ b/src/cmd/ksh93/include/name.h
@@ -189,7 +189,6 @@ extern bool nv_unsetnotify(Namval_t *, char **);
 extern struct argnod *nv_onlist(struct argnod *, const char *);
 extern void nv_optimize(Namval_t *);
 extern void nv_unref(Namval_t *);
-extern void _nv_unset(Namval_t *, int);
 extern bool nv_hasget(Namval_t *);
 extern void nv_chkrequired(Namval_t *);
 extern int nv_clone(Namval_t *, Namval_t *, int);

--- a/src/cmd/ksh93/include/name.h
+++ b/src/cmd/ksh93/include/name.h
@@ -76,7 +76,6 @@ union Value {
 #define ARRAY_SETSUB (64L << ARRAY_BITS)    // set subscript
 #define ARRAY_NOSCOPE (128L << ARRAY_BITS)  // top level scope only
 #define ARRAY_TREE (256L << ARRAY_BITS)     // arrays of compound vars
-#define NV_ASETSUB 8                        // set subscript
 
 // These flags are used as options to array_get().
 #define ARRAY_ASSIGN 0

--- a/src/cmd/ksh93/include/nval.h
+++ b/src/cmd/ksh93/include/nval.h
@@ -211,11 +211,25 @@ static inline bool nv_isarray(Namval_t *np) { return nv_isattr(np, NV_ARRAY) == 
 #define NV_ACURRENT 7  // return current subscript Namval_t*
 #define NV_ASETSUB 8   // set current subscript
 
-// The following are for nv_disc.
-#define NV_FIRST 1
-#define NV_LAST 2
-#define NV_POP 3
-#define NV_CLONE 4
+// The following symbols are for use with nv_disc(). We start with the arbitrary value 113 to help
+// ensure that calling `nv_disc()` with an unexpected op value (especially zero) will fail.
+enum {
+    DISC_OP_NOOP_val = 1,  // ??? (this used to be the magic `0` constant used by four callers)
+    DISC_OP_FIRST_val,     // Move or push <fp> to top of the stack or delete top
+    DISC_OP_LAST_val,      // Move or push <fp> to bottom of stack or delete last
+    DISC_OP_POP_val,       // Delete <fp> from top of the stack
+    DISC_OP_CLONE_val      // Replace <fp> with a copy created my malloc() and return it
+};
+
+typedef struct {
+    int val;
+} Nvdisc_op_t;
+
+const Nvdisc_op_t DISC_OP_NOOP;
+const Nvdisc_op_t DISC_OP_FIRST;
+const Nvdisc_op_t DISC_OP_LAST;
+const Nvdisc_op_t DISC_OP_POP;
+const Nvdisc_op_t DISC_OP_CLONE;
 
 // The following are operations for nv_putsub().
 #define ARRAY_BITS 22
@@ -268,7 +282,7 @@ extern int nv_settype(Namval_t *, Namval_t *, int);
 extern void nv_setvec(Namval_t *, int, int, char *[]);
 extern void nv_setvtree(Namval_t *);
 extern int nv_setsize(Namval_t *, int);
-extern Namfun_t *nv_disc(Namval_t *, Namfun_t *, int);
+extern Namfun_t *nv_disc(Namval_t *, Namfun_t *, Nvdisc_op_t);
 extern void nv_unset(Namval_t *); /*obsolete */
 extern void _nv_unset(Namval_t *, int);
 extern Namval_t *nv_search(const char *, Dt_t *, int);
@@ -281,6 +295,6 @@ extern const Namdisc_t *nv_discfun(int);
 
 #define nv_unset(np) _nv_unset(np, 0)
 #define nv_size(np) nv_setsize((np), -1)
-#define nv_stack(np, nf) nv_disc(np, nf, 0)
+#define nv_stack(np, nf) nv_disc(np, nf, DISC_OP_NOOP)
 
 #endif  // _NVAL_H

--- a/src/cmd/ksh93/include/nval.h
+++ b/src/cmd/ksh93/include/nval.h
@@ -84,13 +84,39 @@ struct Nambfun {
     Namval_t *bltins[1];
 };
 
+// The following constants define operations on associative arrays performed by `nv_associative()`.
+enum {
+    ASSOC_OP_INIT_val = 1,  // initialize
+    ASSOC_OP_FREE_val,      // free array
+    ASSOC_OP_NEXT_val,      // advance to next subscript
+    ASSOC_OP_NAME_val,      // return subscript name
+    ASSOC_OP_DELETE_val,    // delete current subscript
+    ASSOC_OP_ADD_val,       // add subscript if not found
+    ASSOC_OP_ADD2_val,      // ??? (this used to be the constant zero passed to nv_associative())
+    ASSOC_OP_CURRENT_val,   // return current subscript Namval_t*
+    ASSOC_OP_SETSUB_val,    // set current subscript
+};
+
+typedef struct {
+    int val;
+} Nvassoc_op_t;
+const Nvassoc_op_t ASSOC_OP_INIT;
+const Nvassoc_op_t ASSOC_OP_FREE;
+const Nvassoc_op_t ASSOC_OP_NEXT;
+const Nvassoc_op_t ASSOC_OP_NAME;
+const Nvassoc_op_t ASSOC_OP_DELETE;
+const Nvassoc_op_t ASSOC_OP_ADD;
+const Nvassoc_op_t ASSOC_OP_ADD2;
+const Nvassoc_op_t ASSOC_OP_CURRENT;
+const Nvassoc_op_t ASSOC_OP_SETSUB;
+
 // This is an array template header.
 struct Namarray {
     Namfun_t hdr;
-    long nelem;                                   // number of elements
-    void *(*fun)(Namval_t *, const char *, int);  // associative arrays
-    Dt_t *table;                                  // for subscripts
-    void *scope;                                  // non-NULL when scoped
+    long nelem;                                            // number of elements
+    void *(*fun)(Namval_t *, const char *, Nvassoc_op_t);  // associative array ops
+    Dt_t *table;                                           // for subscripts
+    void *scope;                                           // non-NULL when scoped
     int flags;
 };
 
@@ -201,16 +227,6 @@ static inline void nv_setattr(Namval_t *np, unsigned int nvflag) { np->nvflag = 
 
 static inline bool nv_isarray(Namval_t *np) { return nv_isattr(np, NV_ARRAY) == NV_ARRAY; }
 
-// The following are operations for associative arrays.
-#define NV_AINIT 1     // initialize
-#define NV_AFREE 2     // free array
-#define NV_ANEXT 3     // advance to next subscript
-#define NV_ANAME 4     // return subscript name
-#define NV_ADELETE 5   // delete current subscript
-#define NV_AADD 6      // add subscript if not found
-#define NV_ACURRENT 7  // return current subscript Namval_t*
-#define NV_ASETSUB 8   // set current subscript
-
 // The following symbols are for use with nv_disc(). We start with the arbitrary value 113 to help
 // ensure that calling `nv_disc()` with an unexpected op value (especially zero) will fail.
 enum {
@@ -247,9 +263,9 @@ typedef enum {
 
 // Prototype for array interface.
 extern Namarr_t *nv_arrayptr(Namval_t *);
-extern Namarr_t *nv_setarray(Namval_t *, void *(*)(Namval_t *, const char *, int));
+extern Namarr_t *nv_setarray(Namval_t *, void *(*)(Namval_t *, const char *, Nvassoc_op_t));
 extern int nv_arraynsub(Namarr_t *);
-extern void *nv_associative(Namval_t *, const char *, int);
+extern void *nv_associative(Namval_t *, const char *, Nvassoc_op_t);
 extern int nv_aindex(Namval_t *);
 extern bool nv_nextsub(Namval_t *);
 extern char *nv_getsub(Namval_t *);

--- a/src/cmd/ksh93/include/nval.h
+++ b/src/cmd/ksh93/include/nval.h
@@ -237,9 +237,13 @@ const Nvdisc_op_t DISC_OP_CLONE;
 #define ARRAY_SCAN (2L << ARRAY_BITS)   // For ${array[@]}
 #define ARRAY_UNDEF (4L << ARRAY_BITS)  // For ${array}
 
-// These  are disciplines provided by the library for use with nv_discfun.
-#define NV_DCADD 0       // used to add named disciplines
-#define NV_DCRESTRICT 1  // variable that are restricted in rsh
+// These symbols are passed to `nv_discfun()` to cause it to return a set of disciplines that
+// implement a specific policy. We start with the arbitrary value 19 to help ensure that calling
+// `nv_discfun()` with an unexpected op value will fail.
+typedef enum {
+    DISCFUN_ADD = 19,  // for vars that have named shell level disciplines (e.g., var.get() {...})
+    DISCFUN_RESTRICT   // for vars that cannot be modified in a restricted shell
+} Nvdiscfun_op_t;
 
 // Prototype for array interface.
 extern Namarr_t *nv_arrayptr(Namval_t *);
@@ -291,7 +295,7 @@ extern Namval_t *nv_type(Namval_t *);
 // Note that the third parameter should be a pointer to a Optdisc_t or a structure where that type
 // is the first member.
 extern void nv_addtype(Namval_t *, const char *, void *, size_t);
-extern const Namdisc_t *nv_discfun(int);
+extern const Namdisc_t *nv_discfun(Nvdiscfun_op_t);
 
 #define nv_unset(np) _nv_unset(np, 0)
 #define nv_size(np) nv_setsize((np), -1)

--- a/src/cmd/ksh93/sh/array.c
+++ b/src/cmd/ksh93/sh/array.c
@@ -100,7 +100,7 @@ static_fn bool array_unscope(Namval_t *np, Namarr_t *ap) {
 
     if (!ap->scope) return false;
     if (is_associative(ap)) (*ap->fun)(np, NULL, NV_AFREE);
-    fp = nv_disc(np, (Namfun_t *)ap, NV_POP);
+    fp = nv_disc(np, (Namfun_t *)ap, DISC_OP_POP);
     if (fp && !(fp->nofree & 1)) free(fp);
     nv_delete(np, NULL, 0);
     return true;
@@ -580,7 +580,7 @@ static_fn void array_putval(Namval_t *np, const void *string, int flags, Namfun_
             _nv_unset(nv_namptr(aq->xp, 0), NV_RDONLY);
             free(aq->xp);
         }
-        if ((nfp = nv_disc(np, (Namfun_t *)ap, NV_POP)) && !(nfp->nofree & 1)) {
+        if ((nfp = nv_disc(np, (Namfun_t *)ap, DISC_OP_POP)) && !(nfp->nofree & 1)) {
             ap = 0;
             free(nfp);
         }
@@ -602,14 +602,14 @@ static const Namdisc_t array_disc = {.dsize = sizeof(Namarr_t),
                                      .clonef = array_clone};
 
 static_fn void array_copytree(Namval_t *np, Namval_t *mp) {
-    Namfun_t *fp = nv_disc(np, NULL, NV_POP);
+    Namfun_t *fp = nv_disc(np, NULL, DISC_OP_POP);
     nv_offattr(np, NV_ARRAY);
     nv_clone(np, mp, 0);
     if (np->nvalue.cp && !nv_isattr(np, NV_NOFREE)) free(np->nvalue.sp);
     np->nvalue.cp = 0;
     np->nvalue.up = &mp->nvalue;
     fp->nofree &= ~1;
-    nv_disc(np, (Namfun_t *)fp, NV_FIRST);
+    nv_disc(np, (Namfun_t *)fp, DISC_OP_FIRST);
     fp->nofree |= 1;
     nv_onattr(np, NV_ARRAY);
     mp->nvenv = (char *)np;
@@ -687,7 +687,7 @@ static_fn struct index_array *array_grow(Namval_t *np, struct index_array *arp, 
         ap->namarr.nelem = i;
         ap->namarr.flags = flags;
         ap->namarr.hdr.disc = &array_disc;
-        nv_disc(np, (Namfun_t *)ap, NV_FIRST);
+        nv_disc(np, (Namfun_t *)ap, DISC_OP_FIRST);
         nv_onattr(np, NV_ARRAY);
         if (mp) {
             array_copytree(np, mp);
@@ -853,7 +853,7 @@ Namval_t *nv_arraychild(Namval_t *np, Namval_t *nq, int c) {
     }
     nq->nvenv = (char *)np;
     nq->nvshell = np->nvshell;
-    if ((fp = nq->nvfun) && fp->disc && fp->disc->setdisc && (fp = nv_disc(nq, fp, NV_POP))) {
+    if ((fp = nq->nvfun) && fp->disc && fp->disc->setdisc && (fp = nv_disc(nq, fp, DISC_OP_POP))) {
         free(fp);
     }
     if (!ap->fun) {
@@ -1189,7 +1189,7 @@ void *nv_associative(Namval_t *np, const char *sp, int mode) {
                 ap->cur = 0;
                 ap->pos = 0;
                 ap->namarr.hdr.disc = &array_disc;
-                nv_disc(np, (Namfun_t *)ap, NV_FIRST);
+                nv_disc(np, (Namfun_t *)ap, DISC_OP_FIRST);
                 ap->namarr.hdr.dsize = sizeof(struct assoc_array);
                 ap->namarr.hdr.nofree &= ~1;
             }

--- a/src/cmd/ksh93/sh/bash.c
+++ b/src/cmd/ksh93/sh/bash.c
@@ -376,7 +376,7 @@ void bash_init(Shell_t *shp, int mode) {
     // Restrict BASH_ENV.
     np = nv_open("BASH_ENV", shp->var_tree, 0);
     if (np) {
-        const Namdisc_t *dp = nv_discfun(NV_DCRESTRICT);
+        const Namdisc_t *dp = nv_discfun(DISCFUN_RESTRICT);
         Namfun_t *fp = calloc(dp->dsize, 1);
         fp->disc = dp;
         nv_disc(np, fp, DISC_NOOP);

--- a/src/cmd/ksh93/sh/bash.c
+++ b/src/cmd/ksh93/sh/bash.c
@@ -379,7 +379,7 @@ void bash_init(Shell_t *shp, int mode) {
         const Namdisc_t *dp = nv_discfun(NV_DCRESTRICT);
         Namfun_t *fp = calloc(dp->dsize, 1);
         fp->disc = dp;
-        nv_disc(np, fp, 0);
+        nv_disc(np, fp, DISC_NOOP);
     }
 
     // Open GLOBIGNORE node.
@@ -388,7 +388,7 @@ void bash_init(Shell_t *shp, int mode) {
         const Namdisc_t *dp = &SH_GLOBIGNORE_disc;
         Namfun_t *fp = calloc(dp->dsize, 1);
         fp->disc = dp;
-        nv_disc(np, fp, 0);
+        nv_disc(np, fp, DISC_NOOP);
     }
 
     np = nv_open("BASH_EXECUTION_STRING", shp->var_tree, 0);

--- a/src/cmd/ksh93/sh/fault.c
+++ b/src/cmd/ksh93/sh/fault.c
@@ -512,7 +512,7 @@ static_fn void array_notify(Namval_t *np, void *data) {
     Namarr_t *ap = nv_arrayptr(np);
     UNUSED(data);
 
-    if (ap && ap->fun) (*ap->fun)(np, 0, NV_AFREE);
+    if (ap && ap->fun) (*ap->fun)(np, 0, ASSOC_OP_FREE);
 }
 
 //

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -256,7 +256,7 @@ static_fn void put_optindex(Namval_t *np, const void *val, int flags, Namfun_t *
     Shell_t *shp = sh_ptr(np);
     shp->st.opterror = shp->st.optchar = 0;
     nv_putv(np, val, flags, fp);
-    if (!val) nv_disc(np, fp, NV_POP);
+    if (!val) nv_disc(np, fp, DISC_OP_POP);
 }
 
 static_fn Sfdouble_t nget_optindex(Namval_t *np, Namfun_t *fp) {
@@ -720,7 +720,7 @@ static_fn void match2d(Shell_t *shp, struct match *mp) {
     int i;
     Namarr_t *ap;
 
-    nv_disc(SH_MATCHNOD, &mp->hdr, NV_POP);
+    nv_disc(SH_MATCHNOD, &mp->hdr, DISC_OP_POP);
     np = nv_namptr(mp->nodes, 0);
     for (i = 0; i < mp->nmatch; i++) {
         np->nvname = mp->names + 3 * i;
@@ -757,7 +757,7 @@ void sh_setmatch(Shell_t *shp, const char *v, int vsize, int nmatch, int match[]
         np = nv_namptr(mp->nodes, 0);
         if (mp->index == 0) match2d(shp, mp);
         for (i = 0; i < mp->nmatch; i++) {
-            nv_disc(np, &mp->hdr, NV_LAST);
+            nv_disc(np, &mp->hdr, DISC_OP_LAST);
             nv_putsub(np, NULL, mp->index, 0);
             for (x = mp->index; x >= 0; x--) {
                 n = i + x * mp->nmatch;
@@ -796,7 +796,7 @@ void sh_setmatch(Shell_t *shp, const char *v, int vsize, int nmatch, int match[]
         }
         mp->nodes = (char *)calloc(mp->nmatch * (NV_MINSZ + sizeof(void *) + 3), 1);
         mp->names = mp->nodes + mp->nmatch * (NV_MINSZ + sizeof(void *));
-        nv_disc(SH_MATCHNOD, &mp->hdr, NV_LAST);
+        nv_disc(SH_MATCHNOD, &mp->hdr, DISC_OP_LAST);
         for (i = nmatch; --i >= 0;) {
             if (match[2 * i] >= 0) nv_putsub(SH_MATCHNOD, Empty, i, ARRAY_ADD);
         }
@@ -2045,7 +2045,7 @@ static_fn void put_trans(Namval_t *np, const void *vp, int flags, Namfun_t *fp) 
         val = stakptr(offset);
     } else {
         nv_putv(np, val, flags, fp);
-        nv_disc(np, fp, NV_POP);
+        nv_disc(np, fp, DISC_OP_POP);
         if (!(fp->nofree & 1)) free(fp);
         stakseek(offset);
         return;
@@ -2071,7 +2071,7 @@ Namfun_t *nv_mapchar(Namval_t *np, const char *name) {
     if (low && strcmp(name, e_toupper)) n += strlen(name) + 1;
     if (mp) {
         if (strcmp(name, mp->name) == 0) return &mp->hdr;
-        nv_disc(np, &mp->hdr, NV_POP);
+        nv_disc(np, &mp->hdr, DISC_OP_POP);
         if (!(mp->hdr.nofree & 1)) free(mp);
     }
     mp = calloc(1, sizeof(struct Mapchar) + n);

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -1112,8 +1112,10 @@ void nv_delete(Namval_t *np, Dt_t *root, int flags) {
                 ((flags & NV_FUNCTION) || !nv_subsaved(np, flags & NV_TABLE))) {
                 Namarr_t *ap;
                 if (nv_isarray(np) && np->nvfun && (ap = nv_arrayptr(np)) && is_associative(ap)) {
-                    while (nv_associative(np, 0, NV_ANEXT)) nv_associative(np, 0, NV_ADELETE);
-                    nv_associative(np, 0, NV_AFREE);
+                    while (nv_associative(np, 0, ASSOC_OP_NEXT)) {
+                        nv_associative(np, 0, ASSOC_OP_DELETE);
+                    }
+                    nv_associative(np, 0, ASSOC_OP_FREE);
                     free(np->nvfun);
                 }
                 free(np);

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -2577,9 +2577,9 @@ void nv_newattr(Namval_t *np, unsigned newatts, int size) {
             mp = nv_opensub(np);
             if (mp) {
                 if (trans) {
-                    nv_disc(np, &ap->hdr, NV_POP);
+                    nv_disc(np, &ap->hdr, DISC_OP_POP);
                     nv_clone(np, mp, 0);
-                    nv_disc(np, &ap->hdr, NV_FIRST);
+                    nv_disc(np, &ap->hdr, DISC_OP_FIRST);
                     nv_offattr(mp, NV_ARRAY);
                 }
                 nv_newattr(mp, newatts & ~NV_ARRAY, size);

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -186,7 +186,9 @@ static_fn struct blocked *block_info(Namval_t *np, struct blocked *pp) {
     void *sub = 0;
     int isub = 0;
 
-    if (nv_isarray(np) && (isub = nv_aindex(np)) < 0) sub = nv_associative(np, NULL, NV_ACURRENT);
+    if (nv_isarray(np) && (isub = nv_aindex(np)) < 0) {
+        sub = nv_associative(np, NULL, ASSOC_OP_CURRENT);
+    }
     for (bp = blist; bp; bp = bp->next) {
         if (bp->np == np && bp->sub == sub && bp->isub == isub) return bp;
     }

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -1272,10 +1272,10 @@ Namval_t *nv_mount(Namval_t *np, const char *name, Dt_t *dict) {
     return mp;
 }
 
-const Namdisc_t *nv_discfun(int which) {
-    if (which == NV_DCADD) return &Nv_bdisc;
-    if (which == NV_DCRESTRICT) return &RESTRICTED_disc;
-    return NULL;
+const Namdisc_t *nv_discfun(Nvdiscfun_op_t op) {
+    if (op == DISCFUN_ADD) return &Nv_bdisc;
+    if (op == DISCFUN_RESTRICT) return &RESTRICTED_disc;
+    abort();
 }
 
 bool nv_hasget(Namval_t *np) {

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -650,7 +650,7 @@ static_fn int typeinfo(Opt_t *op, Sfio_t *out, const char *str, Optdisc_t *od) {
     }
     if (strcmp(str, "other") == 0) {
         Nambfun_t *bp;
-        bp = (Nambfun_t *)nv_hasdisc(np, nv_discfun(NV_DCADD));
+        bp = (Nambfun_t *)nv_hasdisc(np, nv_discfun(DISCFUN_ADD));
         if (bp) {
             for (i = 0; i < bp->num; i++) {
                 if (nv_isattr(bp->bltins[i], NV_OPTGET)) {
@@ -1003,7 +1003,7 @@ Namval_t *nv_mktype(Namval_t **nodes, int numnodes) {
                     }
                 }
             }
-            bfp = (Nambfun_t *)nv_hasdisc(np, nv_discfun(NV_DCADD));
+            bfp = (Nambfun_t *)nv_hasdisc(np, nv_discfun(DISCFUN_ADD));
             if (bfp) {
                 for (j = 0; j < bfp->num; j++) {
                     pp->names[nd++] = (char *)bfp->bnames[j];

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -283,7 +283,7 @@ static_fn int fixnode(Namtype_t *dp, Namtype_t *pp, int i, struct Namref *nrp, i
     Namfun_t *fp;
 
     fp = nv_hasdisc(nq, &chtype_disc);
-    if (fp) nv_disc(nq, fp, NV_POP);
+    if (fp) nv_disc(nq, fp, DISC_OP_POP);
     if (nv_isattr(nq, NV_REF)) {
         nq->nvalue.nrp = nrp++;
         nv_setsize(nq, 0);
@@ -312,7 +312,7 @@ static_fn int fixnode(Namtype_t *dp, Namtype_t *pp, int i, struct Namref *nrp, i
             } else {
                 clone_all_disc(np, nq, flag);
             }
-            if (fp) nv_disc(np, fp, NV_LAST);
+            if (fp) nv_disc(np, fp, DISC_OP_LAST);
         }
 #if 0
 		if(nq->nvalue.cp >=  pp->data && nq->nvalue.cp < (char*)pp +pp->fun.dsize)
@@ -341,7 +341,7 @@ static_fn int fixnode(Namtype_t *dp, Namtype_t *pp, int i, struct Namref *nrp, i
             nv_offattr(nq, NV_NOFREE);
         }
     }
-    if (fp) nv_disc(nq, &dp->childfun.fun, NV_LAST);
+    if (fp) nv_disc(nq, &dp->childfun.fun, DISC_OP_LAST);
     return 0;
 }
 
@@ -565,7 +565,7 @@ static_fn void put_type(Namval_t *np, const void *val, int flag, Namfun_t *fp) {
                 _nv_unset(nq, flag | NV_TYPE | nv_isattr(nq, NV_RDONLY));
             }
         }
-        nv_disc(np, fp, NV_POP);
+        nv_disc(np, fp, DISC_OP_POP);
         if (!(fp->nofree & 1)) free(fp);
     }
 }
@@ -1040,12 +1040,12 @@ Namval_t *nv_mktype(Namval_t **nodes, int numnodes) {
             // If field is a type, mark the type by setting strsize<0.  This changes create_type().
             clone_all_disc(np, nq, NV_RDONLY);
             if (nv_isarray(np)) {
-                nv_disc(nq, &pp->childfun.fun, NV_LAST);
+                nv_disc(nq, &pp->childfun.fun, DISC_OP_LAST);
                 k++;
                 goto skip;
             }
             fp = nv_hasdisc(nq, &chtype_disc);
-            if (fp) nv_disc(nq, &pp->childfun.fun, NV_LAST);
+            if (fp) nv_disc(nq, &pp->childfun.fun, DISC_OP_LAST);
             tp = (Namtype_t *)nv_hasdisc(nq, &type_disc);
             if (tp) tp->strsize = -tp->strsize;
             for (r = 0; r < dp->numnodes; r++) {
@@ -1068,7 +1068,7 @@ Namval_t *nv_mktype(Namval_t **nodes, int numnodes) {
                     } else {
                         nq->nvalue.cp = strdup(nr->nvalue.cp);
                     }
-                    nv_disc(nq, &pp->childfun.fun, NV_LAST);
+                    nv_disc(nq, &pp->childfun.fun, DISC_OP_LAST);
                 }
                 nq->nvsize = nr->nvsize;
                 offset += dsize;
@@ -1102,7 +1102,7 @@ Namval_t *nv_mktype(Namval_t **nodes, int numnodes) {
             nq->nvfun = np->nvfun;
             nq->nvshell = np->nvshell;
             np->nvfun = 0;
-            nv_disc(nq, &pp->childfun.fun, NV_LAST);
+            nv_disc(nq, &pp->childfun.fun, DISC_OP_LAST);
             if (nq->nvfun) {
                 for (fp = nq->nvfun; fp; fp = fp->next) fp->nofree |= 1;
             }
@@ -1147,7 +1147,7 @@ Namval_t *nv_mktype(Namval_t **nodes, int numnodes) {
         mp->nvalue.cp = Empty;
     }
     nv_onattr(mp, NV_TAGGED);
-    nv_disc(mp, &pp->fun, NV_LAST);
+    nv_disc(mp, &pp->fun, DISC_OP_LAST);
     if (nd > 0) {
         pp->names[nd] = 0;
         nv_adddisc(mp, (const char **)pp->names, mnodes);
@@ -1187,7 +1187,7 @@ Namval_t *nv_mkinttype(char *name, size_t size, int sign, const char *help, Namd
         nv_onattr(mp, NV_INT64);
     }
     if (!sign) nv_onattr(mp, NV_UNSIGN);
-    nv_disc(mp, fp, NV_LAST);
+    nv_disc(mp, fp, DISC_OP_LAST);
     nv_newtype(mp);
     return mp;
 }
@@ -1297,7 +1297,7 @@ int nv_settype(Namval_t *np, Namval_t *tp, int flags) {
     }
     if (ap) {
         int nofree;
-        nv_disc(np, &ap->hdr, NV_POP);
+        nv_disc(np, &ap->hdr, DISC_OP_POP);
         np->nvalue.up = 0;
         nv_clone(tp, np, flags | NV_NOFREE);
         if (np->nvalue.cp && np->nvalue.cp != Empty && !nv_isattr(np, NV_NOFREE)) {
@@ -1307,7 +1307,7 @@ int nv_settype(Namval_t *np, Namval_t *tp, int flags) {
         nofree = ap->hdr.nofree;
         ap->hdr.nofree = 0;
         ap->hdr.type = tp;
-        nv_disc(np, &ap->hdr, NV_FIRST);
+        nv_disc(np, &ap->hdr, DISC_OP_FIRST);
         ap->hdr.nofree = nofree;
         nv_onattr(np, NV_ARRAY);
         if (nelem) {
@@ -1409,7 +1409,7 @@ Namval_t *nv_mkstruct(const char *name, int rsize, stat_fields_t *fields, void *
             if (dp) dp->strsize = -dp->strsize;
             dp = (Namtype_t *)nv_hasdisc(tp, &type_disc);
             if (dp) {
-                if (nv_hasdisc(nq, &chtype_disc)) nv_disc(nq, &pp->childfun.fun, NV_LAST);
+                if (nv_hasdisc(nq, &chtype_disc)) nv_disc(nq, &pp->childfun.fun, DISC_OP_LAST);
                 sp = (char *)nq->nvalue.cp;
                 memcpy(sp, dp->data, nv_size(tp));
                 for (j = 0; j < dp->numnodes; j++) {
@@ -1442,7 +1442,7 @@ Namval_t *nv_mkstruct(const char *name, int rsize, stat_fields_t *fields, void *
     stkseek(shp->stk, offset);
     nv_onattr(mp, NV_RDONLY | NV_NOFREE | NV_BINARY);
     nv_setsize(mp, rsize);
-    nv_disc(mp, &pp->fun, NV_LAST);
+    nv_disc(mp, &pp->fun, DISC_OP_LAST);
     mp->nvalue.cp = pp->data;
     nv_newtype(mp);
     return mp;
@@ -1455,7 +1455,7 @@ static_fn void put_stat(Namval_t *np, const void *val, int flag, Namfun_t *nfp) 
         return;
     }
     nv_putv(np, val, flag, nfp);
-    nv_disc(np, nfp, NV_POP);
+    nv_disc(np, nfp, DISC_OP_POP);
     if (!(nfp->nofree & 1)) free(nfp);
 }
 
@@ -1470,7 +1470,7 @@ void nv_mkstat(Shell_t *shp) {
     fp = calloc(1, sizeof(Namfun_t));
     fp->type = tp;
     fp->disc = &stat_disc;
-    nv_disc(tp, fp, NV_FIRST);
+    nv_disc(tp, fp, DISC_OP_FIRST);
     nv_putval(tp, e_devnull, 0);
     nv_onattr(tp, NV_RDONLY);
 }

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -439,14 +439,14 @@ static_fn Namfun_t *clone_type(Namval_t *np, Namval_t *mp, int flags, Namfun_t *
             nv_putsub(nr, NULL, 0, ARRAY_SCAN | ARRAY_NOSCOPE);
             do {
                 if (is_associative(ap)) {
-                    cp = (char *)((*ap->fun)(nr, NULL, NV_ANAME));
+                    cp = (char *)((*ap->fun)(nr, NULL, ASSOC_OP_NAME));
                 } else {
                     cp = nv_getsub(nr);
                 }
                 nv_putsub(nq, cp, 0, ARRAY_ADD | ARRAY_NOSCOPE);
                 if (is_associative(ap)) {
-                    Namval_t *mr = (Namval_t *)((*ap->fun)(nr, NULL, NV_ACURRENT));
-                    Namval_t *mq = (Namval_t *)((*ap->fun)(nq, NULL, NV_ACURRENT));
+                    Namval_t *mr = (Namval_t *)((*ap->fun)(nr, NULL, ASSOC_OP_CURRENT));
+                    Namval_t *mq = (Namval_t *)((*ap->fun)(nq, NULL, ASSOC_OP_CURRENT));
                     nv_clone(mr, mq, NV_MOVE);
                     ap->nelem--;
                     nv_delete(mr, ap->table, 0);

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -326,7 +326,7 @@ static_fn void nv_restore(struct subshell *sp) {
         if (nv_isattr(mp, NV_MINIMAL) && !nv_isattr(np, NV_EXPORT)) flags |= NV_MINIMAL;
         if (nv_isarray(mp)) nv_putsub(mp, NULL, 0, ARRAY_SCAN);
         nofree = mp->nvfun ? mp->nvfun->nofree : 0;
-        _nv_unset(mp, NV_RDONLY | NV_CLONE);
+        _nv_unset(mp, NV_RDONLY);
         if (nv_isarray(np)) {
             nv_clone(np, mp, NV_MOVE);
             goto skip;

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -512,7 +512,7 @@ static_fn struct Level *init_level(Shell_t *shp, int level) {
     shp->last_root = nv_dict(DOTSHNOD);
     nv_putval(SH_LEVELNOD, (char *)&lp->maxlevel, NV_INT16);
     lp->hdr.disc = &level_disc;
-    nv_disc(SH_LEVELNOD, &lp->hdr, NV_FIRST);
+    nv_disc(SH_LEVELNOD, &lp->hdr, DISC_OP_FIRST);
     return lp;
 }
 


### PR DESCRIPTION
These three changes represent a small step towards making it harder to incorrectly combine various constants related to the Namval_t type. And make it clearer which constants are related to Namval_t attributes versus adjunct functions (e.g., popping a Namval_t discipline).