### PR TITLE
Check for and report I/O error in output builtins

### DIFF
--- a/src/cmd/ksh93/data/msg.c
+++ b/src/cmd/ksh93/data/msg.c
@@ -76,6 +76,7 @@ const char e_access[] = "permission denied";
 const char e_direct[] = "bad directory";
 const char e_file[] = "%s: bad file unit number";
 const char e_redirect[] = "redirection failed";
+const char e_io[] = "I/O error";
 const char e_trap[] = "%s: bad trap";
 const char e_readonly[] = "%s: is read only";
 const char e_badfield[] = "%d: negative field size";

--- a/src/cmd/ksh93/include/io.h
+++ b/src/cmd/ksh93/include/io.h
@@ -85,6 +85,7 @@ extern const char e_tmpcreate[];
 extern const char e_exists[];
 extern const char e_file[];
 extern const char e_redirect[];
+extern const char e_io[];
 extern const char e_formspec[];
 extern const char e_badregexp[];
 extern const char e_open[];

--- a/src/cmd/ksh93/tests/b_print.sh
+++ b/src/cmd/ksh93/tests/b_print.sh
@@ -104,3 +104,24 @@ then
 else
     log_error 'print -s -f fails'
 fi
+
+# ======
+# Check that I/O errors are detected <https://github.com/att/ast/issues/1093>
+actual=$(
+    {
+        (
+            trap "" PIPE
+            for ((i = SECONDS + 1; SECONDS < i; )); do
+                print hi || {
+                    print $? >&2
+                    exit
+                }
+            done
+        ) | true
+    } 2>&1
+)
+expect=$': print: I/O error\n1'
+if [[ $actual != *"$expect" ]]
+then
+    log_error 'I/O error not detected' "$expect" "$actual"
+fi


### PR DESCRIPTION
This allows scripts to check for a nonzero exit status on the `print`, `printf` and `echo` builtins and prevent possible infinite loops if `SIGPIPE` is ignored.

`sfsync()` was already returning a negative value on I/O error, so all we need to do is add a check. The stream buffer will need to be filled before an I/O error can be detected, but this is the same on
other shells. See manual page: `src/lib/libast/man/sfio.3`

Fixes #1093

`src/cmd/ksh93/bltins/print.c`: `b_print()`:
- Make sure an error result from `sfsync()` is reflected in the output builtin's exit status (`exitval`).
- Write an I/O error message (`e_io`) if the exit status is nonzero.

`src/cmd/ksh93/data/msg.c`, `src/cmd/ksh93/include/io.h`:
- Add the `e_io[]` error message.

`src/cmd/ksh93/tests/b_print.sh`:
- Add I/O error regression test, checking for the correct error message and exit status. All three output builtins use the same `b_print()` function so we only need to test one.