### PR TITLE
Normalize optget() usage in enum.c

### DIFF
--- a/src/cmd/ksh93/bltins/enum.c
+++ b/src/cmd/ksh93/bltins/enum.c
@@ -263,27 +263,26 @@ int b_enum(int argc, char **argv, Shbltin_t *context) {
     } optdisc;
 
     if (cmdinit(argc, argv, context, ERROR_NOTIFY)) return -1;
-    for (;;) {
-        switch (optget(argv, enum_usage)) {
+    while ((n = optget(argv, enum_usage))) {
+        switch (n) {
             case 'p': {
                 pflag = true;
-                continue;
+                break;
             }
             case 'i': {
                 iflag = true;
-                continue;
-            }
-            case '?': {
-                error(ERROR_USAGE | 4, "%s", opt_info.arg);
                 break;
             }
             case ':': {
-                error(2, "%s", opt_info.arg);
+                errormsg(SH_DICT, 2, "%s", opt_info.arg);
                 break;
+            }
+            case '?': {
+                errormsg(SH_DICT, ERROR_usage(2), "%s", opt_info.arg);
+                __builtin_unreachable();
             }
             default: { break; }
         }
-        break;
     }
 
     argv += opt_info.index;


### PR DESCRIPTION
This makes the b_enum() use of optget() match that seen in other
modules such as cd_pwd.c. It also eliminates this oclint warning about
an anti-pattern:

    src/cmd/ksh93/bltins/enum.c:286:9: avoid branching statement as last
    in loop [convention|P2]

It also eliminates two of the four uses of the `error(ERROR_USAGE | x, ...)`
pattern. Bringing those error message invocations in line with all the
other code.

Related #1153