### PR TITLE
Use compiler set in `CC` environment variable

### DIFF
--- a/scripts/libast_prereq.sh
+++ b/scripts/libast_prereq.sh
@@ -18,14 +18,19 @@ INC_DIRS="$INC_DIRS -I$MESON_SOURCE_ROOT/src/lib/libast/include"
 INC_DIRS="$INC_DIRS -I$MESON_SOURCE_ROOT/src/lib/libast/features"
 INC_DIRS="$INC_DIRS -I$MESON_SOURCE_ROOT/src/cmd/std"
 
+if [ -z "$CC" ];
+then
+    CC=cc
+fi
+
 cd "$MESON_BUILD_ROOT"
 
 # Generate the conftab.[ch] source files.
 # shellcheck disable=SC2086
-"$comp_dir/conf.sh" cc -std=gnu99 -D_BLD_DLL $INC_DIRS
+"$comp_dir/conf.sh" $CC -std=gnu99 -D_BLD_DLL $INC_DIRS
 
 # Generate header files whose content depends on the current platform.
 "$MESON_SOURCE_ROOT/scripts/siglist.sh" > features/siglist.h
 # shellcheck disable=SC2086
-cc -D_BLD_DLL $INC_DIRS -std=gnu99 -o "sfinit" "$MESON_SOURCE_ROOT/etc/sfinit.c"
+$CC -D_BLD_DLL $INC_DIRS -std=gnu99 -o "sfinit" "$MESON_SOURCE_ROOT/etc/sfinit.c"
 ./sfinit > features/sfinit.h


### PR DESCRIPTION
Use `CC` environment variable while doing legacy feature tests.

Resolves: #1107