### PR TITLE
Ensure fd 0, 1, 2 are never closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ None at this time.
 
 ## Other significant changes
 
+- You can no longer run an external command with stdin, stdout, or stderr
+  closed. If you attempt to do so (e.g., `a_cmd <&-`) it will be opened on
+  /dev/null in the child process (issue #1117).
 - Vi raw mode is now the default and cannot be disabled. Note that this was
   true at least as far back as ksh93u+. The difference is that now it's no
   longer even theoretically possible to even build with that feature disabled.

--- a/meson.build
+++ b/meson.build
@@ -159,7 +159,7 @@ endif
 
 shared_c_args = [
     '-DUSAGE_LICENSE=""',
-    '-D_AST_no_spawnveg=1',
+    '-DUSE_SPAWN=' + '@0@'.format(get_option('use-spawn').to_int()),
 ]
 
 ptr_size = cc.sizeof('void*')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,10 @@
+# We don't use posix_spawn() by default due to a race condition involving
+# setting the terminal foreground process group. If you want to risk failures
+# due to that scenario build with `meson -Duse-spawn=true`.
+#
+# See https://github.com/att/ast/issues/468.
+option('use-spawn', type : 'boolean', value : false)
+
 # This build symbol used to be named SHOPT_TIMEOUT. It was renamed when it
 # stopped being used to conditionally compile segments of code. It defines
 # the default, and maximum, read timeout value (see the `TMOUT` shell var).

--- a/src/cmd/ksh93/include/fault.h
+++ b/src/cmd/ksh93/include/fault.h
@@ -105,17 +105,18 @@ struct siginfo_ll {
 };
 typedef struct siginfo_ll siginfo_ll_t;
 
-#if !_AST_no_spawnveg
+#if USE_SPAWN
 #define sh_pushcontext(shp, bp, n)                                                           \
     ((bp)->mode = (n), (bp)->olist = 0, (bp)->topfd = shp->topfd, (bp)->prev = shp->jmplist, \
      (bp)->vexi = ((Spawnvex_t *)shp->vexp)->cur, (bp)->err = *ERROR_CONTEXT_BASE,           \
      shp->jmplist = (sigjmp_buf *)(&(bp)->buff))
 
-#else
+#else  // USE_SPAWN
+
 #define sh_pushcontext(shp, bp, n)                                                           \
     ((bp)->mode = (n), (bp)->olist = 0, (bp)->topfd = shp->topfd, (bp)->prev = shp->jmplist, \
      (bp)->err = *ERROR_CONTEXT_BASE, shp->jmplist = (sigjmp_buf *)(&(bp)->buff))
-#endif
+#endif  // USE_SPAWN
 
 #define sh_popcontext(shp, bp) (shp->jmplist = (bp)->prev, errorpop(&((bp)->err)))
 

--- a/src/cmd/ksh93/include/io.h
+++ b/src/cmd/ksh93/include/io.h
@@ -58,10 +58,10 @@ extern int sh_iorenumber(Shell_t *, int, int);
 extern void sh_pclose(int[]);
 extern void sh_rpipe(int[]);
 extern void sh_iorestore(Shell_t *, int, int);
-#if !_AST_no_spawnveg
+#if USE_SPAWN
 extern void sh_vexrestore(Shell_t *, int);
 extern void sh_vexsave(Shell_t *, int, int, Spawnvex_f, void *);
-#endif
+#endif  // USE_SPAWN
 extern Sfio_t *sh_iostream(Shell_t *, int, int);
 extern int sh_redirect(Shell_t *, struct ionod *, int);
 extern void sh_iosave(Shell_t *, int, int, char *);

--- a/src/cmd/ksh93/include/path.h
+++ b/src/cmd/ksh93/include/path.h
@@ -28,10 +28,6 @@
 #include "name.h"
 #include "shell.h"
 
-#if !SHOPT_SPAWN && _use_spawnveg
-#error -D_use_spawnveg requires -DSHOPT_SPAWN
-#endif  // !SHOPT_SPAWN && _use_spawnveg
-
 #define PATH_PATH 0001
 #define PATH_FPATH 0002
 #define PATH_CDPATH 0004

--- a/src/cmd/ksh93/include/shell.h
+++ b/src/cmd/ksh93/include/shell.h
@@ -244,10 +244,10 @@ struct Shell_s {
     char **argaddr;
     void *optlist;
     siginfo_ll_t **siginfo;
-#if !_AST_no_spawnveg
+#if USE_SPAWN
     Spawnvex_t *vex;
     Spawnvex_t *vexp;
-#endif
+#endif  // USE_SPAWN
     struct sh_scoped global;
     struct checkpt checkbase;
     Shinit_f userinit;

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -944,11 +944,11 @@ struct argnod *sh_argprocsub(Shell_t *shp, struct argnod *argp) {
     if (monitor) sh_offstate(shp, SH_MONITOR);
     shp->subshell = 0;
 #if has_dev_fd
-#ifdef SPAWN_cwd
+#if USE_SPAWN
     if (shp->vex || (shp->vex = (void *)spawnvex_open(0))) {
         spawnvex_add((Spawnvex_t *)shp->vex, pv[fd], pv[fd], 0, 0);
     } else
-#endif  // SPAWN_cwd
+#endif  // USE_SPAWN
         fcntl(pv[fd], F_SETFD, 0);
     shp->fdstatus[pv[fd]] &= ~IOCLEX;
 #endif  // has_dev_fd

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -1303,7 +1303,7 @@ Shell_t *sh_init(int argc, char *argv[], Shinit_f userinit) {
     }
     *SHLVL->nvalue.ip += 1;
     nv_offattr(SHLVL, NV_IMPORT);
-#if SHOPT_SPAWN
+#if USE_SPAWN
     {
         // Try to find the pathname for this interpreter.
         // Try using environment variable _ or argv[0].
@@ -1412,7 +1412,7 @@ Shell_t *sh_init(int argc, char *argv[], Shinit_f userinit) {
     //
     error_info.id = strdup(shp->st.dolv[0]);  // error_info.id is $0
     shp->jmpbuffer = (void *)&shp->checkbase;
-#ifdef SPAWN_cwd
+#if USE_SPAWN
     shp->vex = spawnvex_open(0);
     shp->vexp = spawnvex_open(0);
 #endif

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -954,7 +954,7 @@ static_fn char *io_usename(Shell_t *shp, char *name, int *perm, int fno, int mod
     return tname;
 }
 
-#ifdef SPAWN_cwd
+#if USE_SPAWN
 //
 // Restore sfstderr and close file descriptors.
 //
@@ -1014,6 +1014,7 @@ static_fn void iovex_stdstream(Shell_t *shp, int fn) {
 // Restore stream in parent.
 //
 static_fn int iovex_stream(void *context, uintmax_t origfd, uintmax_t fd2) {
+    UNUSED(fd2);
     Shell_t *shp = (Shell_t *)context;
     Sfio_t *sp, *sporig = shp->sftable[origfd];
 
@@ -1103,7 +1104,7 @@ int sh_redirect(Shell_t *shp, struct ionod *iop, int flag) {
     int isstring = shp->subshell ? (sfset(sfstdout, 0, 0) & SF_STRING) : 0;
     int herestring = (flag & IOHERESTRING);
     int vex = (flag & IOUSEVEX);
-#ifdef SPAWN_cwd
+#if USE_SPAWN
     Spawnvex_t *vp = shp->vexp;
     Spawnvex_t *vc = shp->vex;
 #endif
@@ -1113,7 +1114,7 @@ int sh_redirect(Shell_t *shp, struct ionod *iop, int flag) {
     if (flag == 2) clexec = 1;
     if (iop) traceon = sh_trace(shp, NULL, 0);
 
-#ifdef SPAWN_cwd
+#if USE_SPAWN
     if (vex) indx = vp->cur;
 #endif
 
@@ -1219,7 +1220,7 @@ int sh_redirect(Shell_t *shp, struct ionod *iop, int flag) {
                     } else {
                         dupfd = strtol(fname, &number, 10);
                     }
-#ifdef SPAWN_cwd
+#if USE_SPAWN
                     if (vex && (f = spawnvex_get(vc, dupfd, 0)) >= 0) dupfd = f;
 #endif
                     if (*number == '-') {
@@ -1286,7 +1287,7 @@ int sh_redirect(Shell_t *shp, struct ionod *iop, int flag) {
                     shp->sftable[fd] = sfnew(NULL, cp, r, -1, SF_READ | SF_STRING);
                     shp->fdstatus[fd] = shp->fdstatus[dupfd];
                 } else if (vex && toclose >= 0) {
-#ifdef SPAWN_cwd
+#if USE_SPAWN
                     indx = spawnvex_add(vp, dupfd, -1, 0, 0);
                     spawnvex_add(vc, dupfd, -1, 0, 0);
 #endif
@@ -1474,7 +1475,7 @@ int sh_redirect(Shell_t *shp, struct ionod *iop, int flag) {
                     // someone debugging a problem in the future finds it helpful.
                     //
                     //   if (flag < 2) {
-                    // #ifdef SPAWN_cwd
+                    // #if USE_SPAWN
                     //     sh_vexsave(shp, fn, (iof & IODOC) ? -1 : -2, 0, 0);
                     // #endif
                     //   } else if (!(iof & IODOC)) {
@@ -1540,7 +1541,7 @@ int sh_redirect(Shell_t *shp, struct ionod *iop, int flag) {
                     }
                     if (fx != fd) shp->fdstatus[fx] = status;
 #endif
-#ifdef SPAWN_cwd
+#if USE_SPAWN
                     if (fn <= 2) iovex_stdstream(shp, fn);
 #endif
                 } else if (vex) {
@@ -1550,7 +1551,7 @@ int sh_redirect(Shell_t *shp, struct ionod *iop, int flag) {
                         close(fn);
                     }
 
-#ifdef SPAWN_cwd
+#if USE_SPAWN
                     Spawnvex_f fun = NULL;
                     if (trunc) {
                         fun = iovex_trunc;
@@ -1793,7 +1794,7 @@ void sh_iosave(Shell_t *shp, int origfd, int oldtop, char *name) {
     }
 }
 
-#ifdef SPAWN_cwd
+#if USE_SPAWN
 void sh_vexsave(Shell_t *shp, int fn, int fd, Spawnvex_f vexfun, void *arg) {
     Spawnvex_t *vp = shp->vexp;
     Spawnvex_t *vc = shp->vex;

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -2439,7 +2439,7 @@ static_fn char *sh_tilde(Shell_t *shp, const char *string) {
         char *s2;
         size_t len;
         int fd, offset = stktell(shp->stk);
-#ifdef SPAWN_cwd
+#if USE_SPAWN
         Spawnvex_t *vc = (Spawnvex_t *)shp->vex;
         if (!vc && (vc = spawnvex_open(0))) shp->vex = (void *)vc;
 #endif
@@ -2468,7 +2468,7 @@ static_fn char *sh_tilde(Shell_t *shp, const char *string) {
         sfprintf(shp->stk, "/dev/fd/%d", fd);
 #endif
 #endif
-#ifdef SPAWN_cwd
+#if USE_SPAWN
         if (vc) spawnvex_add(vc, fd, fd, 0, 0);
 #endif
         return stkfreeze(shp->stk, 1);

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -95,6 +95,16 @@ static_fn pid_t path_pfexecve(Shell_t *shp, const char *path, char *argv[], char
 #else
     UNUSED(shp);
 #endif
+
+    // Ensure stdin, stdout, stderr are open in the child process.
+    // See https://github.com/att/ast/issues/1117.
+    for (int fd = 0; fd < 3; ++fd) {
+        errno = 0;
+        if (fcntl(fd, F_GETFD, NULL) == -1 || errno == EBADF) {
+            open("/dev/null", O_RDWR);
+        }
+    }
+
     return execve(path, argv, envp);
 }
 

--- a/src/cmd/ksh93/sh/pmain.c
+++ b/src/cmd/ksh93/sh/pmain.c
@@ -19,8 +19,20 @@
  ***********************************************************************/
 #include "config_ast.h"  // IWYU pragma: keep
 
+#include <errno.h>
+#include <fcntl.h>
 #include <stddef.h>
 
 #include "shell.h"
 
-int main(int argc, char *argv[]) { return sh_main(argc, argv, NULL); }
+int main(int argc, char *argv[]) {
+    // Ensure stdin, stdout, stderr are open. See https://github.com/att/ast/issues/1117.
+    for (int fd = 0; fd < 3; ++fd) {
+        errno = 0;
+        if (fcntl(fd, F_GETFD, NULL) == -1 || errno == EBADF) {
+            open("/dev/null", O_RDWR);
+        }
+    }
+
+    return sh_main(argc, argv, NULL);
+}

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -458,7 +458,7 @@ Sfio_t *sh_subshell(Shell_t *shp, Shnode_t *t, volatile int flags, int comsub) {
     struct sh_scoped savst;
     struct dolnod *argsav = 0;
     int argcnt;
-#ifdef SPAWN_cwd
+#if USE_SPAWN
     Spawnvex_t *vp;
 #endif
 
@@ -746,9 +746,9 @@ Sfio_t *sh_subshell(Shell_t *shp, Shnode_t *t, volatile int flags, int comsub) {
     subshell_data = sp->prev;
     if (!argsav || argsav->dolrefcnt == argcnt) sh_argfree(shp, argsav, 0);
     if (shp->topfd != buff.topfd) sh_iorestore(shp, buff.topfd | IOSUBSHELL, jmpval);
-#ifdef SPAWN_cwd
+#if USE_SPAWN
     if ((vp = (Spawnvex_t *)shp->vexp) && vp->cur) sh_vexrestore(shp, buff.vexi);
-#endif  // SPAWN_cwd
+#endif
     if (sp->sig) {
         if (sp->prev) {
             sp->prev->sig = sp->sig;

--- a/src/cmd/ksh93/tests/basic.sh
+++ b/src/cmd/ksh93/tests/basic.sh
@@ -488,11 +488,8 @@ chmod +x $TEST_DIR/scriptx
 [[ $($SHELL -c "print foo | $TEST_DIR/scriptx ;:" 2> /dev/null ) == foo ]] || log_error 'piping into script fails'
 [[ $($SHELL -c 'X=1;print -r -- ${X:=$(expr "a(0)" : '"'a*(\([^)]\))')}'" 2> /dev/null) == 1 ]] || log_error 'x=1;${x:=$(..."...")} failure'
 [[ $($SHELL -c 'print -r -- ${X:=$(expr "a(0)" : '"'a*(\([^)]\))')}'" 2> /dev/null) == 0 ]] || log_error '${x:=$(..."...")} failure'
-if $bin_cat /dev/fd/3 >/dev/null 2>&1  || whence mkfifo > /dev/null
-then
-    [[ $(cat <(print hello) ) == hello ]] || log_error "process substitution not working outside for or while loop"
-    $SHELL -c '[[ $(for i in 1;do cat <(print hello);done ) == hello ]]' 2> /dev/null|| log_error "process substitution not working in for or while loop"
-fi
+[[ $(cat <(print hello) ) == hello ]] || log_error "process substitution not working outside for or while loop"
+$SHELL -c '[[ $(for i in 1;do cat <(print hello);done ) == hello ]]' 2> /dev/null|| log_error "process substitution not working in for or while loop"
 
 exec 3> /dev/null
 print 'print foo "$@"' > $TEST_DIR/scriptx

--- a/src/lib/libast/include/ast_lib.h
+++ b/src/lib/libast/include/ast_lib.h
@@ -12,9 +12,6 @@
 
 #define _fd_self_dir_fmt "/proc/self/fd/%d%s%s"
 #define _fd_pid_dir_fmt "/proc/%d/fd/%d%s%s"
-#if !_AST_no_spawnveg
-#define _use_spawnveg 1
-#endif
 
 // https://github.com/att/ast/issues/370
 #define _UNIV_DEFAULT "ucb"

--- a/src/lib/libast/include/ast_sys.h
+++ b/src/lib/libast/include/ast_sys.h
@@ -45,7 +45,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#if !_AST_no_spawnveg
+#if USE_SPAWN
 typedef struct Spawnvex_s {
     unsigned int cur;
     int io;
@@ -104,7 +104,7 @@ extern int spawnvex_apply(Spawnvex_t *, int, int);
 extern intmax_t spawnvex_get(Spawnvex_t *, int, int);
 extern int spawnvex_close(Spawnvex_t *);
 
-#endif
+#endif  // USE_SPAWN
 
 extern char *fgetcwd(int, char *, size_t);
 extern char *resolvepath(const char *, char *, size_t);

--- a/src/lib/libast/misc/meson.build
+++ b/src/lib/libast/misc/meson.build
@@ -9,6 +9,6 @@ libast_files += [
     'misc/fts.c', 'misc/vmbusy.c', 'misc/fallbacks.c'
 ]
 
-if not shared_c_args.contains('-D_AST_no_spawnveg=1')
+if shared_c_args.contains('-DUSE_SPAWN=1')
     libast_files += [ 'misc/spawnvex.c' ]
 endif

--- a/src/lib/libast/misc/spawnvex.c
+++ b/src/lib/libast/misc/spawnvex.c
@@ -893,6 +893,17 @@ bad:
                     break;
             }
         }
+
+        // Ensure stdin, stdout, stderr are open in the child process.
+        // See https://github.com/att/ast/issues/1117.
+        for (int fd = 0; fd < 3; ++fd) {
+            errno = 0;
+            if (fcntl(fd, F_GETFD, NULL) == -1 || errno == EBADF) {
+                err = posix_spawn_file_actions_addopen(&fx, fd, "/dev/null", O_RDWR, 0);
+                if (err) goto bad;
+            }
+        }
+
         if (err = posix_spawn(&pid, path, &fx, &ax, argv, envv ? envv : environ)) goto bad;
         posix_spawnattr_destroy(&ax);
         posix_spawn_file_actions_destroy(&fx);


### PR DESCRIPTION
Closing stdin, stdout, or stderr is extremely dangerous and should never
be done. If an attempt is made to do so redirect the file descriptor to
/dev/null. Similarly, if ksh is started with one of those fd's closed
open it on /dev/null before doing anything else.

Resolves #1117