### PR TITLE
Add feature test for expm1l, log1pl and remainderl

### DIFF
--- a/config_ast.h.in
+++ b/config_ast.h.in
@@ -141,6 +141,9 @@
 #mesondefine _lib_utimensat
 #mesondefine _lib_wcrtomb
 #mesondefine _lib_wcscpy
+#mesondefine _lib_expm1l
+#mesondefine _lib_log1pl
+#mesondefine _lib_remainderl
 
 #mesondefine _mem_base_rel_utsname
 #mesondefine _mem_d_fileno_dirent

--- a/features/meson.build
+++ b/features/meson.build
@@ -93,6 +93,16 @@ feature_data.set10('_lib_pipe2',
 feature_data.set10('_lib_syncfs',
     cc.has_function('syncfs', prefix: '#include <unistd.h>', args: feature_test_args))
 
+# https://github.com/att/ast/issues/1096
+# These math functions are not available on NetBSD
+feature_data.set10('_lib_expm1l',
+    cc.has_function('expm1l', prefix: '#include <math.h>', args: feature_test_args))
+feature_data.set10('_lib_log1pl',
+    cc.has_function('log1pl', prefix: '#include <math.h>', args: feature_test_args))
+feature_data.set10('_lib_remainderl',
+    cc.has_function('remainderl', prefix: '#include <math.h>', args: feature_test_args))
+
+
 socketpair_shutdown_feature_file = files('socketpair_shutdown.c')
 socketpair_shutdown_feature_result = cc.run(
     socketpair_shutdown_feature_file,

--- a/src/cmd/ksh93/bltins/math.c
+++ b/src/cmd/ksh93/bltins/math.c
@@ -147,7 +147,11 @@ const struct mathtab shtab_math[] = {{"\001acos", (Math_f)acosl},
                                      {"\001erfc", (Math_f)erfcl},
                                      {"\001exp", (Math_f)expl},
                                      {"\001exp2", (Math_f)exp2l},
+#if _lib_expm1l
                                      {"\001expm1", (Math_f)expm1l},
+#else
+                                     {"\001expm1", (Math_f)expm1},
+#endif
                                      {"\001fabs", (Math_f)fabsl},
                                      {"\001abs", (Math_f)fabsl},
                                      {"\002fdim", (Math_f)fdiml},
@@ -181,14 +185,22 @@ const struct mathtab shtab_math[] = {{"\001acos", (Math_f)acosl},
                                      {"\001lgamma", (Math_f)lgammal},
                                      {"\001log", (Math_f)logl},
                                      {"\001log10", (Math_f)log10l},
+#if _lib_log1pl
                                      {"\001log1p", (Math_f)log1pl},
+#else
+                                     {"\001log1p", (Math_f)log1p},
+#endif
                                      {"\001log2", (Math_f)log2l},
                                      {"\001logb", (Math_f)logbl},
                                      {"\001nearbyint", (Math_f)nearbyintl},
                                      {"\102nextafter", (Math_f)local_nextafter},
                                      {"\102nexttoward", (Math_f)local_nexttoward},
                                      {"\002pow", (Math_f)powl},
+#if _lib_remainderl
                                      {"\002remainder", (Math_f)remainderl},
+#else
+                                     {"\002remainder", (Math_f)remainder},
+#endif
                                      {"\001rint", (Math_f)rintl},
                                      {"\001round", (Math_f)roundl},
                                      {"\002scalbn", (Math_f)scalbnl},


### PR DESCRIPTION
These functions are not available on NetBSD. Add a feature test for them
and fallback to their respective counterparts that don't accept long
arguments if these functions are not available.

Resolves: #1096