### PR TITLE
Fix the `time` keyword

### DIFF
--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -441,13 +441,8 @@ static_fn char *get_ifs(Namval_t *np, Namfun_t *fp) {
 //
 // These functions are used to get and set the SECONDS variable.
 //
-#ifdef timeofday
 #define dtime(tp) ((double)((tp)->tv_sec) + 1e-6 * ((double)((tp)->tv_usec)))
 #define tms timeval
-#else
-#define dtime(tp) (((double)times(tp)) / shgd->lim.clk_tck)
-#define timeofday(a)
-#endif
 
 static_fn void put_seconds(Namval_t *np, const void *val, nvflag_t flags, Namfun_t *fp) {
     double d;

--- a/src/cmd/ksh93/sh/timers.c
+++ b/src/cmd/ksh93/sh/timers.c
@@ -47,14 +47,9 @@ static char time_state;
 
 static_fn double getnow(void) {
     double now;
-#ifdef timeofday
     struct timeval tp;
     timeofday(&tp);
     now = tp.tv_sec + 1.e-6 * tp.tv_usec;
-
-#else
-    now = (double)time(NULL);
-#endif  // timeofday
     return now + .001;
 }
 

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -2120,11 +2120,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
             struct tms before, after;
             const char *format = e_timeformat;
             clock_t at, tm[3];
-#ifdef timeofday
             struct timeval tb, ta;
-#else
-            clock_t bt;
-#endif  // timeofday
 #if SHOPT_COSHELL
             if (shp->inpool) {
                 if (t->par.partre) sh_exec(shp, t->par.partre, 0);
@@ -2140,37 +2136,24 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                 long timer_on;
                 if (shp->subshell && shp->comsub == 1) sh_subfork();
                 timer_on = sh_isstate(shp, SH_TIMING);
-#ifdef timeofday
                 timeofday(&tb);
                 times(&before);
-#else   // timeofday
-                bt = times(&before);
-#endif  // timeofday
                 job.waitall = 1;
                 sh_onstate(shp, SH_TIMING);
                 sh_exec(shp, t->par.partre, OPTIMIZE);
                 if (!timer_on) sh_offstate(shp, SH_TIMING);
                 job.waitall = 0;
             } else {
-#ifdef timeofday
-                tb.tv_sec = tb.tv_usec = 0;
-#else
-                bt = 0;
-#endif  // timeofday
+                timeofday(&tb);
                 before.tms_utime = before.tms_cutime = 0;
                 before.tms_stime = before.tms_cstime = 0;
             }
-#ifdef timeofday
             times(&after);
             timeofday(&ta);
-            assert(tb.tv_sec);
             at = shp->gd->lim.clk_tck * (ta.tv_sec - tb.tv_sec);
             at += ((shp->gd->lim.clk_tck *
                     (((1000000L / 2) / shp->gd->lim.clk_tck) + (ta.tv_usec - tb.tv_usec))) /
                    1000000L);
-#else   // timeofday
-            at = times(&after) - bt;
-#endif  // timeofday
             tm[0] = at;
             if (t->par.partre) {
                 Namval_t *np = nv_open("TIMEFORMAT", shp->var_tree, NV_NOADD);

--- a/src/cmd/ksh93/tests/meson.build
+++ b/src/cmd/ksh93/tests/meson.build
@@ -19,7 +19,7 @@ all_tests = [
     ['chmod'],
     # These are interactive tests to be run via the `expect` utility.
     ['echo.exp'], ['emacs.exp'], ['glob.exp'], ['hist.exp'], ['jobs.exp'], ['read.exp'], ['set.exp'],
-    ['test.exp'], ['vi.exp'],
+    ['test.exp'], ['time.exp'], ['vi.exp'],
     # The following are tests that must be run serially after all other tests that might be run in
     # parallel. For example, the `special-dev-paths` test opens network connections on fixed TCP/IP
     # port numbers and thus cannot be run in parallel with itself (shcomp and non-shcomp variants).

--- a/src/cmd/ksh93/tests/time.exp
+++ b/src/cmd/ksh93/tests/time.exp
@@ -1,0 +1,49 @@
+# Tests of `time` keyword and `times` alias.
+set pid [spawn $ksh]
+expect_prompt
+
+set zero_time_re "\[\t \]*0m0\.\[0-9\]\[0-9\]s"
+
+# ==========
+log_test_entry
+send "time\r"
+expect -re "\r\nuser$zero_time_re\r\nsys$zero_time_re\r\n" {
+    puts "time with no pipeline produces expected output"
+}
+expect_prompt
+
+# ==========
+# Timing a simple sleep command works.
+log_test_entry
+send "time sleep 1\r"
+expect -re "\r\nreal\[\t \]*0m1\.\[0-9\]\[0-9\]s\r\nuser$zero_time_re\r\nsys$zero_time_re\r\n" {
+    puts "time sleep 1 produces expected output"
+}
+expect_prompt
+
+# ==========
+# Timing a more complex pipeline works.
+log_test_entry
+send "time { sleep 0.05 | sleep 0.05; }\r"
+expect -re "\r\nreal\[\t \]*0m0\.0\[5-9\]s\r\nuser$zero_time_re\r\nsys$zero_time_re\r\n" {
+    puts "time sleep 0.05 pipeline produces expected output"
+}
+expect_prompt
+
+# ==========
+# The times command with no args produces reasonable output.
+log_test_entry
+send "times\r"
+expect -re "\r\nuser$zero_time_re\r\nsys$zero_time_re\r\n" {
+    puts "times produces expected output"
+}
+expect_prompt
+
+# ==========
+# The times command with args produces a syntax error.
+log_test_entry
+send "times sleep 1\r"
+expect ": syntax error: " {
+    puts "times sleep 1 produces syntax error"
+}
+expect_prompt

--- a/src/cmd/ksh93/tests/time.exp.out
+++ b/src/cmd/ksh93/tests/time.exp.out
@@ -1,0 +1,5 @@
+time with no pipeline produces expected output
+time sleep 1 produces expected output
+time sleep 0.05 pipeline produces expected output
+times produces expected output
+times sleep 1 produces syntax error


### PR DESCRIPTION
Commit 595f499 by me introduced an assert and initialized var `tb`
in a path where it was used without being initialized. However, the
initialization to zero and the subsequent assert it was non-zero was
incorrect. This fixes that and adds a unit test to verify `time` and
`times` produce reasonable output.

Related #1328