### PR TITLE
Add `glibc-all-langpacks` as a dependency for Fedora

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
           compiler: gcc
           env:
             - DISTRO_TYPE=fedora
-              INSTALL_REQUIREMENTS="dnf repolist; dnf --allowerasing install -y gcc python3 meson sudo langpacks-zh_CN ed ncurses vi findutils which nmap-ncat expect git"
+              INSTALL_REQUIREMENTS="dnf repolist; dnf --allowerasing install -y gcc python3 meson sudo langpacks-zh_CN ed ncurses vi findutils which nmap-ncat expect git glibc-all-langpacks"
           before_install:
               - docker pull ${DISTRO_TYPE}
 


### PR DESCRIPTION
Recently Travis builds for Fedora broke because `glibc-all-langpacks`
was not installed on Fedora docker instance. Explicitly add it as a
dependency to build on Fedora.