### PR TITLE
Lint: iousepipe() return value is a constant

### DIFF
--- a/src/cmd/ksh93/include/io.h
+++ b/src/cmd/ksh93/include/io.h
@@ -56,7 +56,7 @@ extern void sh_ioinit(Shell_t *);
 extern int sh_iomovefd(Shell_t *, int);
 extern int sh_iorenumber(Shell_t *, int, int);
 extern void sh_pclose(int[]);
-extern int sh_rpipe(int[]);
+extern void sh_rpipe(int[]);
 extern void sh_iorestore(Shell_t *, int, int);
 #if !_AST_no_spawnveg
 extern void sh_vexrestore(Shell_t *, int);

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -740,7 +740,7 @@ int sh_pipe(int pv[]) {
 //
 // Create a real pipe when pipe() is socketpair.
 //
-int sh_rpipe(int pv[]) {
+void sh_rpipe(int pv[]) {
     Shell_t *shp = sh_getinterp();
     int fd[2];
 
@@ -754,7 +754,6 @@ int sh_rpipe(int pv[]) {
     if (pv[1] <= 2) pv[1] = sh_iomovefd(shp, pv[1]);
     sh_subsavefd(pv[0]);
     sh_subsavefd(pv[1]);
-    return 0;
 }
 
 #if SHOPT_COSHELL

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -133,7 +133,7 @@ static_fn void fifo_check(void *handle) {
 //
 static int subpipe[3], subdup, tsetio, usepipe;
 
-static_fn bool iousepipe(Shell_t *shp) {
+static_fn void iousepipe(Shell_t *shp) {
     int i;
     int fd = sffileno(sfstdout);
     if (!sh_iovalidfd(shp, fd)) abort();
@@ -141,12 +141,12 @@ static_fn bool iousepipe(Shell_t *shp) {
         usepipe++;
         sh_iounpipe(shp);
     }
-    if (sh_rpipe(subpipe) < 0) return false;
+    sh_rpipe(subpipe);
     usepipe++;
     if (shp->comsub != 1) {
         subpipe[2] = sh_fcntl(subpipe[1], F_DUPFD, 10);
         sh_close(subpipe[1]);
-        return true;
+        return;
     }
     subpipe[2] = sh_fcntl(fd, F_DUPFD_CLOEXEC, 10);
     if (!sh_iovalidfd(shp, subpipe[2])) abort();
@@ -166,7 +166,6 @@ static_fn bool iousepipe(Shell_t *shp) {
             }
         }
     }
-    return true;
 }
 
 void sh_iounpipe(Shell_t *shp) {
@@ -738,7 +737,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
     if (sh_isoption(shp, SH_NOEXEC)) return shp->exitval;
 
     Stk_t *stkp = shp->stk;
-    int unpipe = 0;
+    bool unpipe = false;
     int type = flags;
     char *com0 = 0;
     int errorflg = (type & sh_state(SH_ERREXIT)) | OPTIMIZE;
@@ -1314,12 +1313,15 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                 sh_exec(shp, t->fork.forktre, 0);
                 break;
             }
-#endif /* SHOPT_COSHELL */
+#endif  // SHOPT_COSHELL
             if (shp->subshell) {
                 sh_subtmpfile(shp);
                 if ((type & (FAMP | TFORK)) == (FAMP | TFORK)) {
                     if (shp->comsub && !(shp->fdstatus[1] & IONOSEEK)) {
-                        unpipe = iousepipe(shp);
+                        iousepipe(shp);
+#if SHOPT_SPAWN
+                        unpipe = true;
+#endif  // SHOPT_SPAWN
                     }
                     sh_subfork();
                 }
@@ -1359,8 +1361,8 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                     pipes[2] = 0;
                     coproc_init(shp, pipes);
                 }
-#if SHOPT_SPAWN
 
+#if SHOPT_SPAWN
                 if (com) {
                     parent = sh_ntfork(shp, t, com, &jobid, ntflag);
                 } else {

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1595,7 +1595,18 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                     }
                     if (type || !sh_isoption(shp, SH_PIPEFAIL)) shp->exitval = type;
                 }
+#if 1
+                // See https://github.com/att/ast/pull/1113. It should be impossible for `unpipe` to
+                // be true when we reach this juncture. Thus there is no reason to call
+                // `sh_iounpipe()`. We're making this conditional and leaving the original statement
+                // for context.
+                //
+                // TODO: Remove all the code covered by this `#if 1...#else...#endif` once we're
+                // confident the analysis is correct.
+                if (shp->comsub == 1 && usepipe) assert(!unpipe);
+#else
                 if (shp->comsub == 1 && usepipe && unpipe) sh_iounpipe(shp);
+#endif
                 shp->pipepid = 0;
                 shp->st.ioset = 0;
                 if (simple && was_errexit) {


### PR DESCRIPTION
Both clang static analysis and Coverity Scan reported that the value
assigned to `unpipe` for the `if (shp->subshell) {` case is unused when
building when `SHOPT_SPAWN` is false. There are only two callers of
`iousepipe()` and one of them ignores the return value which makes sense
since the return value is a constant -- once you realize that `sh_rpipe()`
can't fail. For the call site that does use the return value just set the
`unpipe` to true only if `SHOPT_SPAWN` is true to mirror where the value of
`unpipe` is used.

Note that while `sh_rpipe()` can fail it cannot return a failure value.
For good or bad it always returns success unless there is a problem in
which case it longjmp's via the call to `errormsg()`.

This still leaves some cruft since `unpipe` is only needed at all if
`SHOPT_SPAWN` is true. But removing that cruft requires a much larger
refactoring.