### PR TITLE
Restructure code to eliminate cppcheck warning

### DIFF
--- a/src/cmd/ksh93/sh/arith.c
+++ b/src/cmd/ksh93/sh/arith.c
@@ -324,9 +324,8 @@ static_fn Sfdouble_t arith(const char **ptr, struct lval *lvalue, int type, Sfdo
                 Namval_t *np = NULL;
                 int dot = 0;
                 while (1) {
-                    while (xp = str, c = mb1char(str), isaname(c)) {
-                        ;  // empty body
-                    }
+                    xp = str;
+                    while (c = mb1char(str), isaname(c)) xp = str;
                     str = xp;
                     while (c == '[' && dot == NV_NOADD) {
                         str = nv_endsubscript(NULL, str, 0, shp);
@@ -390,9 +389,8 @@ static_fn Sfdouble_t arith(const char **ptr, struct lval *lvalue, int type, Sfdo
                         } else {
                             dot = NV_NOADD | NV_NOFAIL;
                             str++;
-                            while (xp = str, c = mb1char(str), isaname(c)) {
-                                ;  // empty body
-                            }
+                            xp = str;
+                            while (c = mb1char(str), isaname(c)) xp = str;
                             str = xp;
                         }
                     }


### PR DESCRIPTION
The existing code was written in a manner which confuses both human readers
and lint tools like `cppcheck` due to `mb1char()` being a preprocessor
macro with unexpected side-effects. This change only fixes the issue for
tools like `cppcheck`. For humans I've already noted in a previous change
that use of `mb1char()` needs to be replaced. See the ast.h header.

Fixes #1138