### PR TITLE
Remove `getconf` from the ksh.1 man page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ None at this time.
 
 ## Notable fixes and improvements
 
+- Mention of the `getconf` builtin has been removed from the main ksh man
+  page. That command has never been enabled by default and is now deprecated
+  in favor of the platform command of the same name (issue #1118).
 - The `test` command no longer silently fails all uses of the `=~` operator.
   Instead an error is printed suggesting the use of `[[...]]` (issue #1152).
 - Doing `[ -t1 ]` inside a command substitution behaves correctly

--- a/src/cmd/ksh93/ksh.1
+++ b/src/cmd/ksh93/ksh.1
@@ -6197,28 +6197,6 @@ See
 for a description of the format of
 .IR job .
 .TP
-\f3getconf\fP \*(OK \f2name\^\fP \*(OK \f2pathname\^\fP \*(CK \*(CK
-Prints the current value of the configuration parameter given by
-.IR name .
-The configuration parameters are defined by the IEEE POSIX 1003.1
-and IEEE POSIX 1003.2 standards.
-(See
-.IR pathconf (2)
-and
-.IR sysconf (2).)
-The
-.I pathname
-argument is required for parameters whose value depends on
-the location in the file system.
-If no arguments are given,
-.B getconf
-prints the names and values of the current configuration
-parameters.
-The pathname
-.B /
-is used for each of the parameters that requires
-.IR pathname .
-.TP
 \f3getopts\fP \*(OK \f3\ \-a\fP \f2name\^\fP \*(CK \f2optstring vname\^\fP \*(OK \f2arg\^\fP .\|.\|. \*(CK
 Checks
 .I arg


### PR DESCRIPTION
The `getconf` command is the only optional (i.e., not enabled by default)
builtin mentioned in the main ksh man page. Remove that text.  We do not
want people to

a) think that just executing `getconf ...` will run the ksh builtin
(since it doesn't without first doing `builtin getconf`), and

b) we want to deprecate this command and ultimately remove it in favor
of the platform version.

Related #1118