### PR TITLE
Fix dynamic library for musl-fts

### DIFF
--- a/src/lib/libast/meson.build
+++ b/src/lib/libast/meson.build
@@ -18,7 +18,7 @@ libast = library('ast', libast_files,
                  include_directories: [configuration_incdir, libast_incdir],
                  c_args: libast_c_args,
                  dependencies: [libm_dep, libiconv_dep, libcatgets_dep, libexecinfo_dep, libdl_dep,
-                                libsocket_dep, libnsl_dep, libfts_dep],
+                                libsocket_dep, libnsl_dep],
                  install: get_option('default_library') == 'shared')
 
 # This library exists solely to support libast unit tests so that `sh_getenv()` and

--- a/src/lib/libcmd/meson.build
+++ b/src/lib/libcmd/meson.build
@@ -12,5 +12,6 @@ incdir = include_directories('../libast/include')
 
 libcmd = library('cmd', libcmd_files, c_args: libcmd_c_args,
                  include_directories: [configuration_incdir, incdir],
+                 dependencies: libfts_dep,
                  link_with: libast,
                  install: get_option('default_library') == 'shared')

--- a/src/lib/libdll/meson.build
+++ b/src/lib/libdll/meson.build
@@ -7,6 +7,7 @@ libdll_c_args = shared_c_args + [
 
 libdll = library('dll', libdll_files, c_args: libdll_c_args,
                  include_directories: [configuration_incdir, libast_incdir],
+                 dependencies: libfts_dep,
                  link_with: libast,
                  install: get_option('default_library') == 'shared')
 


### PR DESCRIPTION
Upon further inspection after pull request #1362 , I've added the feature test for `fts.h` and fixed the dynamic library compilation.