### PR TITLE
`read -u` should not set default value for terminal input

### DIFF
--- a/src/cmd/ksh93/bltins/read.c
+++ b/src/cmd/ksh93/bltins/read.c
@@ -318,8 +318,8 @@ int b_read(int argc, char *argv[], Shbltin_t *context) {
                             (shp->gd->hist_ptr && fd == sffileno(shp->gd->hist_ptr->histfp)))) {
                     break;
                 }
+                break;
             }
-            // FALLTHRU
             case 'v': {
                 flags |= V_FLAG;
                 break;


### PR DESCRIPTION
Remove an invalid fall through in `read` builtin.

Resolves: #817