### PR TITLE
Show version number through `ksh --version`

### DIFF
--- a/scripts/builtin_documentation.sh
+++ b/scripts/builtin_documentation.sh
@@ -3,6 +3,8 @@
 # the raw markup text.
 out_file="$MESON_BUILD_ROOT/$MESON_SUBDIR/documentation.c"
 exec > "$out_file"
+# `ksh_mini.1` uses `SH_VERSION` macro to generate version number string
+echo '#include "version.h"'
 for in_file in "$MESON_SOURCE_ROOT/src/cmd/ksh93/docs/"*.1
 do
     cmd_name=$(basename "$in_file" .1)

--- a/src/cmd/ksh93/docs/ksh_mini.1
+++ b/src/cmd/ksh93/docs/ksh_mini.1
@@ -1,5 +1,5 @@
 +[-1?
-@(#)$Id: sh (AT&T Research) $
+@(#)$Id: sh (AT&T Research) " SH_RELEASE " $
 ]
 [+NAME?\b\f?\f\b - Shell, the standard command language interpreter]
 [+DESCRIPTION?\b\f?\f\b is a command language interpreter that executes commands read from a command line string, the standard input, or a specified file.]


### PR DESCRIPTION
Version number is stored in `SH_RELEASE` macro. Add it to the output of
`ksh --version`. This was a regression introduced by 44fb5d5a.