### PR TITLE
Update fallback version number to `2020.0.0-alpha1`

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -32,7 +32,7 @@ option('build-api-tests-only', type : 'boolean', value : false)
 
 # This number is used when git is not available
 #   meson -Dfallback-version-number='x.y.z'
-option('fallback-version-number', type : 'string', value : '0.0.0')
+option('fallback-version-number', type : 'string', value : '2020.0.0-alpha1')
 
 # To build with support for ASAN (AddressSanitizer:
 #   meson -DASAN=true


### PR DESCRIPTION
When git tags are not available, fallback to `2020.0.0-alpha1` version.