### PR TITLE
Remove uses of astconf()

### DIFF
--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -117,11 +117,11 @@ int B_echo(int argc, char *argv[], Shbltin_t *context) {
     UNUSED(argc);
 
     // This mess is because /bin/echo on BSD is different.
-    if (!prdata.sh->universe) {
+    if (!prdata.sh->echo_universe_valid) {
         char *universe;
         universe = astconf("UNIVERSE", 0, 0);
         if (universe) bsd_univ = (strcmp(universe, "ucb") == 0);
-        prdata.sh->universe = 1;
+        prdata.sh->echo_universe_valid = true;
     }
     if (!bsd_univ) return b_print(0, argv, (Shbltin_t *)&prdata);
     prdata.options = sh_optecho;

--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -107,7 +107,7 @@ static char *nullarg[] = {0, 0};
 //
 // Builtin `echo`.
 //
-// See https://github.com/att/ast/issues/370 for discussion around echo builtin
+// See https://github.com/att/ast/issues/370 for a discussion about the `echo` builtin.
 int B_echo(int argc, char *argv[], Shbltin_t *context) {
     static char bsd_univ;
     struct print prdata;
@@ -116,11 +116,10 @@ int B_echo(int argc, char *argv[], Shbltin_t *context) {
     prdata.sh = context->shp;
     UNUSED(argc);
 
-    // This mess is because /bin/echo on BSD is different.
+    // The external `echo` command is different on BSD and ATT platforms. So
+    // base our behavior on the contents of $PATH.
     if (!prdata.sh->echo_universe_valid) {
-        char *universe;
-        universe = astconf("UNIVERSE", 0, 0);
-        if (universe) bsd_univ = (strcmp(universe, "ucb") == 0);
+        bsd_univ = path_is_bsd_universe();
         prdata.sh->echo_universe_valid = true;
     }
     if (!bsd_univ) return b_print(0, argv, (Shbltin_t *)&prdata);

--- a/src/cmd/ksh93/include/shell.h
+++ b/src/cmd/ksh93/include/shell.h
@@ -26,6 +26,7 @@
 #ifndef _SHELL_H
 #define _SHELL_H 1
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <sys/stat.h>
 
@@ -172,7 +173,7 @@ struct Shell_s {
     char deftype;
     char funload;
     char used_pos;  // used postional parameter
-    char universe;
+    bool echo_universe_valid;
     char winch;
     char inarith;           // set when in ((...))
     char indebug;           // set when in debug trap

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -627,12 +627,6 @@ void sh_applyopts(Shell_t *shp, Shopt_t newflags) {
     on_option(&newflags, SH_LITHIST);
     on_option(&newflags, SH_NOEMPTYCMDCOMPL);
 
-    if (!is_option(&newflags, SH_XPG_ECHO) && sh_isoption(shp, SH_XPG_ECHO)) {
-        astconf("UNIVERSE", 0, "ucb");
-    }
-    if (is_option(&newflags, SH_XPG_ECHO) && !sh_isoption(shp, SH_XPG_ECHO)) {
-        astconf("UNIVERSE", 0, "att");
-    }
     if (is_option(&newflags, SH_HISTORY2) && !sh_isoption(shp, SH_HISTORY2)) {
         sh_onstate(shp, SH_HISTORY);
         sh_onoption(shp, SH_HISTORY);

--- a/src/cmd/ksh93/sh/bash.c
+++ b/src/cmd/ksh93/sh/bash.c
@@ -328,7 +328,7 @@ void bash_init(Shell_t *shp, int mode) {
         sh_onoption(shp, SH_NOEMPTYCMDCOMPL);
         sh_onoption(shp, SH_POSIX);
         if (shp->login_sh == 2) sh_onoption(shp, SH_LOGIN_SHELL);
-        if (strcmp(astconf("UNIVERSE", 0, 0), "att") == 0) {
+        if (!path_is_bsd_universe()) {
             sh_onoption(shp, SH_XPG_ECHO);
         } else {
             sh_offoption(shp, SH_XPG_ECHO);

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -288,10 +288,10 @@ static_fn void put_restricted(Namval_t *np, const void *val, nvflag_t flags, Nam
         shp->pathlist = path_unsetfpath(shp);
     }
     nv_putv(np, val, flags, fp);
-    shp->universe = 0;
     if (shp->pathlist) {
         val = FETCH_VT(np->nvalue, const_cp);
         if (np == PATHNOD || path_scoped) {
+            shp->echo_universe_valid = false;
             pp = path_addpath(shp, shp->pathlist, val, PATH_PATH);
         } else if (val && (np == FPATHNOD || fpath_scoped)) {
             pp = path_addpath(shp, shp->pathlist, val, PATH_FPATH);

--- a/src/cmd/ksh93/tests/echo.exp
+++ b/src/cmd/ksh93/tests/echo.exp
@@ -1,12 +1,20 @@
-# Test for echo builtin
+# Test for echo builtin.
+#
+# This test is somewhat unusual in that it performs each test twice. First time with BSD behavior
+# enabled. Second time with ATT behavior enabled.
 set pid [spawn $ksh]
+expect_prompt
+
+# ==========
+# Start by ensuring the value of PATH will select bsd behavior.
+send "PATH=/bsd:\$PATH\r"
 expect_prompt
 
 # ==========
 log_test_entry
 send "echo -n hello world; echo EOT\r"
 expect "\r\nhello worldEOT\r\n" {
-    puts "echo -n does not print new line"
+    puts "bsd echo -n does not print new line"
 }
 expect_prompt
 
@@ -14,7 +22,7 @@ expect_prompt
 log_test_entry
 send "echo -e 'hello\nworld'\r"
 expect "\r\nhello\r\nworld\r\n" {
-    puts "echo -e interprets escape sequences"
+    puts "bsd echo -e interprets escape sequences"
 }
 expect_prompt
 
@@ -22,7 +30,7 @@ expect_prompt
 log_test_entry
 send "echo -ne 'hello\nworld'; echo EOT\r"
 expect "\r\nhello\r\nworldEOT\r\n" {
-    puts "echo -ne does not print new line and interprets escape sequences"
+    puts "bsd echo -ne does not print new line and interprets escape sequences"
 }
 expect_prompt
 
@@ -30,10 +38,49 @@ expect_prompt
 log_test_entry
 send "echo -en 'hello\nworld'; echo EOT\r"
 expect "\r\nhello\r\nworldEOT\r\n" {
-    puts "echo -en does not print new line and interprets escape sequences"
+    puts "bsd echo -en does not print new line and interprets escape sequences"
 }
 expect_prompt
 
+# ==========
+# Now ensure the value of PATH will select bsd behavior.
+send "PATH=/argle:/usr/xpg4:\$PATH\r"
+expect_prompt
+
+# ==========
+log_test_entry
+send "echo -n hello world; echo EOT\r"
+expect "\r\n-n hello world\r\nEOT\r\n" {
+    puts "att echo -n does print new line"
+}
+expect_prompt
+
+# ==========
+# Note that in ATT mode `echo -e` is the default behavior and the `-e` flag is not special.
+log_test_entry
+send "echo -e 'hello\nworld'\r"
+expect "\r\n-e hello\r\nworld\r\n" {
+    puts "att echo -e interprets escape sequences"
+}
+expect_prompt
+
+# ==========
+log_test_entry
+send "echo -ne 'hello\nworld'; echo EOT\r"
+expect "\r\n-ne hello\r\nworld\r\nEOT\r\n" {
+    puts "att echo -ne does print new line and interprets escape sequences"
+}
+expect_prompt
+
+# ==========
+log_test_entry
+send "echo -en 'hello\nworld'; echo EOT\r"
+expect "\r\n-en hello\r\nworld\r\nEOT\r\n" {
+    puts "att echo -en does print new line and interprets escape sequences"
+}
+expect_prompt
+
+# ==========
 # Exit shell with ctrl-d
 log_test_entry
 send [ctrl D]

--- a/src/cmd/ksh93/tests/echo.exp
+++ b/src/cmd/ksh93/tests/echo.exp
@@ -20,6 +20,14 @@ expect_prompt
 
 # ==========
 log_test_entry
+send "echo 'hello world\\c\n'; echo EOT\r"
+expect "\r\nhello world\\\\c\r\n\r\nEOT" {
+    puts "bsd echo \\c does print new line"
+}
+expect_prompt
+
+# ==========
+log_test_entry
 send "echo -e 'hello\nworld'\r"
 expect "\r\nhello\r\nworld\r\n" {
     puts "bsd echo -e interprets escape sequences"
@@ -52,6 +60,14 @@ log_test_entry
 send "echo -n hello world; echo EOT\r"
 expect "\r\n-n hello world\r\nEOT\r\n" {
     puts "att echo -n does print new line"
+}
+expect_prompt
+
+# ==========
+log_test_entry
+send "echo 'hello world\\c\n'; echo EOT\r"
+expect "\r\nhello worldEOT\r\n" {
+    puts "att echo \\c does not print new line"
 }
 expect_prompt
 

--- a/src/cmd/ksh93/tests/echo.exp.out
+++ b/src/cmd/ksh93/tests/echo.exp.out
@@ -1,8 +1,10 @@
 bsd echo -n does not print new line
+bsd echo \c does print new line
 bsd echo -e interprets escape sequences
 bsd echo -ne does not print new line and interprets escape sequences
 bsd echo -en does not print new line and interprets escape sequences
 att echo -n does print new line
+att echo \c does not print new line
 att echo -e interprets escape sequences
 att echo -ne does print new line and interprets escape sequences
 att echo -en does print new line and interprets escape sequences

--- a/src/cmd/ksh93/tests/echo.exp.out
+++ b/src/cmd/ksh93/tests/echo.exp.out
@@ -1,4 +1,8 @@
-echo -n does not print new line
-echo -e interprets escape sequences
-echo -ne does not print new line and interprets escape sequences
-echo -en does not print new line and interprets escape sequences
+bsd echo -n does not print new line
+bsd echo -e interprets escape sequences
+bsd echo -ne does not print new line and interprets escape sequences
+bsd echo -en does not print new line and interprets escape sequences
+att echo -n does print new line
+att echo -e interprets escape sequences
+att echo -ne does print new line and interprets escape sequences
+att echo -en does print new line and interprets escape sequences

--- a/src/lib/libast/include/ast.h
+++ b/src/lib/libast/include/ast.h
@@ -212,6 +212,7 @@ extern char *pathcanon(char *, size_t, int);
 extern char *pathcat(const char *, int, const char *, const char *, char *, size_t);
 extern int pathexists(char *, int);
 extern int pathgetlink(const char *, char *, int);
+extern bool path_is_bsd_universe(void);
 extern char *pathpath(const char *, const char *, int, char *, size_t);
 extern size_t pathprog(const char *, char *, size_t);
 extern char *pathshell(void);

--- a/src/lib/libast/path/meson.build
+++ b/src/lib/libast/path/meson.build
@@ -4,5 +4,5 @@ libast_files += [
     'path/pathgetlink.c', 'path/pathpath.c',
     'path/pathprog.c',
     'path/pathshell.c', 'path/pathstat.c',
-    'path/pathtemp.c'
+    'path/pathtemp.c', 'path/pathuniverse.c',
 ]

--- a/src/lib/libast/path/pathuniverse.c
+++ b/src/lib/libast/path/pathuniverse.c
@@ -1,0 +1,78 @@
+/***********************************************************************
+ *                                                                      *
+ *               This software is part of the ast package               *
+ *          Copyright (c) 1982-2014 AT&T Intellectual Property          *
+ *                      and is licensed under the                       *
+ *                 Eclipse Public License, Version 1.0                  *
+ *                    by AT&T Intellectual Property                     *
+ *                                                                      *
+ *                A copy of the License is available at                 *
+ *          http://www.eclipse.org/org/documents/epl-v10.html           *
+ *         (with md5 checksum b35adb5213ca9657e911e9befb180842)         *
+ *                                                                      *
+ *              Information and Software Systems Research               *
+ *                            AT&T Research                             *
+ *                           Florham Park NJ                            *
+ *                                                                      *
+ *                    David Korn <dgkorn@gmail.com>                     *
+ *                                                                      *
+ ***********************************************************************/
+#include "config_ast.h"  // IWYU pragma: keep
+
+#include <stdlib.h>
+#include <string.h>
+
+// Returns true if the current universe as defined by the PATH env var, or the default universe,
+// indicates the command should provide BSD rather than SysV semantics.
+//
+// This code was lifted out of the astconf.c module and was changed only as needed to make it a
+// standalone function. I mention that because, beyond the problems with the style, it has several
+// undesirable behaviors. But since changing the behavior could conceivably be noticed by someone
+// (thus changing how `echo` works) we should not change the implementation.
+bool path_is_bsd_universe() {
+    bool is_bsd = strcmp(_UNIV_DEFAULT, "att") != 0;
+
+    const char *p = getenv("PATH");
+    if (!p) return is_bsd;
+
+    int r = 1;
+    while (true) {
+        switch (*p++) {
+            case 0:
+                break;
+            case ':':
+                r = 1;
+                continue;
+            case '/':
+                if (r) {
+                    r = 0;
+                    if (p[0] == 'u' && p[1] == 's' && p[2] == 'r' && p[3] == '/') {
+                        for (p += 4; *p == '/'; p++) {
+                            ;  // empty loop
+                        }
+                    }
+                    if (p[0] == 'b' && p[1] == 'i' && p[2] == 'n') {
+                        for (p += 3; *p == '/'; p++) {
+                            ;  // empty loop
+                        }
+                        if (!*p || *p == ':') break;
+                    }
+                }
+                if (!strncmp(p, "xpg", 3)) {
+                    is_bsd = false;
+                    break;
+                }
+                if (!strncmp(p, "bsd", 3) || !strncmp(p, "ucb", 3)) {
+                    is_bsd = true;
+                    break;
+                }
+                continue;
+            default:
+                r = 0;
+                continue;
+        }
+        break;
+    }
+
+    return is_bsd;
+}

--- a/src/lib/libcmd/cat.c
+++ b/src/lib/libcmd/cat.c
@@ -352,7 +352,7 @@ int b_cat(int argc, char **argv, Shbltin_t *context) {
     char states[UCHAR_MAX + 1];
 
     if (cmdinit(argc, argv, context, 0)) return -1;
-    att = !strcmp(astconf("UNIVERSE", NULL, NULL), "att");
+    att = !path_is_bsd_universe();
     mode = "r";
     while ((flag = optget(argv, usage))) {
         n = 0;


### PR DESCRIPTION
This removes the remaining `astconf()` calls outside of the *getconf.c* module. It also introduces some new tests to verify that the `echo` command behaves correctly whether the universe, based on `$PATH`, should result in bsd or att behavior.