### PR TITLE
Display the prompt on stdout rather than stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ was subsequently created to document the work being done.
 
 ## Notable fixes and improvements
 
+- Interactive prompts are now written to stdout rather than stderr (issue #1380)
 - `declare` has been added as an alias for `typeset` (issue #220).
 - `local` has been added as a constrained alias for `typeset` when used inside
   a function (issue #220).

--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -357,9 +357,9 @@ int ed_expand(Edit_t *ep, char outbuff[], int *cur, int *eol, int mode, int coun
                     *ptrcom = path_basename(*ptrcom);
                 }
             }
-            sfputc(sfstderr, '\n');
-            sh_menu(shp, sfstderr, narg, com);
-            sfsync(sfstderr);
+            sfputc(sfstdout, '\n');
+            sh_menu(shp, sfstdout, narg, com);
+            sfsync(sfstdout);
             ep->e_nlist = narg;
             ep->e_clist = com;
             goto done;

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -263,7 +263,7 @@ int ed_window(void) {
 //
 void ed_flush(Edit_t *ep) {
     int n = ep->e_outptr - ep->e_outbase;
-    int fd = STDERR_FILENO;
+    int fd = STDOUT_FILENO;
 
     if (n <= 0) return;
     write(fd, ep->e_outbase, (unsigned)n);
@@ -273,7 +273,7 @@ void ed_flush(Edit_t *ep) {
 //
 // Send the bell character ^G to the terminal.
 //
-void ed_ringbell(void) { write(STDERR_FILENO, bellchr, 1); }
+void ed_ringbell(void) { write(STDOUT_FILENO, bellchr, 1); }
 
 //
 // Send a carriage return line feed to the terminal.
@@ -429,21 +429,21 @@ void ed_setup(Edit_t *ep, int fd, int reedit) {
         ep->e_plen -= shift;
         last[-ep->e_plen - 2] = '\r';
     }
-    sfsync(sfstderr);
-    if (fd == sffileno(sfstderr)) {
-        // Can't use output buffer when reading from stderr.
+    sfsync(sfstdout);
+    if (fd == sffileno(sfstdout)) {
+        // Can't use output buffer when reading from stdout.
         static char *buff;
         if (!buff) buff = malloc(MAXLINE);
         ep->e_outbase = ep->e_outptr = buff;
         ep->e_outlast = ep->e_outptr + MAXLINE;
         return;
     }
-    qlen = sfset(sfstderr, SF_READ, 0);
+    qlen = sfset(sfstdout, SF_READ, 0);
     // Make sure SF_READ not on.
-    ep->e_outbase = ep->e_outptr = sfreserve(sfstderr, SF_UNBOUND, SF_LOCKR);
-    ep->e_outlast = ep->e_outptr + sfvalue(sfstderr);
-    if (qlen) sfset(sfstderr, SF_READ, 1);
-    sfwrite(sfstderr, ep->e_outptr, 0);
+    ep->e_outbase = ep->e_outptr = sfreserve(sfstdout, SF_UNBOUND, SF_LOCKR);
+    ep->e_outlast = ep->e_outptr + sfvalue(sfstdout);
+    if (qlen) sfset(sfstdout, SF_READ, 1);
+    sfwrite(sfstdout, ep->e_outptr, 0);
     ep->e_eol = reedit;
     if (ep->e_multiline) {
 #ifdef _cmd_tput

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -176,7 +176,7 @@ int ed_emacsread(void *context, int fd, char *buff, int scend, int reedit) {
     Prompt = prompt;
     ep->screen = Screen;
     ep->lastdraw = FINAL;
-    if (tty_raw(STDERR_FILENO, 0) < 0) {
+    if (tty_raw(STDOUT_FILENO, 0) < 0) {
         return reedit ? reedit : ed_read(context, fd, buff, scend, 0);
     }
     raw = 1;
@@ -207,7 +207,7 @@ int ed_emacsread(void *context, int fd, char *buff, int scend, int reedit) {
             draw(ep, FINAL);
             ed_flush(ep->ed);
         }
-        tty_cooked(STDERR_FILENO);
+        tty_cooked(STDOUT_FILENO);
         if (i == UEOF) return 0;  // EOF
         return -1;                // some other error
     }
@@ -266,7 +266,7 @@ int ed_emacsread(void *context, int fd, char *buff, int scend, int reedit) {
             }
             case EOFCHAR: {
                 ed_flush(ep->ed);
-                tty_cooked(STDERR_FILENO);
+                tty_cooked(STDOUT_FILENO);
                 return 0;
             }
             case '\t': {
@@ -600,7 +600,7 @@ process:
         *out = '\0';
     }
     draw(ep, FINAL);
-    tty_cooked(STDERR_FILENO);
+    tty_cooked(STDOUT_FILENO);
     if (ed->e_nlist) {
         ed->e_nlist = 0;
         stkset(stkstd, ed->e_stkptr, ed->e_stkoff);

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -183,7 +183,7 @@ int ed_viread(void *context, int fd, char *shbuf, int nchar, int reedit) {
     shbuf[reedit] = 0;
 
     // Set raw mode.
-    if (tty_raw(STDERR_FILENO, 0) < 0) {
+    if (tty_raw(STDOUT_FILENO, 0) < 0) {
         return reedit ? reedit : ed_read(context, fd, shbuf, nchar, 0);
     }
     i = last_virt - 1;
@@ -237,7 +237,7 @@ int ed_viread(void *context, int fd, char *shbuf, int nchar, int reedit) {
             sync_cursor(vp);
         }
         virtual[0] = '\0';
-        tty_cooked(STDERR_FILENO);
+        tty_cooked(STDOUT_FILENO);
 
         if (i == UEOF) return 0;    // EOF
         if (i == UINTR) return -1;  // interrupt
@@ -254,7 +254,7 @@ int ed_viread(void *context, int fd, char *shbuf, int nchar, int reedit) {
     vigetline(vp, APPEND);
     if (vp->ed->e_multiline) cursor(vp, last_phys);
     // Add a new line if user typed unescaped \n to cause the shell to process the line.
-    tty_cooked(STDERR_FILENO);
+    tty_cooked(STDOUT_FILENO);
     if (ed->e_nlist) {
         ed->e_nlist = 0;
         stkset(ed->sh->stk, ed->e_stkptr, ed->e_stkoff);

--- a/src/cmd/ksh93/sh/fault.c
+++ b/src/cmd/ksh93/sh/fault.c
@@ -551,7 +551,7 @@ __attribute__((noreturn)) void sh_done(void *ptr, int sig) {
 #ifdef JOBS
     if ((sh_isoption(shp, SH_INTERACTIVE) && shp->login_sh) ||
         (!sh_isoption(shp, SH_INTERACTIVE) && (sig == SIGHUP))) {
-        job_walk(shp, sfstderr, job_terminate, SIGHUP, NULL);
+        job_walk(shp, sfstdout, job_terminate, SIGHUP, NULL);
     }
 #endif  // JOBS
     job_close(shp);

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -476,11 +476,11 @@ bool job_reap(int sig) {
         nochild = true;
     }
     if (sh_isoption(shp, SH_NOTIFY) && sh_isstate(shp, SH_TTYWAIT)) {
-        outfile = sfstderr;
+        outfile = sfstdout;
         assert(pw);
         job_list(pw, JOB_NFLAG | JOB_NLFLAG);
         job_unpost(shp, pw, 1);
-        sfsync(sfstderr);
+        sfsync(sfstdout);
     }
     shp->trapnote |= (shp->sigflag[SIGCHLD] & SH_SIGTRAP);
     if (!sig && (shp->trapnote & SH_SIGTRAP)) {
@@ -1308,9 +1308,9 @@ bool job_wait(pid_t pid) {
             for (px = job.pwlist; px; px = px->p_nxtjob) {
                 if (px != pw && (px->p_flag & P_NOTIFY)) {
                     if (sh_isoption(shp, SH_NOTIFY)) {
-                        outfile = sfstderr;
+                        outfile = sfstdout;
                         job_list(px, JOB_NFLAG | JOB_NLFLAG);
-                        sfsync(sfstderr);
+                        sfsync(sfstdout);
                     } else if (!sh_isoption(shp, SH_INTERACTIVE) && (px->p_flag & P_SIGNALLED)) {
                         job_prmsg(shp, px);
                         px->p_flag &= ~P_NOTIFY;
@@ -1355,7 +1355,7 @@ bool job_wait(pid_t pid) {
                 continue;
             }
         }
-        sfsync(sfstderr);
+        sfsync(sfstdout);
         job.waitsafe = 0;
         nochild = job_reap(job.savesig);
         if (job.waitsafe) continue;

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -138,7 +138,7 @@ int sh_main(int ac, char *av[], Shinit_f userinit) {
         // Decide whether shell is interactive.
         if (!sh_isoption(shp, SH_INTERACTIVE) && !sh_isoption(shp, SH_TFLAG) &&
             !sh_isoption(shp, SH_CFLAG) && sh_isoption(shp, SH_SFLAG) && tty_check(0) &&
-            tty_check(STDERR_FILENO)) {
+            tty_check(STDOUT_FILENO)) {
             sh_onoption(shp, SH_INTERACTIVE);
         }
         if (sh_isoption(shp, SH_INTERACTIVE)) {
@@ -440,7 +440,7 @@ static_fn void exfile(Shell_t *shp, Sfio_t *iop, int fno) {
             sh_offstate(shp, SH_MONITOR);
             if (sh_isoption(shp, SH_MONITOR)) sh_onstate(shp, SH_MONITOR);
             if (job.pwlist) {
-                job_walk(shp, sfstderr, job_list, JOB_NFLAG, NULL);
+                job_walk(shp, sfstdout, job_list, JOB_NFLAG, NULL);
                 job_wait((pid_t)0);
             }
 #endif  // JOBS
@@ -471,7 +471,7 @@ static_fn void exfile(Shell_t *shp, Sfio_t *iop, int fno) {
         if (tdone || !sfreserve(iop, 0, 0)) {
         eof_or_error:
             if (sh_isstate(shp, SH_INTERACTIVE) && !sferror(iop)) {
-                if (--maxtry > 0 && sh_isoption(shp, SH_IGNOREEOF) && !sferror(sfstderr)) {
+                if (--maxtry > 0 && sh_isoption(shp, SH_IGNOREEOF) && !sferror(sfstdout)) {
                     // It is theoretically possible for fno == -1 at this point. That would be bad.
                     assert(fno >= 0);
                     if ((shp->fdstatus[fno] & IOTTY)) {
@@ -495,7 +495,7 @@ static_fn void exfile(Shell_t *shp, Sfio_t *iop, int fno) {
         if (sh_isstate(shp, SH_INTERACTIVE) && shp->gd->hist_ptr) {
             job_wait((pid_t)0);
             hist_eof(shp->gd->hist_ptr);
-            sfsync(sfstderr);
+            sfsync(sfstdout);
         }
         if (sh_isoption(shp, SH_HISTORY)) sh_onstate(shp, SH_HISTORY);
         job.waitall = job.curpgid = 0;
@@ -523,7 +523,7 @@ static_fn void exfile(Shell_t *shp, Sfio_t *iop, int fno) {
 done:
     sh_popcontext(shp, &buff);
     if (sh_isstate(shp, SH_INTERACTIVE)) {
-        sfputc(sfstderr, '\n');
+        sfputc(sfstdout, '\n');
         job_close(shp);
     }
     if (jmpval == SH_JMPSCRIPT) {

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1293,7 +1293,7 @@ int sh_exec(Shell_t *shp, const Shnode_t *t, int flags) {
                             shp->exitval = (*shp->bltinfun)(argn, com, bp);
                             sfsync(NULL);
                         }
-                        if (error_info.flags & ERROR_INTERACTIVE) tty_check(STDERR_FILENO);
+                        if (error_info.flags & ERROR_INTERACTIVE) tty_check(STDOUT_FILENO);
                         ((Shnode_t *)t)->com.comstate = shp->bltindata.data;
                         bp->data = (void *)save_data;
                         if (shp->exitval && errno == EINTR && shp->lastsig) {


### PR DESCRIPTION
This makes it possible to redirect stderr and still have a usable
interactive shell. This is expected to be used rarely in the normal
course of using the shell, but is particularly valuable for unit
testing.

Fixes #1380