### PR TITLE
Test glob <=> ere conversion

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project('ksh93', 'c', default_options: ['b_lundef=false', 'default_library=static'])
 
+source_dir = meson.current_source_dir()
 cc = meson.get_compiler('c')
 cpu = host_machine.cpu()
 system = host_machine.system()

--- a/src/cmd/ksh93/meson.build
+++ b/src/cmd/ksh93/meson.build
@@ -44,6 +44,7 @@ test_dir = join_paths(meson.current_source_dir(), 'tests')
 test_driver = join_paths(test_dir, 'util', 'run_test.sh')
 
 # This variable is used by some tests while executing subtests
+src_root = 'SRC_ROOT=' + source_dir
 test_root = 'TEST_ROOT=' + test_dir
 shell_var = 'SHELL=' + ksh93_exe.full_path()
 shcomp_var = 'SHCOMP=' + shcomp_exe.full_path()

--- a/src/cmd/ksh93/tests/api/meson.build
+++ b/src/cmd/ksh93/tests/api/meson.build
@@ -43,6 +43,6 @@ foreach testspec : api_tests
             install: false)
         test('API/ksh/' + test_name, ksh93_exe, timeout: timeout, is_parallel: parallel,
             args: [test_driver, 'api', test_target, test_name],
-            env: [shell_var, lang_var, test_root, ld_library_path, libsample_path])
+            env: [shell_var, lang_var, src_root, test_root, ld_library_path, libsample_path])
     endif
 endforeach

--- a/src/cmd/ksh93/tests/meson.build
+++ b/src/cmd/ksh93/tests/meson.build
@@ -81,7 +81,7 @@ all_tests = [
     ['restricted'],
     ['rksh'],
     ['select'],
-    ['sh_match'],
+    ['sh_match', 120],
     ['sigchld', 100],
     ['signal'],
     ['statics'],
@@ -107,17 +107,20 @@ all_tests = [
 
 # Some tests fail for inexplicable reasons on some platforms. In some cases, such as Cygwin, things
 # simply don't work as expected and probably never will due to quirks of the platform. Another
-# example is sunos/solaris has /proc but doesn't support manipulating directory fd's.
+# example is sunos/solaris has /proc but doesn't support manipulating directory fd's. Also, some
+# tests are simply too slow on particular platforms when hosted on a VM.
 tests_to_skip = [
     ['cygwin', 'b_jobs.exp'],
     ['cygwin', 'b_time.exp'],
     ['cygwin', 'b_times.exp'],
     ['cygwin', 'signal'],
+    ['cygwin', 'sh_match'],  # too slow, times out
     ['openbsd', 'b_times.exp'],
     ['sunos', 'vi.exp'],
     ['sunos', 'directoryfd'],
     ['wsl', 'b_time.exp'],
     ['wsl', 'b_times.exp'],
+    ['wsl', 'sh_match'],  # too slow, times out
     # Tests to be skipped because they are known to be broken when compiled by `shcomp`.
     # TODO: Fix these tests or the shcomp code.
     ['shcomp', 'io'],
@@ -155,7 +158,7 @@ foreach testspec : all_tests
         lang_var = 'LANG=en_US.UTF-8'
         test(test_name, ksh93_exe, timeout: timeout, is_parallel: parallel,
             args: [test_driver, test_name],
-            env: [shell_var, lang_var, test_root, ld_library_path, libsample_path])
+            env: [shell_var, lang_var, src_root, test_root, ld_library_path, libsample_path])
 
         # The shcomp variants are only applicable to the non-interactive tests.
         if not test_name.endswith('.exp')
@@ -171,7 +174,7 @@ foreach testspec : all_tests
                 # Run the test after compiling the script with `shcomp`.
                 test(test_name + '/shcomp', ksh93_exe, timeout: timeout, is_parallel: parallel,
                     args: [ test_driver, 'shcomp', test_name],
-                    env: [shell_var, lang_var, test_root, shcomp_var, ld_library_path,
+                    env: [shell_var, lang_var, src_root, test_root, shcomp_var, ld_library_path,
                           libsample_path])
             endif
         endif

--- a/src/cmd/ksh93/tests/util/preamble.sh
+++ b/src/cmd/ksh93/tests/util/preamble.sh
@@ -40,6 +40,7 @@ readonly NO_BUILTINS_PATH
 readonly FULL_PATH
 readonly OLD_PATH
 readonly SAFE_PATH
+readonly SRC_ROOT
 readonly TEST_DIR
 readonly TEST_ROOT
 readonly BUILD_DIR

--- a/src/lib/libast/tests/string/fmtmatch.c
+++ b/src/lib/libast/tests/string/fmtmatch.c
@@ -1,4 +1,5 @@
 // See also src/lib/libast/tests/string/fmtre.c.
+// See also src/lib/cmd/ksh93/tests/sh_match.sh.
 #include "config_ast.h"  // IWYU pragma: keep
 
 #include <string.h>
@@ -7,7 +8,7 @@
 #include "terror.h"
 
 static const struct StringToStringTest tests[] = {
-    {"", "**"},
+    {"", "**"},  // empty ERE pattern should yield a weird but equivalent and valid glob
     {".*", "*"},
     {"^(xyz)*$", "*(xyz)"},
     {"^(x)*?$", "*-(x)"},
@@ -48,7 +49,7 @@ static const struct StringToStringTest tests[] = {
     {"^(x|y)$", "@(x|y)"},
 
     // ERE patterns that cannot be translated to ksh patterns.
-    {"^x..*|\\(|(b.$", NULL},  // {"^x..*|\\(|(b.$", "x?*|\\(|b?"},
+    {"^x..*|\\(|(b.$", NULL},  // "x?*|\\(|b?"
     {"^x{$", NULL},            // "x{"
     {"^{$", NULL},             // "{"
     {"^{}$", NULL},            // "{}"

--- a/src/lib/libast/tests/string/fmtre.c
+++ b/src/lib/libast/tests/string/fmtre.c
@@ -1,4 +1,5 @@
 // See also src/lib/libast/tests/string/fmtmatch.c.
+// See also src/lib/cmd/ksh93/tests/sh_match.sh.
 #include "config_ast.h"  // IWYU pragma: keep
 
 #include <string.h>


### PR DESCRIPTION
When converting between globs and EREs it is a good idea to verify the
generated pattern matches the same lines as the original pattern.

Related #1367