### PR TITLE
More nv_open() safety + silence a Coverity warning

### DIFF
--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -1150,7 +1150,7 @@ Namval_t *nv_open(const char *name, Dt_t *root, int flags) {
     Shell_t *shp = sh_getinterp();
     char *cp = (char *)name;
     int c;
-    Namval_t *np = 0;
+    Namval_t *np = NULL;
     Namfun_t fun;
     int append = 0;
     const char *msg = e_varname;
@@ -1159,10 +1159,12 @@ Namval_t *nv_open(const char *name, Dt_t *root, int flags) {
     Dt_t *funroot;
     struct Cache_entry *xp;
 
+    // It's not clear why these two assignments are required before the check for non-empty name.
+    shp->openmatch = NULL;
+    shp->last_table = NULL;
+    if (!name || !*name) return NULL;
+
     memset(&fun, 0, sizeof(fun));
-    shp->openmatch = 0;
-    shp->last_table = 0;
-    if (!name) return 0;
     sh_stats(STAT_NVOPEN);
     if (!root) root = shp->var_tree;
     shp->last_root = root;

--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -1171,8 +1171,8 @@ static_fn void put_tree(Namval_t *np, const void *val, int flags, Namfun_t *fp) 
         Shell_t *shp = sh_ptr(np);
         Namval_t *last_table = shp->last_table;
         Dt_t *last_root = shp->last_root;
-        Namval_t *mp =
-            val ? nv_open(val, shp->var_tree, NV_VARNAME | NV_NOADD | NV_ARRAY | NV_NOFAIL) : 0;
+        // Note that val may be non-NULL but point to an empty string which will cause mp == NULL;
+        Namval_t *mp = nv_open(val, shp->var_tree, NV_VARNAME | NV_NOADD | NV_ARRAY | NV_NOFAIL);
         if (mp && nv_isvtree(mp)) {
             shp->prev_table = shp->last_table;
             shp->prev_root = shp->last_root;


### PR DESCRIPTION
There is a theoretical path from extend() (in print.c) thru fmtbase64()
to nv_open() that can result in the latter accessing a byte past the end
of an empty string. It doesn't look like that can actually happen due
to constraints that Coverity isn't aware of.  There are, however, ways
(most notably from the nv_open() in put_tree()) that a zero length var
name can be passed and which expect a NULL value to be returned
(verified by instrumenting the code).

Investigating this caused me to notice that nv_open() only handles a zero
length var name more or less by accident. Mostly by virtue of nv_search()
returning a NULL pointer for that case. Instead explicitly test for a
nil var name and return early. Hopefully this will silence the Coverity
warning.

Coverity CID#253849