### PR TITLE
Fix bug in uname builtin

### DIFF
--- a/src/lib/libcmd/uname.c
+++ b/src/lib/libcmd/uname.c
@@ -238,8 +238,7 @@ int b_uname(int argc, char **argv, Shbltin_t *context) {
         }
         output(OPT_system, ut.sysname, "sysname");
         if (flags & OPT_nodename) {
-            if (sizeof(ut.nodename) > 9 || gethostname(s, sizeof(buf))) s = ut.nodename;
-            output(OPT_nodename, s, "nodename");
+            output(OPT_nodename, ut.nodename, "nodename");
         }
         output(OPT_release, ut.release, "release");
         output(OPT_version, ut.version, "version");


### PR DESCRIPTION
The program incorrectly uses var `s` in the `gethostname()` call. Also,
the test of the length of `ut.nodename` is always true on all systems
I've checked (Linux, *BSD, macOS) so `gethostname()` won't even be called.
And, as far as I can determine, the days when the fields of `struct uname`
might be just 8 or 9 chars in length are long past.