### PR TITLE
Replace struct Value Nambfp_f bfp

### DIFF
--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -1062,7 +1062,7 @@ int b_builtin(int argc, char *argv[], Shbltin_t *context) {
             np = nv_search(arg, context->shp->bltin_tree, 0);
             if (np) {
                 if (nv_isattr(np, BLT_SPC)) errmsg = "restricted name";
-                addr = (Shbltin_f)FETCH_VT(np->nvalue, bfp);
+                addr = FETCH_VT(np->nvalue, shbltinp);
             }
         }
         if (!disable && !addr) {

--- a/src/cmd/ksh93/include/name.h
+++ b/src/cmd/ksh93/include/name.h
@@ -34,7 +34,11 @@
 #include "cdt.h"
 #include "option.h"
 
-typedef int (*Nambfp_f)(int, char **, void *);
+#ifndef _SHCMD_H
+typedef struct Shbltin_s Shbltin_t;
+typedef int (*Shbltin_f)(int, char **, Shbltin_t *);
+#endif
+
 struct pathcomp;
 
 // Nodes can have all kinds of values. We track the type last stored and check the type is what we
@@ -62,7 +66,7 @@ enum value_type {
     VT_rp,
     VT_funp,
     VT_nrp,
-    VT_bfp,
+    VT_shbltinp,
     VT_pathcomp,
     VT_pidp,
     VT_uidp,
@@ -98,7 +102,7 @@ struct Value {
         struct Ufunction *rp;
         struct Namfun *funp;
         struct Namref *nrp;
-        Nambfp_f bfp;  // builtin entry point function pointer
+        Shbltin_f shbltinp;
         struct pathcomp *pathcomp;
 
         pid_t *pidp;
@@ -560,7 +564,7 @@ struct argnod;
 #define is_abuiltin(n) (nv_isattr(n, NV_BLTIN | NV_INTEGER) == NV_BLTIN)
 #define is_afunction(n) (nv_isattr(n, NV_FUNCTION | NV_REF) == NV_FUNCTION)
 #define nv_funtree(n) FETCH_VT((n)->nvalue, rp)->ptree
-#define funptr(n) FETCH_VT((n)->nvalue, bfp)
+#define funptr(n) FETCH_VT((n)->nvalue, shbltinp)
 
 #define NV_SUBQUOTE (NV_ADD << 1)  // used with nv_endsubscript
 

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -645,7 +645,7 @@ static_fn void astbin_update(Shell_t *shp, const char *from, const char *to) {
         if (mp) {
             nv_offattr(mp, BLT_DISABLE);
         } else {
-            sh_addbuiltin(shp, path, (Shbltin_f)FETCH_VT(np->nvalue, bfp), 0);
+            sh_addbuiltin(shp, path, FETCH_VT(np->nvalue, shbltinp), 0);
         }
     }
     if (strcmp(from, SH_CMDLIB_DIR) == 0) path_cmdlib(shp, from, false);
@@ -1912,7 +1912,7 @@ static_fn Dt_t *inittree(Shell_t *shp, const struct shtable2 *name_vals) {
         np->nvenv = 0;
         np->nvshell = (void *)shp;
         if (name_vals == (const struct shtable2 *)shtab_builtins) {
-            STORE_VT(np->nvalue, bfp, (Nambfp_f)((struct shtable3 *)tp)->sh_value);
+            STORE_VT(np->nvalue, shbltinp, ((struct shtable3 *)tp)->sh_value);
         } else {
             if (name_vals == shtab_variables) np->nvfun = &shp->nvfun;
             STORE_VT(np->nvalue, const_cp, tp->sh_value);

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -78,7 +78,7 @@ const char *value_type_names[] = {
     "rp",             // VT_rp
     "funp",           // VT_funp
     "nrp",            // VT_nrp
-    "bfp",            // VT_bfp
+    "shbltinp",       // VT_shbltinp
     "pathcomp",       // VT_pathcomp
     "pidp",           // VT_pidp
     "uidp",           // VT_uidp

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -1086,7 +1086,7 @@ Namval_t *sh_addbuiltin(Shell_t *shp, const char *path, Shbltin_f bltin, void *e
     if (extra == builtin_delete) {
         name = path;
     } else if ((name = path_basename(path)) == path &&
-               bltin != (Shbltin_f)FETCH_VT(SYSTYPESET->nvalue, bfp) &&
+               bltin != FETCH_VT(SYSTYPESET->nvalue, shbltinp) &&
                (nq = nv_bfsearch(name, shp->bltin_tree, (Namval_t **)0, &cp))) {
         path = name = stkptr(shp->stk, offset);
     } else if (shp->bltin_dir && extra != builtin_delete) {
@@ -1117,7 +1117,7 @@ Namval_t *sh_addbuiltin(Shell_t *shp, const char *path, Shbltin_f bltin, void *e
             // Exists probably with different path so delete it.
             if (strcmp(path, nv_name(np))) {
                 if (nv_isattr(np, BLT_SPC)) return np;
-                if (!bltin) bltin = (Shbltin_f)FETCH_VT(np->nvalue, bfp);
+                if (!bltin) bltin = FETCH_VT(np->nvalue, shbltinp);
                 if (extra == builtin_delete) {
                     dtdelete(shp->bltin_tree, np);
                     return NULL;
@@ -1136,7 +1136,7 @@ Namval_t *sh_addbuiltin(Shell_t *shp, const char *path, Shbltin_f bltin, void *e
     np->nvenv = 0;
     np->nvfun = 0;
     if (bltin) {
-        STORE_VT(np->nvalue, bfp, (Nambfp_f)bltin);
+        STORE_VT(np->nvalue, shbltinp, bltin);
         nv_onattr(np, NV_BLTIN | NV_NOFREE);
         np->nvfun = extra;
     }

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -38,7 +38,6 @@
 #include "error.h"
 #include "fault.h"
 #include "history.h"
-#include "io.h"
 #include "name.h"
 #include "option.h"
 #include "sfio.h"
@@ -815,7 +814,7 @@ void nv_addtype(Namval_t *np, const char *optstr, void *op, size_t optsz) {
     if ((bp = nv_search(name, shp->fun_tree, NV_NOSCOPE)) && !FETCH_VT(bp->nvalue, ip)) {
         nv_delete(bp, shp->fun_tree, 0);
     }
-    bp = sh_addbuiltin(shp, name, (Shbltin_f)FETCH_VT(mp->nvalue, bfp), cp);
+    bp = sh_addbuiltin(shp, name, FETCH_VT(mp->nvalue, shbltinp), cp);
     nv_onattr(bp, mp->nvflag);
     nv_onattr(np, NV_RDONLY);
 }

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -1383,7 +1383,7 @@ static_fn Shnode_t *simple(Lex_t *lexp, int flag, struct ionod *io) {
                     sfputc(stkp, 0);
                     sfseek(stkp, (Sfoff_t)-1, SEEK_CUR);
 
-                    if (np && FETCH_VT(np->nvalue, bfp) != (Nambfp_f)b_alias &&
+                    if (np && FETCH_VT(np->nvalue, shbltinp) != b_alias &&
                         strchr(stkptr(stkp, ARGVAL), '[')) {
                         sfputc(stkp, '@');
                     }
@@ -1419,7 +1419,7 @@ static_fn Shnode_t *simple(Lex_t *lexp, int flag, struct ionod *io) {
                         cmdarg++;
                     } else if (np == SYSEXEC) {
                         lexp->inexec = 1;
-                    } else if (FETCH_VT(np->nvalue, bfp) == (Nambfp_f)b_getopts) {
+                    } else if (FETCH_VT(np->nvalue, shbltinp) == b_getopts) {
                         opt_get |= FOPTGET;
                     }
                 }

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -712,7 +712,7 @@ Pathcomp_t *path_absolute(Shell_t *shp, const char *name, Pathcomp_t *pp) {
                 }
 
                 if (np) {
-                    addr = (Shbltin_f)FETCH_VT(np->nvalue, bfp);
+                    addr = FETCH_VT(np->nvalue, shbltinp);
                     np = sh_addbuiltin(shp, stkptr(shp->stk, PATH_OFFSET), addr, NULL);
                     if (np) return oldpp;
                 }
@@ -769,7 +769,7 @@ Pathcomp_t *path_absolute(Shell_t *shp, const char *name, Pathcomp_t *pp) {
                 if (dll) sh_addlib(shp, dll, stkptr(shp->stk, m), oldpp);
                 if (dll && (addr = (Shbltin_f)dlllook(dll, stkptr(shp->stk, n))) &&
                     (!(np = sh_addbuiltin(shp, stkptr(shp->stk, PATH_OFFSET), NULL, NULL)) ||
-                     FETCH_VT(np->nvalue, bfp) != (Nambfp_f)addr) &&
+                     FETCH_VT(np->nvalue, shbltinp) != addr) &&
                     (np = sh_addbuiltin(shp, stkptr(shp->stk, PATH_OFFSET), addr, NULL))) {
                     np->nvenv = dll;
                     goto found;
@@ -804,7 +804,7 @@ Pathcomp_t *path_absolute(Shell_t *shp, const char *name, Pathcomp_t *pp) {
             if (np) {
                 n = np->nvflag;
                 np = sh_addbuiltin(shp, stkptr(shp->stk, PATH_OFFSET),
-                                   (Shbltin_f)FETCH_VT(np->nvalue, bfp), nv_context(np));
+                                   FETCH_VT(np->nvalue, shbltinp), nv_context(np));
                 nv_setattr(np, n);
             }
         }

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -321,7 +321,7 @@ static_fn int xec_p_comarg(Shell_t *shp, struct comnod *com) {
         // Was bp->flags = SH_END_OPTIM but no builtin actually uses the flags structure member
         // and it's companion symbols, SH_BEGIN_OPTIM, isn't used anywhere.
         bp->flags = 0;
-        ((Shbltin_f)funptr(np))(0, (char **)0, bp);
+        funptr(np)(0, NULL, bp);
         bp->ptr = save_ptr;
         bp->data = save_data;
     }
@@ -980,8 +980,8 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                         }
                     }
 #endif  // SHOPT_BASH
-                    if (np == SYSTYPESET ||
-                        (np && FETCH_VT(np->nvalue, bfp) == FETCH_VT(SYSTYPESET->nvalue, bfp))) {
+                    if (np == SYSTYPESET || (np && FETCH_VT(np->nvalue, shbltinp) ==
+                                                       FETCH_VT(SYSTYPESET->nvalue, shbltinp))) {
                         if (np != SYSTYPESET) {
                             shp->typeinit = np;
                             tp = nv_type(np);
@@ -1151,7 +1151,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                             }
                             shp->redir0 = 1;
                             sh_redirect(shp, io,
-                                        type | (FETCH_VT(np->nvalue, bfp) == (Nambfp_f)b_dot_cmd
+                                        type | (FETCH_VT(np->nvalue, shbltinp) == b_dot_cmd
                                                     ? 0
                                                     : IOHERESTRING | IOUSEVEX));
                             for (item = buffp->olist; item; item = item->next) item->strm = 0;
@@ -1182,7 +1182,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                         opt_info.disc = 0;
                         error_info.id = *com;
                         if (argn) shp->exitval = 0;
-                        shp->bltinfun = (Shbltin_f)funptr(np);
+                        shp->bltinfun = funptr(np);
                         bp->bnode = np;
                         bp->vnode = nq;
                         bp->ptr = nv_context(np);
@@ -2811,7 +2811,7 @@ int sh_fun(Shell_t *shp, Namval_t *np, Namval_t *nq, char *argv[]) {
             opt_info.index = opt_info.offset = 0;
             opt_info.disc = 0;
             shp->exitval = 0;
-            shp->exitval = ((Shbltin_f)funptr(np))(n, argv, bp);
+            shp->exitval = (funptr(np))(n, argv, bp);
         }
         sh_popcontext(shp, buffp);
         if (jmpval > SH_JMPCMD) siglongjmp(*shp->jmplist, jmpval);

--- a/src/lib/libast/include/shcmd.h
+++ b/src/lib/libast/include/shcmd.h
@@ -55,8 +55,10 @@ struct Shbltin_s {
     int pwdfd;
 };
 
+#if !defined(_NAME_H)
 typedef struct Shbltin_s Shbltin_t;
 typedef int (*Shbltin_f)(int, char **, Shbltin_t *);
+#endif
 
 // The following symbols used to have a `sh_` prefix and were meant to mask the functions of the
 // same name when used in a builtin (e.g., code in src/lib/libcmd). That has been changed because


### PR DESCRIPTION
Struct Value member `bfp` and its associated type `Nambfp_f` is not
only unnecessary it obscures the intent due to the explicit casts it
requires. This change is probably not optimal. It represents a baby step
to increasing the sanity involving using `struct Value` (formerly `union
Value`). Replace structure member `bfp` with `shbltinp` which eliminates
the casts between the two types.

Related #1150