### PR TITLE
Hash enum

### DIFF
--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -599,7 +599,7 @@ static_fn int setall(char **argv, int flag, Dt_t *troot, struct tdata *tp) {
                         __builtin_unreachable();
                     }
                     if (shp->namespace) {
-                        np = sh_fsearch(shp, name, NV_ADD | HASH_NOSCOPE);
+                        np = sh_fsearch(shp, name, NV_ADD | NV_NOSCOPE);
                     } else {
                         np = nv_open(name, sh_subfuntree(shp, 1),
                                      NV_NOARRAY | NV_IDENT | NV_NOSCOPE);
@@ -610,7 +610,7 @@ static_fn int setall(char **argv, int flag, Dt_t *troot, struct tdata *tp) {
                         name = sfstruse(shp->strbuf);
                     }
                     np = 0;
-                    if (shp->namespace) np = sh_fsearch(shp, name, HASH_NOSCOPE);
+                    if (shp->namespace) np = sh_fsearch(shp, name, NV_NOSCOPE);
                     if (!np) {
                         np = nv_search(name, troot, 0);
                         if (np) {
@@ -1196,7 +1196,7 @@ static_fn int unall(int argc, char **argv, Dt_t *troot, Shell_t *shp) {
         np = 0;
         if (jmpval == 0) {
             if (shp->namespace && troot != shp->var_tree) {
-                np = sh_fsearch(shp, name, nflag ? HASH_NOSCOPE : 0);
+                np = sh_fsearch(shp, name, nflag ? NV_NOSCOPE : 0);
             }
             if (!np) np = nv_open(name, troot, NV_NOADD | nflag);
         } else {
@@ -1235,7 +1235,7 @@ static_fn int unall(int argc, char **argv, Dt_t *troot, Shell_t *shp) {
 #if 0
             // Causes unsetting local variable to expose global.
             else if(shp->var_tree == troot && shp->var_tree != shp->var_base &&
-                    nv_search((char*)np, shp->var_tree, HASH_BUCKET | HASH_NOSCOPE)) {
+                    nv_search((char*)np, shp->var_tree, HASH_BUCKET | NV_NOSCOPE)) {
                     nv_delete(np,shp->var_tree,0);
             }
 #endif

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -199,7 +199,7 @@ int b_alias(int argc, char *argv[], Shbltin_t *context) {
     // Hacks to handle hash -r | --.
     if (argv[1] && argv[1][0] == '-') {
         if (argv[1][1] == 'r' && argv[1][2] == 0) {
-            Namval_t *np = nv_search((char *)PATHNOD, tdata.sh->var_tree, HASH_BUCKET);
+            Namval_t *np = nv_search_namval(PATHNOD, tdata.sh->var_tree, 0);
             nv_putval(np, nv_getval(np), NV_RDONLY);
             argv++;
             if (!argv[1]) return 0;
@@ -1235,7 +1235,7 @@ static_fn int unall(int argc, char **argv, Dt_t *troot, Shell_t *shp) {
 #if 0
             // Causes unsetting local variable to expose global.
             else if(shp->var_tree == troot && shp->var_tree != shp->var_base &&
-                    nv_search((char*)np, shp->var_tree, HASH_BUCKET | NV_NOSCOPE)) {
+                    nv_search_namval(np, shp->var_tree, NV_NOSCOPE)) {
                     nv_delete(np,shp->var_tree,0);
             }
 #endif

--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -513,7 +513,7 @@ int ed_macro(Edit_t *ep, int i) {
     } else {
         ep->e_macro[2] = 0;
     }
-    if (isalnum(i) && (np = nv_search(ep->e_macro, ep->sh->alias_tree, HASH_SCOPE)) &&
+    if (isalnum(i) && (np = nv_search(ep->e_macro, ep->sh->alias_tree, 0)) &&
         (out = nv_getval(np))) {
         // Copy to buff in internal representation.
         int c = 0;

--- a/src/cmd/ksh93/include/name.h
+++ b/src/cmd/ksh93/include/name.h
@@ -84,7 +84,7 @@ struct Namdisc {
     char *(*setdisc)(Namval_t *, const void *, Namval_t *, Namfun_t *);
     Namval_t *(*createf)(Namval_t *, const void *, int, Namfun_t *);
     Namfun_t *(*clonef)(Namval_t *, Namval_t *, int, Namfun_t *);
-    char *(*namef)(Namval_t *, Namfun_t *);
+    char *(*namef)(const Namval_t *, Namfun_t *);
     Namval_t *(*nextf)(Namval_t *, Dt_t *, Namfun_t *);
     Namval_t *(*typef)(Namval_t *, Namfun_t *);
     int (*readf)(Namval_t *, Sfio_t *, int, Namfun_t *);
@@ -221,9 +221,6 @@ struct Namval {
 #define NV_MOVE (1 << 27)     // for use with nv_clone()
 #define NV_ASSIGN (1 << 28)   // assignment is allowed
 
-// For compatibility with old hash library.
-#define HASH_BUCKET 1
-
 #define NV_NOREF NV_REF    // don't follow reference
 #define NV_FUNCT NV_IDENT  // option for nv_create
 #define NV_IDENT NV_MISC   // name must be identifier
@@ -244,7 +241,7 @@ struct Namval {
 // inline functions rather than macros to facilitate instrumentation while still being fast. In
 // particular validating the nvflag value; both current and new. Variants such as nv_isnull() are
 // not static inline functions because they do more work and were historically extern functions.
-static inline int nv_isattr(Namval_t *np, unsigned int nvflag) { return np->nvflag & nvflag; }
+static inline int nv_isattr(const Namval_t *np, unsigned int nvflag) { return np->nvflag & nvflag; }
 
 static inline void nv_onattr(Namval_t *np, unsigned int nvflag) { np->nvflag |= nvflag; }
 
@@ -310,7 +307,7 @@ extern Sfdouble_t nv_getn(Namval_t *, Namfun_t *);
 extern Sfdouble_t nv_getnum(Namval_t *);
 extern char *nv_getv(Namval_t *, Namfun_t *);
 extern char *nv_getval(Namval_t *);
-extern Namfun_t *nv_hasdisc(Namval_t *, const Namdisc_t *);
+extern Namfun_t *nv_hasdisc(const Namval_t *, const Namdisc_t *);
 extern int nv_isnull(Namval_t *);
 extern Namfun_t *nv_isvtree(Namval_t *);
 extern Namval_t *nv_lastdict(void *);
@@ -332,7 +329,8 @@ extern Namfun_t *nv_disc(Namval_t *, Namfun_t *, Nvdisc_op_t);
 extern void nv_unset(Namval_t *); /*obsolete */
 extern void _nv_unset(Namval_t *, int);
 extern Namval_t *nv_search(const char *, Dt_t *, int);
-extern char *nv_name(Namval_t *);
+extern Namval_t *nv_search_namval(const Namval_t *, Dt_t *, int);
+extern char *nv_name(const Namval_t *);
 extern Namval_t *nv_type(Namval_t *);
 // Note that the third parameter should be a pointer to a Optdisc_t or a structure where that type
 // is the first member.
@@ -485,7 +483,7 @@ extern Namval_t *nv_bfsearch(const char *, Dt_t *, Namval_t **, char **);
 extern Namval_t *nv_mkclone(Namval_t *);
 extern Namval_t *nv_mktype(Namval_t **, int);
 extern Namval_t *nv_addnode(Namval_t *, int);
-extern Namval_t *nv_parent(Namval_t *);
+extern Namval_t *nv_parent(const Namval_t *);
 extern char *nv_getbuf(size_t);
 extern Namval_t *nv_mount(Namval_t *, const char *name, Dt_t *);
 extern Namval_t *nv_arraychild(Namval_t *, Namval_t *, int);
@@ -495,7 +493,7 @@ extern bool nv_subsaved(Namval_t *, int);
 extern void nv_typename(Namval_t *, Sfio_t *);
 extern void nv_newtype(Namval_t *);
 extern Namval_t *nv_typeparent(Namval_t *);
-extern bool nv_istable(Namval_t *);
+extern bool nv_istable(const Namval_t *);
 extern size_t nv_datasize(Namval_t *, size_t *);
 extern Namfun_t *nv_mapchar(Namval_t *, const char *);
 extern void nv_checkrequired(Namval_t *);

--- a/src/cmd/ksh93/include/name.h
+++ b/src/cmd/ksh93/include/name.h
@@ -69,7 +69,6 @@ union Value {
 // For compatibility with old hash library.
 #define HASH_BUCKET 1
 #define HASH_NOSCOPE 2
-#define HASH_SCOPE 4
 
 typedef struct Namval Namval_t;
 typedef struct Namfun Namfun_t;

--- a/src/cmd/ksh93/include/name.h
+++ b/src/cmd/ksh93/include/name.h
@@ -66,10 +66,6 @@ union Value {
     struct pathcomp *pathcomp;
 };
 
-// For compatibility with old hash library.
-#define HASH_BUCKET 1
-#define HASH_NOSCOPE 2
-
 typedef struct Namval Namval_t;
 typedef struct Namfun Namfun_t;
 typedef struct Namdisc Namdisc_t;
@@ -224,6 +220,9 @@ struct Namval {
 #define NV_ADD (1 << 23)      // add node if not found
 #define NV_MOVE (1 << 27)     // for use with nv_clone()
 #define NV_ASSIGN (1 << 28)   // assignment is allowed
+
+// For compatibility with old hash library.
+#define HASH_BUCKET 1
 
 #define NV_NOREF NV_REF    // don't follow reference
 #define NV_FUNCT NV_IDENT  // option for nv_create

--- a/src/cmd/ksh93/sh/arith.c
+++ b/src/cmd/ksh93/sh/arith.c
@@ -424,7 +424,7 @@ static_fn Namval_t *scope(Namval_t *np, struct lval *lvalue, int assign) {
     }
 
     if ((lvalue->emode & ARITH_COMP) && dtvnext(root)) {
-        mp = nv_search(cp, sdict ? sdict : root, HASH_NOSCOPE | HASH_BUCKET);
+        mp = nv_search(cp, sdict ? sdict : root, NV_NOSCOPE | HASH_BUCKET);
         if (!mp && nsdict) mp = nv_search(cp, nsdict, HASH_BUCKET);
         if (mp) np = mp;
     }

--- a/src/cmd/ksh93/sh/arith.c
+++ b/src/cmd/ksh93/sh/arith.c
@@ -420,12 +420,11 @@ static_fn Namval_t *scope(Namval_t *np, struct lval *lvalue, int assign) {
         } else {
             flag = 0;
         }
-        cp = (char *)np;
     }
 
     if ((lvalue->emode & ARITH_COMP) && dtvnext(root)) {
-        mp = nv_search(cp, sdict ? sdict : root, NV_NOSCOPE | HASH_BUCKET);
-        if (!mp && nsdict) mp = nv_search(cp, nsdict, HASH_BUCKET);
+        mp = nv_search_namval(np, sdict ? sdict : root, NV_NOSCOPE);
+        if (!mp && nsdict) mp = nv_search_namval(np, nsdict, 0);
         if (mp) np = mp;
     }
 

--- a/src/cmd/ksh93/sh/arith.c
+++ b/src/cmd/ksh93/sh/arith.c
@@ -424,8 +424,8 @@ static_fn Namval_t *scope(Namval_t *np, struct lval *lvalue, int assign) {
     }
 
     if ((lvalue->emode & ARITH_COMP) && dtvnext(root)) {
-        mp = nv_search(cp, sdict ? sdict : root, HASH_NOSCOPE | HASH_SCOPE | HASH_BUCKET);
-        if (!mp && nsdict) mp = nv_search(cp, nsdict, HASH_SCOPE | HASH_BUCKET);
+        mp = nv_search(cp, sdict ? sdict : root, HASH_NOSCOPE | HASH_BUCKET);
+        if (!mp && nsdict) mp = nv_search(cp, nsdict, HASH_BUCKET);
         if (mp) np = mp;
     }
 

--- a/src/cmd/ksh93/sh/array.c
+++ b/src/cmd/ksh93/sh/array.c
@@ -1285,9 +1285,9 @@ void *nv_associative(Namval_t *np, const char *sp, Nvassoc_op_t op) {
                 type = nv_isattr(np, ~(NV_NOFREE | NV_ARRAY | NV_CHILD | NV_MINIMAL));
                 int mode = 0;
                 if (op.val == ASSOC_OP_ADD_val) {
-                    mode = NV_ADD | HASH_NOSCOPE;
+                    mode = NV_ADD | NV_NOSCOPE;
                 } else if (ap->namarr.flags & ARRAY_NOSCOPE) {
-                    mode = HASH_NOSCOPE;
+                    mode = NV_NOSCOPE;
                 }
                 if (*sp == 0 && sh_isoption(shp, SH_XTRACE) && op.val == ASSOC_OP_ADD_val) {
                     errormsg(SH_DICT, ERROR_warn(0), "adding empty subscript");
@@ -1318,7 +1318,7 @@ void *nv_associative(Namval_t *np, const char *sp, Nvassoc_op_t op) {
                     ap->pos = mp = (Namval_t *)dtprev(ap->namarr.table, &fake);
                     ap->nextpos = (Namval_t *)dtnext(ap->namarr.table, mp);
                 } else if (!mp && *sp && mode == 0) {
-                    mp = nv_search(sp, ap->namarr.table, NV_ADD | HASH_NOSCOPE);
+                    mp = nv_search(sp, ap->namarr.table, NV_ADD | NV_NOSCOPE);
                     if (!mp->nvalue.cp) mp->nvsize |= 1;
                 }
                 np = mp;

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -870,7 +870,7 @@ static_fn char *get_match(Namval_t *np, Namfun_t *fp) {
     return mp->rval[i];
 }
 
-static_fn char *name_match(Namval_t *np, Namfun_t *fp) {
+static_fn char *name_match(const Namval_t *np, Namfun_t *fp) {
     UNUSED(fp);
     Shell_t *shp = sh_ptr(np);
     int sub = nv_aindex(SH_MATCHNOD);
@@ -973,7 +973,7 @@ static const Namdisc_t OPTIONS_disc = {
 
 #define MAX_MATH_ARGS 3
 
-static_fn char *name_math(Namval_t *np, Namfun_t *fp) {
+static_fn char *name_math(const Namval_t *np, Namfun_t *fp) {
     UNUSED(fp);
     Shell_t *shp = sh_ptr(np);
     sfprintf(shp->strbuf, ".sh.math.%s", np->nvname);
@@ -1619,7 +1619,7 @@ static_fn Namfun_t *clone_svar(Namval_t *np, Namval_t *mp, int flags, Namfun_t *
 static const Namdisc_t svar_disc = {
     .dsize = 0, .createf = create_svar, .clonef = clone_svar, .nextf = next_svar};
 
-static_fn char *name_svar(Namval_t *np, Namfun_t *fp) {
+static_fn char *name_svar(const Namval_t *np, Namfun_t *fp) {
     Shell_t *shp = sh_ptr(np);
     Namval_t *mp = *(Namval_t **)(fp + 1);
     sfprintf(shp->strbuf, ".sh.%s.%s", mp->nvname, np->nvname);

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -1416,7 +1416,7 @@ breakloop:
             // Check for aliases.
             Namval_t *np;
             if (!lp->lex.incase && !assignment && fcpeek(0) != LPAREN &&
-                (np = nv_search(state, shp->alias_tree, HASH_SCOPE)) &&
+                (np = nv_search(state, shp->alias_tree, 0)) &&
                 !nv_isattr(np, NV_NOEXPAND) && (lp->aliasok != 2 || nv_isattr(np, BLT_DCL)) &&
                 (!sh_isstate(lp->sh, SH_NOALIAS) || nv_isattr(np, NV_NOFREE)) &&
                 (state = nv_getval(np))) {

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -729,7 +729,7 @@ Namval_t *nv_create(const char *name, Dt_t *root, int flags, Namfun_t *dp) {
                 isref = 0;
                 dp->last = cp;
                 mode = (c == '.' || (flags & NV_NOADD)) ? add : NV_ADD;
-                if (level++ || ((flags & NV_NOSCOPE) && c != '.')) mode |= HASH_NOSCOPE;
+                if (level++ || ((flags & NV_NOSCOPE) && c != '.')) mode |= NV_NOSCOPE;
                 np = 0;
                 if (top) {
                     struct Ufunction *rp;
@@ -769,7 +769,7 @@ Namval_t *nv_create(const char *name, Dt_t *root, int flags, Namfun_t *dp) {
                             np = 0;
                         }
                         if (!np || shp->var_tree->walk != root) {
-                            np = nv_search(name, root, HASH_NOSCOPE | NV_ADD);
+                            np = nv_search(name, root, NV_NOSCOPE | NV_ADD);
                         }
                     }
                 }
@@ -899,7 +899,7 @@ Namval_t *nv_create(const char *name, Dt_t *root, int flags, Namfun_t *dp) {
                     if (c == '[' || (c == '.' && nv_isarray(np))) {
                         int n = 0;
                         sub = 0;
-                        mode &= ~HASH_NOSCOPE;
+                        mode &= ~NV_NOSCOPE;
                         if (c == '[') {
                             Namval_t *table;
                             n = mode | nv_isarray(np);
@@ -1180,7 +1180,7 @@ Namval_t *nv_open(const char *name, Dt_t *root, int flags) {
         }
     } else if (!(flags & (NV_IDENT | NV_VARNAME | NV_ASSIGN))) {
         long mode = ((flags & NV_NOADD) ? 0 : NV_ADD);
-        if (flags & NV_NOSCOPE) mode |= HASH_NOSCOPE;
+        if (flags & NV_NOSCOPE) mode |= NV_NOSCOPE;
         np = nv_search(name, root, mode);
         if (np && !(flags & NV_REF)) {
             while (nv_isref(np)) {
@@ -1234,7 +1234,7 @@ Namval_t *nv_open(const char *name, Dt_t *root, int flags) {
     nvcache.ok = 1;
 #if SHOPT_BASH
     if (root == shp->fun_tree && sh_isoption(shp, SH_BASH)) {
-        c = ((flags & NV_NOSCOPE) ? HASH_NOSCOPE : 0) | ((flags & NV_NOADD) ? 0 : NV_ADD);
+        c = ((flags & NV_NOSCOPE) ? NV_NOSCOPE : 0) | ((flags & NV_NOADD) ? 0 : NV_ADD);
         np = nv_search(name, root, c);
         cp = Empty;
     } else
@@ -1274,7 +1274,7 @@ Namval_t *nv_open(const char *name, Dt_t *root, int flags) {
 nocache:
     nvcache.ok = 0;
     if (fname) {
-        c = ((flags & NV_NOSCOPE) ? HASH_NOSCOPE : 0) | ((flags & NV_NOADD) ? 0 : NV_ADD);
+        c = ((flags & NV_NOSCOPE) ? NV_NOSCOPE : 0) | ((flags & NV_NOADD) ? 0 : NV_ADD);
         *fname = '.';
         np = nv_search(name, funroot, c);
         *fname = 0;

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -1180,7 +1180,7 @@ Namval_t *nv_open(const char *name, Dt_t *root, int flags) {
         }
     } else if (!(flags & (NV_IDENT | NV_VARNAME | NV_ASSIGN))) {
         long mode = ((flags & NV_NOADD) ? 0 : NV_ADD);
-        if (flags & NV_NOSCOPE) mode |= HASH_SCOPE | HASH_NOSCOPE;
+        if (flags & NV_NOSCOPE) mode |= HASH_NOSCOPE;
         np = nv_search(name, root, mode);
         if (np && !(flags & NV_REF)) {
             while (nv_isref(np)) {

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -921,7 +921,7 @@ Namval_t *nv_search(const char *name, Dt_t *root, int mode) {
 
     Namval_t *np;
     Dt_t *dp = 0;
-    if (mode & HASH_NOSCOPE) dp = dtview(root, 0);
+    if (mode & NV_NOSCOPE) dp = dtview(root, 0);
     if (mode & HASH_BUCKET) {
         Namval_t *mp = (void *)name;
         if (!(np = dtsearch(root, mp)) && (mode & NV_ADD)) name = nv_name(mp);
@@ -930,12 +930,12 @@ Namval_t *nv_search(const char *name, Dt_t *root, int mode) {
         np = dtmatch(root, (void *)name);
     }
 #if SHOPT_COSHELL
-    if (shp->inpool) mode |= HASH_NOSCOPE;
+    if (shp->inpool) mode |= NV_NOSCOPE;
 #endif  // SHOPT_COSHELL
     if (!np && (mode & NV_ADD)) {
-        if (shp->namespace && !(mode & HASH_NOSCOPE) && root == shp->var_tree) {
+        if (shp->namespace && !(mode & NV_NOSCOPE) && root == shp->var_tree) {
             root = nv_dict(shp->namespace);
-        } else if (!dp && !(mode & HASH_NOSCOPE)) {
+        } else if (!dp && !(mode & NV_NOSCOPE)) {
             Dt_t *next;
             while ((next = dtvnext(root))) root = next;
         }

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -192,7 +192,7 @@ size_t nv_datasize(Namval_t *np, size_t *offset) {
     return s;
 }
 
-static_fn char *name_chtype(Namval_t *np, Namfun_t *fp) {
+static_fn char *name_chtype(const Namval_t *np, Namfun_t *fp) {
     Namchld_t *pp = (Namchld_t *)fp;
     Shell_t *shp = pp->ptype->sh;
     char *cp, *sub;

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -638,8 +638,7 @@ static_fn int set_instance(Shell_t *shp, Namval_t *nq, Namval_t *node, struct Na
         if (sp) nr->sub = strdup(sp);
     }
     shp->instance = 0;
-    if (shp->var_tree != shp->var_base &&
-        !nv_search((char *)nq, nr->root, HASH_BUCKET | NV_NOSCOPE)) {
+    if (shp->var_tree != shp->var_base && !nv_search_namval(nq, nr->root, NV_NOSCOPE)) {
         nr->root = shp->namespace ? nv_dict(shp->namespace) : shp->var_base;
     }
     nv_putval(SH_NAMENOD, cp, NV_NOFREE);
@@ -2643,8 +2642,7 @@ static_fn void local_exports(Namval_t *np, void *data) {
 
     if (nv_isarray(np)) nv_putsub(np, NULL, 0, 0);
     cp = nv_getval(np);
-    if (cp && (mp = nv_search(nv_name(np), shp->var_tree, NV_ADD | NV_NOSCOPE)) &&
-        nv_isnull(mp)) {
+    if (cp && (mp = nv_search(nv_name(np), shp->var_tree, NV_ADD | NV_NOSCOPE)) && nv_isnull(mp)) {
         nv_putval(mp, cp, 0);
         nv_setattr(mp, np->nvflag);
     }

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -639,7 +639,7 @@ static_fn int set_instance(Shell_t *shp, Namval_t *nq, Namval_t *node, struct Na
     }
     shp->instance = 0;
     if (shp->var_tree != shp->var_base &&
-        !nv_search((char *)nq, nr->root, HASH_BUCKET | HASH_NOSCOPE)) {
+        !nv_search((char *)nq, nr->root, HASH_BUCKET | NV_NOSCOPE)) {
         nr->root = shp->namespace ? nv_dict(shp->namespace) : shp->var_base;
     }
     nv_putval(SH_NAMENOD, cp, NV_NOFREE);
@@ -701,8 +701,8 @@ static_fn Namval_t *enter_namespace(Shell_t *shp, Namval_t *nsp) {
     if (onsp) {
         oroot = nv_dict(onsp);
         if (!nsp) {
-            path = nv_search(PATHNOD->nvname, oroot, HASH_NOSCOPE);
-            fpath = nv_search(FPATHNOD->nvname, oroot, HASH_NOSCOPE);
+            path = nv_search(PATHNOD->nvname, oroot, NV_NOSCOPE);
+            fpath = nv_search(FPATHNOD->nvname, oroot, NV_NOSCOPE);
         }
         if (shp->var_tree == oroot) {
             shp->var_tree = shp->var_tree->view;
@@ -720,11 +720,11 @@ static_fn Namval_t *enter_namespace(Shell_t *shp, Namval_t *nsp) {
         }
     }
     shp->namespace = nsp;
-    if (path && (path = nv_search(PATHNOD->nvname, shp->var_tree, HASH_NOSCOPE)) &&
+    if (path && (path = nv_search(PATHNOD->nvname, shp->var_tree, NV_NOSCOPE)) &&
         (val = nv_getval(path))) {
         nv_putval(path, val, NV_RDONLY);
     }
-    if (fpath && (fpath = nv_search(FPATHNOD->nvname, shp->var_tree, HASH_NOSCOPE)) &&
+    if (fpath && (fpath = nv_search(FPATHNOD->nvname, shp->var_tree, NV_NOSCOPE)) &&
         (val = nv_getval(fpath))) {
         nv_putval(fpath, val, NV_RDONLY);
     }
@@ -1223,7 +1223,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                             if (shp->namespace) {
                                 np = sh_fsearch(shp, com0, 0);
                             } else {
-                                np = nv_search(com0, shp->fun_tree, HASH_NOSCOPE);
+                                np = nv_search(com0, shp->fun_tree, NV_NOSCOPE);
                             }
                         }
 
@@ -1271,7 +1271,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                                     }
                                 }
                                 *ep = 0;
-                                namespace = nv_search(cp - 1, shp->var_base, HASH_NOSCOPE);
+                                namespace = nv_search(cp - 1, shp->var_base, NV_NOSCOPE);
                                 *ep = '.';
                             }
                         }
@@ -2216,7 +2216,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                 __builtin_unreachable();
             }
             if (shp->namespace && !shp->prefix && *fname != '.') {
-                np = sh_fsearch(shp, fname, NV_ADD | HASH_NOSCOPE);
+                np = sh_fsearch(shp, fname, NV_ADD | NV_NOSCOPE);
             }
             if (!np) {
                 np = nv_open(fname, sh_subfuntree(shp, 1), NV_NOARRAY | NV_VARNAME | NV_NOSCOPE);
@@ -2643,7 +2643,7 @@ static_fn void local_exports(Namval_t *np, void *data) {
 
     if (nv_isarray(np)) nv_putsub(np, NULL, 0, 0);
     cp = nv_getval(np);
-    if (cp && (mp = nv_search(nv_name(np), shp->var_tree, NV_ADD | HASH_NOSCOPE)) &&
+    if (cp && (mp = nv_search(nv_name(np), shp->var_tree, NV_ADD | NV_NOSCOPE)) &&
         nv_isnull(mp)) {
         nv_putval(mp, cp, 0);
         nv_setattr(mp, np->nvflag);
@@ -3111,7 +3111,7 @@ int sh_funscope(Shell_t *shp, int argn, char *argv[], int (*fun)(void *), void *
             if (nref) {
                 shp->last_root = 0;
                 for (r = 0; args[r]; r++) {
-                    np = nv_search(args[r], shp->var_tree, HASH_NOSCOPE | NV_ADD);
+                    np = nv_search(args[r], shp->var_tree, NV_NOSCOPE | NV_ADD);
                     if (np && *nref) {
                         nq = *nref++;
                         np->nvalue.nrp = calloc(1, sizeof(struct Namref));


### PR DESCRIPTION
This PR eliminates the legacy `HASH_` symbols that no longer has any obvious meaning since the legacy hash subsystem has been replaced by the CDT subsystem. What I don't understand is why this wasn't done by the AST team long ago.