### PR TITLE
The =~ operator in the `test` command is an error

### DIFF
--- a/src/cmd/ksh93/bltins/test.c
+++ b/src/cmd/ksh93/bltins/test.c
@@ -545,7 +545,21 @@ int test_binop(Shell_t *shp, int op, const char *left, const char *right) {
         case TEST_LE: {
             return lnum <= rnum;
         }
-        default: { abort(); }
+        case TEST_REP: {
+            // The ksh93u release treated this as a silent failure. That is, `test foo =~ foo` would
+            // simply return zero (false) regardless of the operands and whether the condition is
+            // true. We now alert the user that the `=~` binop is not supported by the POSIX test
+            // command. See https://github.com/att/ast/issues/1152.
+            errormsg(SH_DICT, ERROR_exit(2), e_badop, "=~");
+            __builtin_unreachable();
+        }
+        default: {
+            // This requires that all binops be enumerated above. If we haven't done so that is a
+            // bug. Alternatively, data corruption has caused us to be called with an unknown binop.
+            // Either way don't pretend everything is okay by returning 0 (false) like ksh93u did.
+            errormsg(SH_DICT, ERROR_ERROR, e_op_unhandled, op);
+            abort();
+        }
     }
 }
 

--- a/src/cmd/ksh93/data/testops.c
+++ b/src/cmd/ksh93/data/testops.c
@@ -34,7 +34,7 @@ const Shtable_t shtab_testops[] = {
     {"-o", TEST_OR},  {"-ot", TEST_OT}, {"=", TEST_SEQ},  {"==", TEST_SEQ}, {"=~", TEST_REP},
     {"<", TEST_SLT},  {">", TEST_SGT},  {"]]", TEST_END}, {"", 0}};
 
-const char sh_opttest[] =
+const char *sh_opttest =
     "[-1c?\n@(#)$Id: test (AT&T Research) 2003-03-18 $\n]" USAGE_LICENSE
     "[+NAME?test - evaluate expression]"
     "[+DESCRIPTION?\btest\b evaluates expressions and indicates its "
@@ -131,11 +131,10 @@ const char sh_opttest[] =
     "}"
     "[+SEE ALSO?\blet\b(1), \bexpr\b(1)]";
 
-const char test_opchars[] =
-    "HLNRSVOGCaeohrwxdcbfugkv"
-    "psnzt";
-const char e_argument[] = "argument expected";
-const char e_missing[] = "%s missing";
-const char e_badop[] = "%s: unknown operator";
-const char e_tstbegin[] = "[[ ! ";
-const char e_tstend[] = " ]]\n";
+const char *test_opchars = "HLNRSVOGCaeohrwxdcbfugkvpsnzt";
+const char *e_argument = "argument expected";
+const char *e_missing = "%s missing";
+const char *e_badop = "%s: unknown operator";
+const char *e_op_unhandled = "%d: operator not handled";
+const char *e_tstbegin = "[[ ! ";
+const char *e_tstend = " ]]\n";

--- a/src/cmd/ksh93/include/test.h
+++ b/src/cmd/ksh93/include/test.h
@@ -58,12 +58,13 @@ extern int test_unop(Shell_t *, int, const char *);
 extern int test_inode(const char *, const char *);
 extern int test_binop(Shell_t *, int, const char *, const char *);
 
-extern const char sh_opttest[];
-extern const char test_opchars[];
-extern const char e_argument[];
-extern const char e_missing[];
-extern const char e_badop[];
-extern const char e_tstbegin[];
-extern const char e_tstend[];
+extern const char *sh_opttest;
+extern const char *test_opchars;
+extern const char *e_argument;
+extern const char *e_missing;
+extern const char *e_badop;
+extern const char *e_op_unhandled;
+extern const char *e_tstbegin;
+extern const char *e_tstend;
 
 #endif  // _TEST_H

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -655,3 +655,15 @@ expect="umask: foo: bad format"
 actual=$(logname)
 expect=$(command logname)
 [[ "$actual" = "$expect" ]] || log_error "logname failed" "$expect" "$actual"
+
+# ==========
+# Verify that the POSIX `test` builtin complains loudly when the `=~` operator is used rather than
+# failing silently. See //github.com/att/ast/issues/1152.
+actual=$($SHELL -c 'test foo =~ foo' 2>&1)
+actual_status=$?
+actual=${actual#*: }
+expect='test: =~: unknown operator'
+expect_status=2
+[[ "$actual" = "$expect" ]] || log_error "test =~ failed" "$expect" "$actual"
+[[ "$actual_status" = "$expect_status" ]] ||
+    log_error "test =~ failed with wrong status" "$expect_status" "$actual_status"


### PR DESCRIPTION
Fixes #1152