### PR TITLE
slowread() fails to handle errors from readf()

### DIFF
--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -2084,7 +2084,7 @@ static_fn ssize_t slowread(Sfio_t *iop, void *buff, size_t size, Sfdisc_t *handl
     Shell_t *shp = ((struct Iodisc *)handle)->sh;
     int (*readf)(void *, int, char *, int, int);
     int reedit = 0;
-    size_t rsize;
+    ssize_t rsize;
     char *xp = NULL;
 
     if (sh_isoption(shp, SH_EMACS) || sh_isoption(shp, SH_GMACS)) {
@@ -2110,6 +2110,8 @@ static_fn ssize_t slowread(Sfio_t *iop, void *buff, size_t size, Sfdisc_t *handl
             timerdel(timeout);
             timeout = NULL;
         }
+
+        if (rsize == -1) return -1;
 
         if (!(rsize && *(char *)buff != '\n' && shp->nextprompt == 1 &&
               sh_isoption(shp, SH_HISTEXPAND))) {


### PR DESCRIPTION
Something has changed on macOS server and/or this project. The `set.exp`
unit test is now failing consistently on line 52 with a SIGBUS. I
instrumented the code and it's because ksh is running slowread() at that
point and it fails to handle a -1 return value from the readf function.
When it fails while running that unit test errno == ENOTSOCK. The
problem is because it uses the -1 (assigned to rsize which was unsigned)
as an index into `buff[]`. Program goes boom due to invalid address.

So handle failures of the underlying read function.