### PR TITLE
Fix unit test that kills unexpected processes

### DIFF
--- a/src/cmd/ksh93/tests/functions.sh
+++ b/src/cmd/ksh93/tests/functions.sh
@@ -1214,18 +1214,21 @@ function foo
 bar=bam
 foo
 
-function gosleep
-{
-    $bin_sleep 4
+# ========
+function gosleep {
+    $bin_sleep 1
 }
-x=$(
-    (sleep 2; pid=; ps | grep sleep | read pid extra; [[ $pid ]] && kill -- $pid) &
+actual=$(
+    (sleep 0.5; ps | grep '[s]leep 1' | read pid extra; [[ $pid ]] && kill -- $pid) &
     gosleep 2> /dev/null
     print ok
 )
-[[ $x == ok ]] || log_error 'TERM signal sent to last process of function kills the script'
+expect=ok
+[[ $actual == $expect ]] ||
+    log_error 'TERM signal sent to last process of function kills the script' "$expect" "$actual"
 
-# verify that $0 does not change with functions defined as fun()
+# ========
+# Verify that $0 does not change with functions defined as fun().
 func1()
 {
     [[ $0 == "$dol0" ]] || log_error "\$0 changed in func1() to $0"


### PR DESCRIPTION
While working on my previous commit I was surprised to see my editor
(whose command line included the file `sleep.c`) was being killed when
running unit tests. The reason is that one of the tests in the functions.sh
unit test kills any process with the word "sleep" in its command line.

This change also shaves a couple of seconds off that unit test.