### PR TITLE
Add an option to build API tests only

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -26,6 +26,10 @@ option('audit-file', type : 'string', value : '/etc/ksh_audit')
 #   meson -Dbuild-api-tests=false
 option('build-api-tests', type : 'boolean', value : true)
 
+# To build api tests only, set build-api-tests-only option to true:
+#   meson -Dbuild-api-tests-only=true
+option('build-api-tests-only', type : 'boolean', value : false)
+
 # This number is used when git is not available
 #   meson -Dfallback-version-number='x.y.z'
 option('fallback-version-number', type : 'string', value : '0.0.0')

--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -58,4 +58,7 @@ ld_library_path = 'LD_LIBRARY_PATH=' + ':'.join(
 libsample_path = 'LIBSAMPLE_PATH=' + libsample.full_path()
 
 subdir('tests/api')
-subdir('tests')
+# Check if only api tests should be built
+if get_option('build-api-tests-only') == false
+    subdir('tests')
+endif


### PR DESCRIPTION
This option would be helpful while checking coverage of API tests.