### PR TITLE
Fix Broken time And times Built-ins

### DIFF
--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -2153,7 +2153,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                 job.waitall = 0;
             } else {
 #ifdef timeofday
-                tb.tv_sec = tb.tv_usec = 0;
+                memset(&tb, 0, sizeof(tb));
 #else
                 bt = 0;
 #endif  // timeofday
@@ -2163,7 +2163,6 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
 #ifdef timeofday
             times(&after);
             timeofday(&ta);
-            assert(tb.tv_sec);
             at = shp->gd->lim.clk_tck * (ta.tv_sec - tb.tv_sec);
             at += ((shp->gd->lim.clk_tck *
                     (((1000000L / 2) / shp->gd->lim.clk_tck) + (ta.tv_usec - tb.tv_usec))) /

--- a/src/cmd/ksh93/tests/meson.build
+++ b/src/cmd/ksh93/tests/meson.build
@@ -13,7 +13,7 @@ all_tests = [
     ['modifiers'], ['options'], ['path'], ['pointtype'], ['print'], ['printf'], ['quoting'],
     ['quoting2'], ['read'], ['readcsv'], ['recttype'], ['restricted'], ['return'], ['rksh'],
     ['select'], ['set'], ['sh_match'], ['sigchld', 100], ['signal'], ['sleep'], ['statics'],
-    ['subshell', 100], ['substring'], ['tilde'], ['timetype'], ['treemove'], ['types'],
+    ['subshell', 100], ['substring'], ['tilde'], ['time'], ['timetype'], ['treemove'], ['types'],
     ['ulimit'], ['variables'], ['vartree1'], ['vartree2'], ['wc'], ['whence'], ['uname'],
     # Test non-special builtins; i.e., those that have to be enabled explicitly.
     ['chmod'],

--- a/src/cmd/ksh93/tests/time.sh
+++ b/src/cmd/ksh93/tests/time.sh
@@ -1,0 +1,10 @@
+# Tests for time and times builtins
+
+# Make sure all builtins are not enabled by default via PATH. Doing so makes `builtin -d`
+# ineffective. Which breaks (at the time I write this) the final test in this module.
+# See issue #960.
+PATH=$NO_BUILTINS_PATH
+
+# Make sure that we can just run these commands
+time
+times


### PR DESCRIPTION
Currently, the `time` and `times` built-ins result in an assertion failure
causing a crash. This is due to an erroneous assertion from commit
595f499709319d28ebbdbedcd69b2bff223e6f3a which attempted to fix a linter
warning about the usage of an uninitialized `timeval` variable `tb`.

This change removes the assertion and instead runs `memset` on `tb` in the case
where it would have been used without having been initialized. This fixes the
`cppcheck` linter warning and restores the `time` and `times` built-ins to
working order.

A simple set of tests is added to ensure that these built-ins do not break in
the future.