### PR TITLE
Correct PS1 info in man page

### DIFF
--- a/src/cmd/ksh93/ksh.1
+++ b/src/cmd/ksh93/ksh.1
@@ -2174,7 +2174,7 @@ if executing under
 The value of this variable is expanded for parameter
 expansion, command substitution, and arithmetic substitution to define the
 primary prompt string which by default is
-.RB `` "$\|\|\|" ''.
+.RB `` "$ \|\|\|" ''.
 The character
 .B !
 in the primary prompt string is replaced by the


### PR DESCRIPTION
PS1's default value is a dollar sign followed by a space, not just a dollar sign on its own.
Confirmed this both by checking in ksh93 itself, and by checking posix.  PS2, PS3, and PS4 already show the space included in their default values, in the man page.