### PR TITLE
Asan heap-use-after-free in fault.c

### DIFF
--- a/src/cmd/ksh93/tests/signal.sh
+++ b/src/cmd/ksh93/tests/signal.sh
@@ -109,10 +109,6 @@ actual=$(
 # ====================
 # Verify SIGINT trapping works for various complicated cases of nested scripts.
 #
-if [[ $OS_NAME != "Linux" ]]
-then
-    log_info "TODO: Enable this test on non-Linux systems when issue #658 is fixed."
-else
 empty_fifos
 typeset -A expected
 expected[...]="1-main 2-main 3-main SIGINT 3-intr"
@@ -135,7 +131,6 @@ do
     expect=${expected[$ops]}
     [[ $actual == $expect ]] || log_error "SIGINT $ops test failed" "$expect" "$actual"
 done < sigtst.out
-fi  # if [[ "$(uname -s)" != "Linux" ]]
 
 # ====================
 # Verify SIGUSR1 trapping works.


### PR DESCRIPTION
This is built on top of PR #1270 so that I could validate the two changes combined yield no regressions and pass tests with ASAN enabled. So ignore the first commit as it is from that PR and should be judged separate from this PR.