### PR TITLE
Install libksh.so when building shared library

### DIFF
--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -24,7 +24,7 @@ libksh = library('ksh', ksh93_files,
                  include_directories: [configuration_incdir, ksh93_incdir],
                  c_args: shared_c_args,
                  dependencies: [libm_dep, libexecinfo_dep, libdl_dep, libsocket_dep, libnsl_dep],
-                 install: false)
+                 install: get_option('default_library') == 'shared')
 
 ksh93_exe = executable('ksh', ['sh/pmain.c'], c_args: shared_c_args,
     include_directories: [configuration_incdir, ksh93_incdir],


### PR DESCRIPTION
This is the latest fix required to make ksh work when building shared library. Prior to this commit, the linking phase succeeded but at runtime it complains about libksh.so not being installed.