### PR TITLE
Change type of struct Namval member nvenv

### DIFF
--- a/config_ast.h.in
+++ b/config_ast.h.in
@@ -266,8 +266,17 @@ extern void _dprintf(const char *fname, int lineno, const char *funcname, const 
 // Note that the function prototype uses a `const void*` because we can't use
 // `struct Value*` here as the src/ksh93/include/name.h header which defines
 // it can't be included before this header.
-extern void _dprint_vtp(const char *fname, int lineno, const char *funcname, const void *vp);
+extern void _dprint_vtp(const char *fname, const int lineno, const char *funcname, const void *vp);
 #define DPRINT_VT(vt) _dprint_vtp(__FILE__, __LINE__, __FUNCTION__, &(vt))
 #define DPRINT_VTP(vtp) _dprint_vtp(__FILE__, __LINE__, __FUNCTION__, vtp)
+
+// Debug print of a `struct Namval` object.
+//
+// Note that the function prototype uses a `const void*` because we can't use
+// `struct Namval*` here as the src/ksh93/include/name.h header which defines
+// it can't be included before this header.
+extern void _dprint_nvp(const char *fname, const int lineno, const char *funcname, const void *vp);
+#define DPRINT_NV(nv) _dprint_nvp(__FILE__, __LINE__, __FUNCTION__, &(nv))
+#define DPRINT_NVP(nvp) _dprint_nvp(__FILE__, __LINE__, __FUNCTION__, nvp)
 
 #endif

--- a/src/cmd/ksh93/bltins/enum.c
+++ b/src/cmd/ksh93/bltins/enum.c
@@ -197,7 +197,7 @@ static_fn Namval_t *create_enum(Namval_t *np, const void *vp, int flags, Namfun_
     const char *v;
     int i, n;
     mp = nv_namptr(ep->node, 0);
-    mp->nvenv = (char *)np;
+    mp->nvenv = np;
     for (i = 0; (v = ep->values[i]); i++) {
         if (ep->iflag) {
             n = strcasecmp(v, name);

--- a/src/cmd/ksh93/bltins/read.c
+++ b/src/cmd/ksh93/bltins/read.c
@@ -478,11 +478,11 @@ int sh_readline(Shell_t *shp, char **names, void *readfn, volatile int fd, int f
             if ((ap = nv_arrayptr(np)) && !ap->fun) ap->nelem--;
             nv_putsub(np, NULL, 0L, 0);
         } else if (flags & C_FLAG) {
-            char *sp = np->nvenv;
+            Namval_t *nvenv = np->nvenv;
             if (strchr(name, '[')) nq = np;
             delim = -1;
             nv_unset(np);
-            if (!nv_isattr(np, NV_MINIMAL)) np->nvenv = sp;
+            if (!nv_isattr(np, NV_MINIMAL)) np->nvenv = nvenv;
             nv_setvtree(np);
             *(void **)(np->nvfun + 1) = readfn;
         } else {
@@ -664,7 +664,7 @@ int sh_readline(Shell_t *shp, char **names, void *readfn, volatile int fd, int f
                 if (var == buf) var = memdup(var, c + 1);
                 nv_putval(np, var, NV_RAW);
                 nv_setsize(np, c);
-                if (!nv_isattr(np, NV_IMPORT | NV_EXPORT) && (mp = (Namval_t *)np->nvenv)) {
+                if (!nv_isattr(np, NV_IMPORT | NV_EXPORT) && (mp = np->nvenv)) {
                     nv_setsize(mp, c);
                 }
             }

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -482,7 +482,8 @@ endargs:
         } else if (nv_isnull(tdata.tp)) {
             nv_newtype(tdata.tp);
         }
-        tdata.tp->nvenv = tdata.help;
+        tdata.tp->nvenv = (Namval_t *)tdata.help;
+        tdata.tp->nvenv_is_cp = true;
         flag &= ~NV_TYPE;
         if (nv_isattr(tdata.tp, NV_TAGGED)) {
             nv_offattr(tdata.tp, NV_TAGGED);
@@ -655,9 +656,8 @@ static_fn int setall(char **argv, int flag, Dt_t *troot, struct tdata *tp) {
             if (!np) continue;
             if (nv_isnull(np) && !nv_isarray(np) && nv_isattr(np, NV_NOFREE)) {
                 nv_offattr(np, NV_NOFREE);
-            } else if (tp->tp && !nv_isattr(np, NV_MINIMAL | NV_EXPORT) &&
-                       (mp = (Namval_t *)np->nvenv) && (ap = nv_arrayptr(mp)) &&
-                       (ap->flags & ARRAY_TREE)) {
+            } else if (tp->tp && !nv_isattr(np, NV_MINIMAL | NV_EXPORT) && (mp = np->nvenv) &&
+                       (ap = nv_arrayptr(mp)) && (ap->flags & ARRAY_TREE)) {
                 errormsg(SH_DICT, ERROR_exit(1), e_typecompat, nv_name(np));
                 __builtin_unreachable();
             } else if ((ap = nv_arrayptr(np)) && nv_aindex(np) > 0 && ap->nelem == 1 &&
@@ -805,7 +805,8 @@ static_fn int setall(char **argv, int flag, Dt_t *troot, struct tdata *tp) {
                 }
             }
             if (tp->help && !nv_isattr(np, NV_MINIMAL | NV_EXPORT)) {
-                np->nvenv = tp->help;
+                np->nvenv = (Namval_t *)tp->help;
+                np->nvenv_is_cp = true;
                 nv_onattr(np, NV_EXPORT);
             }
             if (last) *last = '=';

--- a/src/cmd/ksh93/include/name.h
+++ b/src/cmd/ksh93/include/name.h
@@ -298,7 +298,8 @@ struct Namval {
     Namfun_t *nvfun;      // pointer to trap functions
     struct Value nvalue;  // value field
     void *nvshell;        // shell pointer
-    char *nvenv;          // pointer to environment name
+    Namval_t *nvenv;      // pointer to environment name
+    bool nvenv_is_cp;
 };
 
 #define NV_CLASS ".sh.type"

--- a/src/cmd/ksh93/sh/arith.c
+++ b/src/cmd/ksh93/sh/arith.c
@@ -210,7 +210,7 @@ static_fn Namval_t *scope(Namval_t *np, struct lval *lvalue, int assign) {
                     dtuserdata(ap->table, shp, 1);
                 }
                 if (ap && ap->table && (nq = nv_search(nv_getsub(np), ap->table, NV_ADD))) {
-                    nq->nvenv = (char *)np;
+                    nq->nvenv = np;
                 }
                 if (nq && nv_isnull(nq)) np = nv_arraychild(np, nq, 0);
             }

--- a/src/cmd/ksh93/sh/array.c
+++ b/src/cmd/ksh93/sh/array.c
@@ -302,7 +302,7 @@ static_fn Namval_t *array_find(Namval_t *np, Namarr_t *arp, int flag) {
             cp = sfstruse(shp->strbuf);
             mp = nv_search(cp, ap->namarr.table, NV_ADD);
             assert(mp);  // it is theoretically possible for that nv_search() to fail
-            mp->nvenv = (char *)np;
+            mp->nvenv = np;
             nv_arraychild(np, mp, 0);
         }
         struct Namval *up_np = FETCH_VTP(up, np);
@@ -391,7 +391,7 @@ static_fn Namfun_t *array_clone(Namval_t *np, Namval_t *mp, int flags, Namfun_t 
         if ((flags & NV_COMVAR) && nv_putsub(np, NULL, 0, ARRAY_SCAN)) {
             do {
                 nq = nv_opensub(np);
-                if (nq) nq->nvenv = (void *)mp;
+                if (nq) nq->nvenv = mp;
             } while (nv_nextsub(np));
         }
         return fp;
@@ -436,7 +436,7 @@ static_fn Namfun_t *array_clone(Namval_t *np, Namval_t *mp, int flags, Namfun_t 
         nq = nv_opensub(np);
         if (nq) {
             mq = nv_search(name, ap->table, NV_ADD);
-            if (flags & NV_COMVAR) mq->nvenv = (char *)mp;
+            if (flags & NV_COMVAR) mq->nvenv = mp;
         }
         if (nq && (((flags & NV_COMVAR) && nv_isvtree(nq)) || nv_isarray(nq))) {
             STORE_VT(mq->nvalue, const_cp, NULL);
@@ -629,7 +629,7 @@ static_fn void array_copytree(Namval_t *np, Namval_t *mp) {
     nv_disc(np, (Namfun_t *)fp, DISC_OP_FIRST);
     fp->nofree |= 1;
     nv_onattr(np, NV_ARRAY);
-    mp->nvenv = (char *)np;
+    mp->nvenv = np;
 }
 
 //
@@ -865,7 +865,7 @@ Namval_t *nv_arraychild(Namval_t *np, Namval_t *nq, int c) {
     tp = nv_type(np);
     if (tp || c) {
         ap->flags |= ARRAY_NOCLONE;
-        nq->nvenv = (char *)np;
+        nq->nvenv = np;
         if (c == 't') {
             assert(tp);
             nv_clone(tp, nq, 0);
@@ -875,7 +875,7 @@ Namval_t *nv_arraychild(Namval_t *np, Namval_t *nq, int c) {
         nv_offattr(nq, NV_ARRAY);
         ap->flags &= ~ARRAY_NOCLONE;
     }
-    nq->nvenv = (char *)np;
+    nq->nvenv = np;
     nq->nvshell = np->nvshell;
     if ((fp = nq->nvfun) && fp->disc && fp->disc->setdisc && (fp = nv_disc(nq, fp, DISC_OP_POP))) {
         free(fp);
@@ -1024,7 +1024,7 @@ Namval_t *nv_putsub(Namval_t *np, char *sp, long size, int flags) {
                     sfprintf(shp->strbuf, "%d", ap->cur);
                     cp = sfstruse(shp->strbuf);
                     mp = nv_search(cp, ap->namarr.table, NV_ADD);
-                    mp->nvenv = (char *)np;
+                    mp->nvenv = np;
                     nv_arraychild(np, mp, 0);
                     nv_setvtree(mp);
                 } else {
@@ -1280,7 +1280,7 @@ void *nv_associative(Namval_t *np, const char *sp, Nvassoc_op_t op) {
             return (void *)ap->cur;
         }
         case ASSOC_OP_CURRENT_val: {
-            if (ap->cur) ap->cur->nvenv = (char *)np;
+            if (ap->cur) ap->cur->nvenv = np;
             return (void *)ap->cur;
         }
         case ASSOC_OP_NAME_val: {
@@ -1313,7 +1313,7 @@ void *nv_associative(Namval_t *np, const char *sp, Nvassoc_op_t op) {
                     op.val == ASSOC_OP_ADD_val) {
                     mp->nvshell = np->nvshell;
                     nv_onattr(mp, type);
-                    mp->nvenv = (char *)np;
+                    mp->nvenv = np;
                     if (op.val == ASSOC_OP_ADD_val && nv_type(np)) nv_arraychild(np, mp, 0);
                     if (shp->subshell) sh_assignok(np, 1);
                     if (type & NV_INTEGER) {

--- a/src/cmd/ksh93/sh/debug.c
+++ b/src/cmd/ksh93/sh/debug.c
@@ -198,8 +198,13 @@ void _dprint_nvp(const char *fname, const int lineno, const char *funcname, cons
     _dprintf(fname, lineno, funcname, "np %p ->nvalue is:", NP_BASE_ADDR(np));
     _dprint_vtp(fname, lineno, funcname, &np->nvalue);
     if (np->nvenv) {
-        _dprintf(fname, lineno, funcname, "np %p ->nvenv is %p:", NP_BASE_ADDR(np),
-                 NP_BASE_ADDR(np->nvenv));
-        _dprint_nvp(fname, lineno, funcname, np->nvenv);
+        if (np->nvenv_is_cp) {
+            _dprintf(fname, lineno, funcname, "np %p ->nvenv is %p |%s|", NP_BASE_ADDR(np),
+                     NP_BASE_ADDR(np->nvenv), np->nvenv);
+        } else {
+            _dprintf(fname, lineno, funcname, "np %p ->nvenv is %p:", NP_BASE_ADDR(np),
+                     NP_BASE_ADDR(np->nvenv));
+            _dprint_nvp(fname, lineno, funcname, np->nvenv);
+        }
     }
 }

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -607,7 +607,7 @@ static_fn void put_lastarg(Namval_t *np, const void *val, int flags, Namfun_t *f
     }
     shp->lastarg = (char *)val;
     nv_offattr(np, NV_EXPORT);
-    np->nvenv = 0;
+    np->nvenv = NULL;
 }
 
 static_fn void astbin_update(Shell_t *shp, const char *from, const char *to) {
@@ -1914,7 +1914,7 @@ static_fn Dt_t *inittree(Shell_t *shp, const struct shtable2 *name_vals) {
             np->nvname = (char *)tp->sh_name;
             treep = base_treep;
         }
-        np->nvenv = 0;
+        np->nvenv = NULL;
         np->nvshell = (void *)shp;
         if (name_vals == (const struct shtable2 *)shtab_builtins) {
             STORE_VT(np->nvalue, shbltinp, ((struct shtable3 *)tp)->sh_value);
@@ -1963,7 +1963,8 @@ static_fn void env_init(Shell_t *shp) {
                 np = nv_open(cp, shp->var_tree, (NV_EXPORT | NV_IDENT | NV_ASSIGN | NV_NOFAIL));
                 if (np) {
                     nv_onattr(np, NV_IMPORT);
-                    np->nvenv = cp;
+                    np->nvenv = (Namval_t *)cp;
+                    np->nvenv_is_cp = true;
                     nv_close(np);
                 } else {
                     // Swap with front

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -307,7 +307,7 @@ static_fn void assign(Namval_t *np, const void *val, int flags, Namfun_t *handle
         int n;
 
         block(bp, type);
-        if (!nv_isattr(np, NV_MINIMAL)) pp = (Namval_t *)np->nvenv;
+        if (!nv_isattr(np, NV_MINIMAL)) pp = np->nvenv;
         nv_putv(np, val, flags, handle);
         if (!nv_isarray(np) || array_isempty(np)) nv_disc(np, handle, DISC_OP_POP);
         if (shp->subshell) goto done;
@@ -813,7 +813,7 @@ int nv_clone(Namval_t *np, Namval_t *mp, int flags) {
         Shell_t *shp = (Shell_t *)np->nvshell;
         Namval_t *last_table = shp->last_table;
         if (nv_isattr(mp, NV_EXPORT | NV_MINIMAL) == (NV_EXPORT | NV_MINIMAL)) {
-            mp->nvenv = 0;
+            mp->nvenv = NULL;
             nv_offattr(mp, NV_MINIMAL);
         }
         if (!(flags & NV_COMVAR) && !nv_isattr(np, NV_MINIMAL) && np->nvenv &&
@@ -856,7 +856,7 @@ int nv_clone(Namval_t *np, Namval_t *mp, int flags) {
         if (!nv_isattr(np, NV_MINIMAL) || nv_isattr(mp, NV_EXPORT)) {
             mp->nvenv = np->nvenv;
             if (nv_isattr(np, NV_MINIMAL)) {
-                np->nvenv = 0;
+                np->nvenv = NULL;
                 nv_setattr(np, NV_EXPORT);
             } else {
                 nv_setattr(np, 0);
@@ -1060,8 +1060,8 @@ Namval_t *nv_bfsearch(const char *name, Dt_t *root, Namval_t **var, char **last)
         return np;
     }
     while (nv_isarray(nq) && !nv_isattr(nq, NV_MINIMAL | NV_EXPORT) && nq->nvenv &&
-           nv_isarray((Namval_t *)nq->nvenv)) {
-        nq = (Namval_t *)nq->nvenv;
+           nv_isarray(nq->nvenv)) {
+        nq = nq->nvenv;
     }
     return (Namval_t *)nv_setdisc(nq, dname, nq, (Namfun_t *)nq);
 done:
@@ -1133,8 +1133,8 @@ Namval_t *sh_addbuiltin(Shell_t *shp, const char *path, Shbltin_f bltin, void *e
         if (extra) np->nvfun = extra;
         return np;
     }
-    np->nvenv = 0;
-    np->nvfun = 0;
+    np->nvenv = NULL;
+    np->nvfun = NULL;
     if (bltin) {
         STORE_VT(np->nvalue, shbltinp, bltin);
         nv_onattr(np, NV_BLTIN | NV_NOFREE);

--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -736,8 +736,8 @@ static_fn void outval(char *name, const char *vname, struct Walk *wp) {
             (void)nv_stack(np, fp);
             fp = nv_stack(np, NULL);
             if (fp) free(fp);
-            np->nvfun = 0;
-            if (!nv_isattr(np, NV_MINIMAL)) np->nvenv = 0;
+            np->nvfun = NULL;
+            if (!nv_isattr(np, NV_MINIMAL)) np->nvenv = NULL;
             return;
         }
         for (xp = fp->next; xp; xp = xp->next) {
@@ -1077,7 +1077,7 @@ static_fn char *walk_tree(Namval_t *np, Namval_t *xp, int flags) {
             shp->var_tree = dp;
             if (nq && mq) {
                 struct nvdir *dp = (struct nvdir *)dir;
-                char *nvenv = mq->nvenv;
+                Namval_t *nvenv = mq->nvenv;
                 // Related to the TODO above this condition appears to only ever be true if
                 // flags&NV_MOVE is true.
                 if (dp->table == nq) {

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -333,7 +333,7 @@ static_fn void nv_restore(struct subshell *sp) {
             goto skip;
         }
         nv_setsize(mp, nv_size(np));
-        if (!(flags & NV_MINIMAL)) mp->nvenv = nv_isnull(mp) ? 0 : np->nvenv;
+        if (!(flags & NV_MINIMAL)) mp->nvenv = nv_isnull(mp) ? NULL : np->nvenv;
         if (!nofree) mp->nvfun = np->nvfun;
         if (nv_isattr(np, NV_CLONED)) {
             nv_offattr(np, NV_CLONED);

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -620,8 +620,7 @@ static_fn int set_instance(Shell_t *shp, Namval_t *nq, Namval_t *node, struct Na
     Namarr_t *ap;
     Namval_t *np;
 
-    if (!nv_isattr(nq, NV_MINIMAL | NV_EXPORT | NV_ARRAY) && (np = (Namval_t *)nq->nvenv) &&
-        nv_isarray(np)) {
+    if (!nv_isattr(nq, NV_MINIMAL | NV_EXPORT | NV_ARRAY) && (np = nq->nvenv) && nv_isarray(np)) {
         nq = np;
     } else if (nv_isattr(nq, NV_MINIMAL) == NV_MINIMAL && !nv_type(nq) &&
                (np = nv_typeparent(nq))) {
@@ -2289,7 +2288,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                 slp = t->funct.functstak;
                 sh_funstaks(slp->slchild, 1);
                 stklink(slp->slptr);
-                np->nvenv = (char *)slp;
+                np->nvenv = (Namval_t *)slp;
                 nv_funtree(np) = (int *)(t->funct.functtre);
                 FETCH_VT(np->nvalue, rp)->hoffset = t->funct.functloc;
                 FETCH_VT(np->nvalue, rp)->lineno = t->funct.functline;
@@ -2691,10 +2690,10 @@ Sfdouble_t sh_mathfun(Shell_t *shp, void *fp, int nargs, Sfdouble_t *arg) {
     np = (Namval_t *)fp;
     funenv.node = np;
     funenv.nref = nref;
-    funenv.env = 0;
+    funenv.env = NULL;
     memcpy(&node, SH_VALNOD, sizeof(node));
-    SH_VALNOD->nvfun = 0;
-    SH_VALNOD->nvenv = 0;
+    SH_VALNOD->nvfun = NULL;
+    SH_VALNOD->nvenv = NULL;
     nv_setattr(SH_VALNOD, NV_LDOUBLE | NV_NOFREE);
     STORE_VT(SH_VALNOD->nvalue, sfdoublep, NULL);
     for (i = 0; i < nargs; i++) {
@@ -2704,7 +2703,7 @@ Sfdouble_t sh_mathfun(Shell_t *shp, void *fp, int nargs, Sfdouble_t *arg) {
     *nr = 0;
     STORE_VT(SH_VALNOD->nvalue, sfdoublep, &d);
     argv[0] = np->nvname;
-    argv[1] = 0;
+    argv[1] = NULL;
     sh_funscope(shp, 1, argv, 0, &funenv, 0);
     while ((mp = *nr++)) STORE_VT(mp->nvalue, sfdoublep, NULL);
     SH_VALNOD->nvfun = node.nvfun;

--- a/src/cmd/ksh93/tests/api/debug.c
+++ b/src/cmd/ksh93/tests/api/debug.c
@@ -9,6 +9,7 @@
 #include "config_ast.h"  // IWYU pragma: keep
 
 #include <stdbool.h>
+#include <string.h>
 #include <sys/types.h>
 
 #include "name.h"
@@ -106,9 +107,28 @@ static void test_dprint_vt2() {
     DPRINT_VT(v1);
 }
 
+static char cp[] = "dval2";
+static Namval_t nval1, nval2;
+
+static void test_dprint_nv() {
+    memset(&nval1, 0, sizeof(nval1));
+    memset(&nval2, 0, sizeof(nval2));
+    nval1.nvname = "dvar1";
+    nval1.nvsize = 33;
+    STORE_VT(nval1.nvalue, i, 111);
+    nval2.nvname = "dvar2";
+    nval2.nvsize = 66;
+    nval2.nvenv = (char *)&nval1;
+    STORE_VT(nval2.nvalue, cp, cp);
+
+    SET_BASE_ADDR(&cp, 4);
+    DPRINT_NV(nval2);
+}
+
 int main() {
     _dprintf_debug = true;
     test_dprint_vt1();
     test_dprint_vt2();
+    test_dprint_nv();
     return 0;
 }

--- a/src/cmd/ksh93/tests/api/debug.c
+++ b/src/cmd/ksh93/tests/api/debug.c
@@ -118,11 +118,16 @@ static void test_dprint_nv() {
     STORE_VT(nval1.nvalue, i, 111);
     nval2.nvname = "dvar2";
     nval2.nvsize = 66;
-    nval2.nvenv = (char *)&nval1;
+    nval2.nvenv = &nval1;
     STORE_VT(nval2.nvalue, cp, cp);
 
     SET_BASE_ADDR(&cp, 4);
     DPRINT_NV(nval2);
+
+    nval1.nvsize = 99;
+    nval1.nvenv = (Namval_t *)"nvenv is a string";
+    nval1.nvenv_is_cp = true;
+    DPRINT_NV(nval1);
 }
 
 int main() {

--- a/src/cmd/ksh93/tests/api/debug.err
+++ b/src/cmd/ksh93/tests/api/debug.err
@@ -1,32 +1,41 @@
-### 1234   0.000 debug.c:39         test_dprint_vt1() type "vp" stored @ debug.c:38 in test_dprint_vt1()
-### 1234   0.000 debug.c:39         test_dprint_vt1() value is void* 0x4
-### 1234   0.000 debug.c:45         test_dprint_vt1() type "up" stored @ debug.c:44 in test_dprint_vt1()
-### 1234   0.000 debug.c:45         test_dprint_vt1() value is struct Value* 0x4 which has this value:
-### 1234   0.000 debug.c:45         test_dprint_vt1() type "i" stored @ debug.c:43 in test_dprint_vt1()
-### 1234   0.000 debug.c:45         test_dprint_vt1() value is int 789 (0x315)
-### 1234   0.000 debug.c:49         test_dprint_vt1() type "cp" stored @ debug.c:48 in test_dprint_vt1()
-### 1234   0.000 debug.c:49         test_dprint_vt1() value is char* 0x8 |str|
-### 1234   0.000 debug.c:53         test_dprint_vt1() type "const_cp" stored @ debug.c:52 in test_dprint_vt1()
-### 1234   0.000 debug.c:53         test_dprint_vt1() value is char* 0xc |const str|
-### 1234   0.000 debug.c:56         test_dprint_vt1() type "i" stored @ debug.c:55 in test_dprint_vt1()
-### 1234   0.000 debug.c:56         test_dprint_vt1() value is int 321 (0x141)
-### 1234   0.000 debug.c:59         test_dprint_vt1() type "i16" stored @ debug.c:58 in test_dprint_vt1()
-### 1234   0.000 debug.c:59         test_dprint_vt1() value is int16_t 357(0x165)
-### 1234   0.000 debug.c:66         test_dprint_vt2() type "ip" stored @ debug.c:65 in test_dprint_vt2()
-### 1234   0.000 debug.c:66         test_dprint_vt2() value is int* 0x10 => 111 (0x6F)
-### 1234   0.000 debug.c:71         test_dprint_vt2() type "i16p" stored @ debug.c:70 in test_dprint_vt2()
-### 1234   0.000 debug.c:71         test_dprint_vt2() value is int16_t* 0x14 => 1616 (0x650)
-### 1234   0.000 debug.c:76         test_dprint_vt2() type "i32p" stored @ debug.c:75 in test_dprint_vt2()
-### 1234   0.000 debug.c:76         test_dprint_vt2() value is int32_t* 0x18 => 3232 (0xCA0)
-### 1234   0.000 debug.c:81         test_dprint_vt2() type "i64p" stored @ debug.c:80 in test_dprint_vt2()
-### 1234   0.000 debug.c:81         test_dprint_vt2() value is int64_t* 0x1c => 4294967299 (0x100000003)
-### 1234   0.000 debug.c:86         test_dprint_vt2() type "dp" stored @ debug.c:85 in test_dprint_vt2()
-### 1234   0.000 debug.c:86         test_dprint_vt2() value is double* 0x20 => 2.71828
-### 1234   0.000 debug.c:91         test_dprint_vt2() type "fp" stored @ debug.c:90 in test_dprint_vt2()
-### 1234   0.000 debug.c:91         test_dprint_vt2() value is float* 0x24 => 3.14159
-### 1234   0.000 debug.c:96         test_dprint_vt2() type "sfdoublep" stored @ debug.c:95 in test_dprint_vt2()
-### 1234   0.000 debug.c:96         test_dprint_vt2() value is Sfdouble_t* 0x28 => 1.23457e+37
-### 1234   0.000 debug.c:101        test_dprint_vt2() type "pidp" stored @ debug.c:100 in test_dprint_vt2()
-### 1234   0.000 debug.c:101        test_dprint_vt2() value is pid_t* 0x2c => 98765
-### 1234   0.000 debug.c:106        test_dprint_vt2() type "uidp" stored @ debug.c:105 in test_dprint_vt2()
-### 1234   0.000 debug.c:106        test_dprint_vt2() value is uid_t* 0x30 => 54321
+### 1234   0.000 debug.c:40         test_dprint_vt1() type "vp" stored @ debug.c:39 in test_dprint_vt1()
+### 1234   0.000 debug.c:40         test_dprint_vt1() value is void* 0x4
+### 1234   0.000 debug.c:46         test_dprint_vt1() type "up" stored @ debug.c:45 in test_dprint_vt1()
+### 1234   0.000 debug.c:46         test_dprint_vt1() value is struct Value* 0x4 which has this value:
+### 1234   0.000 debug.c:46         test_dprint_vt1() type "i" stored @ debug.c:44 in test_dprint_vt1()
+### 1234   0.000 debug.c:46         test_dprint_vt1() value is int 789 (0x315)
+### 1234   0.000 debug.c:50         test_dprint_vt1() type "cp" stored @ debug.c:49 in test_dprint_vt1()
+### 1234   0.000 debug.c:50         test_dprint_vt1() value is char* 0x8 |str|
+### 1234   0.000 debug.c:54         test_dprint_vt1() type "const_cp" stored @ debug.c:53 in test_dprint_vt1()
+### 1234   0.000 debug.c:54         test_dprint_vt1() value is char* 0xc |const str|
+### 1234   0.000 debug.c:57         test_dprint_vt1() type "i" stored @ debug.c:56 in test_dprint_vt1()
+### 1234   0.000 debug.c:57         test_dprint_vt1() value is int 321 (0x141)
+### 1234   0.000 debug.c:60         test_dprint_vt1() type "i16" stored @ debug.c:59 in test_dprint_vt1()
+### 1234   0.000 debug.c:60         test_dprint_vt1() value is int16_t 357(0x165)
+### 1234   0.000 debug.c:67         test_dprint_vt2() type "ip" stored @ debug.c:66 in test_dprint_vt2()
+### 1234   0.000 debug.c:67         test_dprint_vt2() value is int* 0x10 => 111 (0x6F)
+### 1234   0.000 debug.c:72         test_dprint_vt2() type "i16p" stored @ debug.c:71 in test_dprint_vt2()
+### 1234   0.000 debug.c:72         test_dprint_vt2() value is int16_t* 0x14 => 1616 (0x650)
+### 1234   0.000 debug.c:77         test_dprint_vt2() type "i32p" stored @ debug.c:76 in test_dprint_vt2()
+### 1234   0.000 debug.c:77         test_dprint_vt2() value is int32_t* 0x18 => 3232 (0xCA0)
+### 1234   0.000 debug.c:82         test_dprint_vt2() type "i64p" stored @ debug.c:81 in test_dprint_vt2()
+### 1234   0.000 debug.c:82         test_dprint_vt2() value is int64_t* 0x1c => 4294967299 (0x100000003)
+### 1234   0.000 debug.c:87         test_dprint_vt2() type "dp" stored @ debug.c:86 in test_dprint_vt2()
+### 1234   0.000 debug.c:87         test_dprint_vt2() value is double* 0x20 => 2.71828
+### 1234   0.000 debug.c:92         test_dprint_vt2() type "fp" stored @ debug.c:91 in test_dprint_vt2()
+### 1234   0.000 debug.c:92         test_dprint_vt2() value is float* 0x24 => 3.14159
+### 1234   0.000 debug.c:97         test_dprint_vt2() type "sfdoublep" stored @ debug.c:96 in test_dprint_vt2()
+### 1234   0.000 debug.c:97         test_dprint_vt2() value is Sfdouble_t* 0x28 => 1.23457e+37
+### 1234   0.000 debug.c:102        test_dprint_vt2() type "pidp" stored @ debug.c:101 in test_dprint_vt2()
+### 1234   0.000 debug.c:102        test_dprint_vt2() value is pid_t* 0x2c => 98765
+### 1234   0.000 debug.c:107        test_dprint_vt2() type "uidp" stored @ debug.c:106 in test_dprint_vt2()
+### 1234   0.000 debug.c:107        test_dprint_vt2() value is uid_t* 0x30 => 54321
+### 1234   0.000 debug.c:125         test_dprint_nv() np 0x88 ->nvname |dvar2|  ->nvsize 66
+### 1234   0.000 debug.c:125         test_dprint_nv() np 0x88 ->nvalue is:
+### 1234   0.000 debug.c:125         test_dprint_nv() type "cp" stored @ debug.c:122 in test_dprint_nv()
+### 1234   0.000 debug.c:125         test_dprint_nv() value is char* 0x4 |dval2|
+### 1234   0.000 debug.c:125         test_dprint_nv() np 0x88 ->nvenv is 0x88:
+### 1234   0.000 debug.c:125         test_dprint_nv() np 0x88 ->nvname |dvar1|  ->nvsize 33
+### 1234   0.000 debug.c:125         test_dprint_nv() np 0x88 ->nvalue is:
+### 1234   0.000 debug.c:125         test_dprint_nv() type "i" stored @ debug.c:118 in test_dprint_nv()
+### 1234   0.000 debug.c:125         test_dprint_nv() value is int 111 (0x6F)

--- a/src/cmd/ksh93/tests/api/debug.err
+++ b/src/cmd/ksh93/tests/api/debug.err
@@ -39,3 +39,8 @@
 ### 1234   0.000 debug.c:125         test_dprint_nv() np 0x88 ->nvalue is:
 ### 1234   0.000 debug.c:125         test_dprint_nv() type "i" stored @ debug.c:118 in test_dprint_nv()
 ### 1234   0.000 debug.c:125         test_dprint_nv() value is int 111 (0x6F)
+### 1234   0.000 debug.c:130         test_dprint_nv() np 0x88 ->nvname |dvar1|  ->nvsize 99
+### 1234   0.000 debug.c:130         test_dprint_nv() np 0x88 ->nvalue is:
+### 1234   0.000 debug.c:130         test_dprint_nv() type "i" stored @ debug.c:118 in test_dprint_nv()
+### 1234   0.000 debug.c:130         test_dprint_nv() value is int 111 (0x6F)
+### 1234   0.000 debug.c:130         test_dprint_nv() np 0x88 ->nvenv is 0x88 |nvenv is a string|


### PR DESCRIPTION
98% of the uses of struct Namval member nvenv involve a Namval_t. So change
the type of that member so all of those casts can be eliminated.  There are
a couple of places that actually do treat it as a char*.  For the moment
simply cast the handful of places which overload `nvenv` to store a char*.