### PR TITLE
Document the limitations of `fmtbuf()`

### DIFF
--- a/src/lib/libast/string/fmtbuf.c
+++ b/src/lib/libast/string/fmtbuf.c
@@ -23,35 +23,42 @@
 
 #include <stdlib.h>
 
-#include "ast.h"
 #include "ast_aso.h"
+#include "ast_assert.h"
 
-/*
- * return small format buffer chunk of size n
- * small buffers thread safe but short-lived
- * only one concurrent buffer with size > sizeof(buf)
- */
+//
+// Return small format buffer chunk of size n. Small buffers thread safe but short-lived. This must
+// only be used by the code in the libast/string directory. And only for functions that format
+// relatively small strings (e.g., less than a kilobyte). Such as might be done when converting a
+// binary int to a string.
+//
+// This API is inherently risky since there is no formal acquire/release semantics. We simply assume
+// we'll never be asked to provide more than a small number of psuedo-static buffers that are in use
+// at any point in time. This allows uses like
+//
+//    printf("%s %s %s\n", fmtint(x), fmtint(y), fmtint(z));
+//
+// This allows users of this API to avoid having to resort to a single static buffer that then
+// requires the callers of those functions to `strdup()` the buffer. Or the users of this API having
+// to always return a `malloc()` buffer that their caller then has to explicitly free.
+//
+// See https://github.com/att/ast/issues/962
+//
 
 static char buf[16 * 1024];
 static char *nxt = buf;
-
-static char *big;
-static size_t bigsiz;
 
 char *fmtbuf(size_t n) {
     char *cur;
     char *tst;
 
+    // This is to ensure a silly abuse of this API doesn't occur. We expect there to be a small
+    // number of "in flight" uses of the small buffers we parcel out.
+    assert(n <= 1024);
+
     do {
         cur = nxt;
         if (n > (&buf[sizeof(buf)] - cur)) {
-            if (n > sizeof(buf)) {
-                if (n > bigsiz) {
-                    bigsiz = roundof(n, 8 * 1024);
-                    big = realloc(big, bigsiz);
-                }
-                return big;
-            }
             tst = buf;
         } else
             tst = cur;


### PR DESCRIPTION
Previous changes have eliminated questionable, unnecessary, or unwanted
uses of `fmtbuf()`. Eliminating the remaining uses is more trouble than
it's worth. Instead, remove support for a "big" buffer since that should
never occur. And make it crystal clear that only small buffers can be
acquired; specifically, no larger than 1 KiB.

Resolves #962