### PR TITLE
Fix build failures caused by update to gcc 9.0

### DIFF
--- a/scripts/libast_prereq.sh
+++ b/scripts/libast_prereq.sh
@@ -25,9 +25,18 @@ fi
 
 cd "$MESON_BUILD_ROOT"
 
+if cc --version | grep -q "GCC"
+then
+    gcc_major_version=$(cc -dumpversion | cut -d. -f1)
+    if [ "$gcc_major_version" -ge 9 ]
+    then
+        extra_flags="-fno-diagnostics-show-line-numbers"
+    fi
+fi
+
 # Generate the conftab.[ch] source files.
 # shellcheck disable=SC2086
-"$comp_dir/conf.sh" $CC -std=gnu99 -D_BLD_DLL $INC_DIRS
+"$comp_dir/conf.sh" $CC -std=gnu99 -D_BLD_DLL $INC_DIRS $extra_flags
 
 # Generate header files whose content depends on the current platform.
 "$MESON_SOURCE_ROOT/scripts/siglist.sh" > features/siglist.h


### PR DESCRIPTION
gcc 9.0 prints line numbers with error messages which affects parsing of
error messages in `conf.sh` script. Keep diagnostic error messages
disabled.

Resolves: #1137