### PR TITLE
Fix a heap-buffer-overflow bug

### DIFF
--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -889,7 +889,7 @@ Namval_t *nv_create(const char *name, Dt_t *root, int flags, Namfun_t *dp) {
                         flags &= ~(noscope ? 0 : NV_NOSCOPE);
                     } else if (c) {
                         char *xp = NULL;
-                        ssize_t xlen;
+                        size_t xlen;
                         c = (cp - sp);
                         // Eliminate namespace name.
                         if (shp->last_table && !nv_type(shp->last_table)) {
@@ -897,8 +897,10 @@ Namval_t *nv_create(const char *name, Dt_t *root, int flags, Namfun_t *dp) {
                             xlen = strlen(xp);
                         }
                         cp = nv_name(np);
-                        if (xp && strncmp(cp, xp, xlen) && cp[xlen] == '.') cp += xlen + 1;
                         copy = strlen(cp);
+                        if (xp && copy > xlen && !strncmp(cp, xp, xlen) && cp[xlen] == '.') {
+                            cp += xlen + 1;
+                        }
                         dp->nofree |= 1;
                         name = copystack(shp, cp, sp, sub);
                         sp = (char *)name + copy;

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -725,10 +725,9 @@ bool nv_setnotify(Namval_t *np, char **addr) {
 }
 
 static_fn void *newnode(const char *name) {
-    size_t s = strlen(name);
-    Namval_t *np = calloc(1, sizeof(Namval_t) + s + 1);
-
-    if (!np) return NULL;
+    size_t s = strlen(name) + 1;
+    Namval_t *np = calloc(1, sizeof(Namval_t) + s);
+    assert(np);
     np->nvname = (char *)np + sizeof(Namval_t);
     memcpy(np->nvname, name, s);
     return np;


### PR DESCRIPTION
If the length of string `xp` is greater than the length of string `cp`
the expression will access beyond the buffer holding `cp`.

Also, it is clear the condition is meant to only be true if the strings
compare equal in the first `xlen` chars but it is true if they are not
equal! Too, as best I can determine the body of that `if()` is never
executed; either with the original or corrected condition.