### PR TITLE
Remove math function `fpclassify()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ was subsequently created to document the work being done.
 
 ## Notable non-backward compatible changes
 
+- The nonportable, unusable, `fpclassify` math function has been removed
+  (issue #1346).
 - The broken math functions `nextforward` and `nexttoward` have been removed
   (issue #1346).
 - Support for binary plugins written for ksh93u+ or earlier releases has been

--- a/src/cmd/ksh93/bltins/math.c
+++ b/src/cmd/ksh93/bltins/math.c
@@ -26,10 +26,6 @@ static int local_finite(Sfdouble_t a1) {
 
 static Sfdouble_t local_float(Sfdouble_t a1) { return a1; }
 
-static int local_fpclassify(Sfdouble_t a1) {
-    return fpclassify(a1);  //!OCLINT(constant conditional operator)
-}
-
 static Sfdouble_t local_int(Sfdouble_t a1) {
     if (a1 < LLONG_MIN || a1 > ULLONG_MAX) return 0.0;
     if (a1 < 0) return (Sfdouble_t)((Sflong_t)a1);
@@ -170,7 +166,6 @@ const struct mathtab shtab_math[] = {{"\001acos", (Math_f)acosl},
                                      {"\002fmax", (Math_f)fmaxl},
                                      {"\002fmin", (Math_f)fminl},
                                      {"\002fmod", (Math_f)fmodl},
-                                     {"\011fpclassify", (Math_f)local_fpclassify},
                                      {"\002hypot", (Math_f)hypotl},
                                      {"\011ilogb", (Math_f)ilogbl},
                                      {"\001int", (Math_f)local_int},

--- a/src/cmd/ksh93/ksh.1
+++ b/src/cmd/ksh93/ksh.1
@@ -3035,8 +3035,8 @@ can be used within an arithmetic expression:
 .PP
 .if t .RS
 .B
-.if n abs acos acosh asin asinh atan atan2 atanh cbrt ceil copysign cos cosh erf erfc exp exp2 expm1 fabs fpclassify fdim finite floor fma fmax fmin fmod hypot ilogb int isfinite sinf isnan isnormal issubnormal issubordered iszero j0 j1 jn lgamma log log10 log2 logb nearbyint pow remainder rint round scanb signbit sin sinh sqrt tan tanh tgamma trunc y0 y1 yn
-.if t abs   acos   acosh   asin   asinh   atan   atan2   atanh   cbrt   ceil copysign   cos   cosh   erf  erfc   exp   exp2   expm1   fabs   fpclassify fdim   finite   floor  fma   fmax   fmod   j0      j1      jn      hypot   ilogb   int   isfinite   isinf   isnan   isnormal  issubnormal   issubordered   iszero lgamma   log   log10 log2   logb   nearbyint   pow   rint   round   scalb   signbit sin   sinh   sqrt   tan   tanh   tgamma   trunc   y0      y1      yn
+.if n abs acos acosh asin asinh atan atan2 atanh cbrt ceil copysign cos cosh erf erfc exp exp2 expm1 fabs fdim finite floor fma fmax fmin fmod hypot ilogb int isfinite sinf isnan isnormal issubnormal issubordered iszero j0 j1 jn lgamma log log10 log2 logb nearbyint pow remainder rint round scanb signbit sin sinh sqrt tan tanh tgamma trunc y0 y1 yn
+.if t abs   acos   acosh   asin   asinh   atan   atan2   atanh   cbrt   ceil copysign   cos   cosh   erf  erfc   exp   exp2   expm1   fabs   fdim   finite   floor  fma   fmax   fmod   j0      j1      jn      hypot   ilogb   int   isfinite   isinf   isnan   isnormal  issubnormal   issubordered   iszero lgamma   log   log10 log2   logb   nearbyint   pow   rint   round   scalb   signbit sin   sinh   sqrt   tan   tanh   tgamma   trunc   y0      y1      yn
 .if t .RE
 In addition, arithmetic functions can be defined as shell functions with a
 variant of the

--- a/src/cmd/ksh93/tests/math.sh
+++ b/src/cmd/ksh93/tests/math.sh
@@ -361,12 +361,6 @@ actual=$(roundto $(( fmod(999.99, 10) )) )
 [[ $actual -eq $expect ]] || log_error "fmod failed" "$expect" "$actual"
 
 # ==========
-# fpclassify
-# TODO: Remove this test when issue #1346 is resolved and the `fpclassify()` function is removed.
-actual=$(( fpclassify(nan) ))
-[[ $actual -ge 0 ]] || log_error "fpclassify failed" ">= 0" "$actual"
-
-# ==========
 # int
 expect=2
 actual=$(( int(2.9) ))


### PR DESCRIPTION
The math function `fpclassify()` is not portable since the values it
returns are not portable without exposing C symbols like `FP_NAN` from
the math.h header file.

This is technically a non-backward compatible change that should only
be done in a major release. However, the `fpclassify()` is unusable as
currently implemented; at least in any portable fashion. The probability
that any ksh script depends on `fpclassify()` is zero, or so close to
it, that removing it is a non-issue. Therefore removing this "feature"
should be harmless.

Fixes #1346