### PR TITLE
`uname -d` should not crash

### DIFF
--- a/src/cmd/ksh93/tests/uname.sh
+++ b/src/cmd/ksh93/tests/uname.sh
@@ -76,10 +76,9 @@ expect=$($bin_uname -o)
 uname -h | grep -q -v "[0-9a-f]*" && log_error "'uname -h' failed"
 
 # ==========
-# https://github.com/att/ast/issues/1184
 #   -d, --domain    The domain name returned by getdomainname(2).
-# actual=$(uname -d)
-# [[ "$expect" =~ "$actual" ]] || log_error "'uname -d' failed"
+actual=$(uname -d)
+[[ ! -z "$actual" ]] || log_error "'uname -d' failed"
 
 # ==========
 #   -R, --extended-release
@@ -90,11 +89,10 @@ expect=$(uname)
 
 # ==========
 #   -A, --everything
-# https://github.com/att/ast/issues/1184
 #                   Equivalent to -snrvmpiohdR.
-# actual=$(uname -A)
-# expect=$(uname)
-# [[ "$actual" =~ "$expect" ]] || log_error "'uname -R' failed" "$expect" "$actual"
+actual=$(uname -A)
+expect=$(uname -snrvmpiohdR)
+[[ "$actual" = "$expect" ]] || log_error "'uname -A' failed" "$expect" "$actual"
 
 # ==========
 #   -f, --list      List all sysinfo(2) names and values, one per line.

--- a/src/lib/libcmd/uname.c
+++ b/src/lib/libcmd/uname.c
@@ -298,8 +298,10 @@ int b_uname(int argc, char **argv, Shbltin_t *context) {
 #endif
         if (flags & OPT_domain) {
             s = astconf("SRPC_DOMAIN", NULL, NULL);
-            if (!(*s)) getdomainname(s, sizeof(buf));
-
+            if (!(*s)) {
+                getdomainname(buf, sizeof(buf));
+                s = buf;
+            }
             output(OPT_domain, s, "domain");
         }
 #if _mem_m_type_utsname


### PR DESCRIPTION
Pass correct buffer to `getdomainname()` while executing `uname -d`.

Resolves: #1184