### PR TITLE
Add `--allowerasing` parameter to dnf in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
           compiler: gcc
           env:
             - DISTRO_TYPE=fedora
-              INSTALL_REQUIREMENTS="dnf repolist; dnf install -y gcc python3 meson sudo langpacks-zh_CN ed ncurses vi findutils which nmap-ncat expect git"
+              INSTALL_REQUIREMENTS="dnf repolist; dnf --allowerasing install -y gcc python3 meson sudo langpacks-zh_CN ed ncurses vi findutils which nmap-ncat expect git"
           before_install:
               - docker pull ${DISTRO_TYPE}
 


### PR DESCRIPTION
Builds for fedora on Travis CI broke because `expect` package now
conflicts with `whois-mkpasswd` package that is installed by default.
This commit fixes it.

https://bugzilla.redhat.com/show_bug.cgi?id=1687870