### PR TITLE
Fix `cd` function and make it automatically available

### DIFF
--- a/src/cmd/ksh93/data/config.ksh
+++ b/src/cmd/ksh93/data/config.ksh
@@ -4,6 +4,8 @@
 # for them to be loaded on demand. It should not do anything not suitable for every single new ksh
 # process. In particular it should be as fast as possible.
 #
+
+#
 # Arrange for standard autoloaded functions to be available. The test for whether or not FPATH is
 # already set isn't technically necessary since empty path components are guaranteed not to be
 # equivalent to `.` (the CWD). But I prefer to be paranoid since doing so is cheap.
@@ -21,4 +23,18 @@ for f in "$__fpath"/*
 do
     typeset -fu $(basename $f)
 done
+
+# Global vars for the `_cd`, `mcd`, `pushd`, `popd`, `dirs` functions.
+integer _push_max=${CDSTACK:-32}
+integer _push_top=${CDSTACK:-32}
+typeset -a _push_stack
+
+# Prefer the `cd` function to the `cd` builtin as the function is needed for functions like
+# `dirs` and `popd` to work. Only do this for interactive shells.
+if [[ $- == *i* && -f "$__fpath/_cd" ]]
+then
+    unalias cd 2>/dev/null  # the alias probably doesn't exist so don't complain in that case
+    alias cd=_cd
+fi
+
 unset __fpath

--- a/src/cmd/ksh93/functions/_cd
+++ b/src/cmd/ksh93/functions/_cd
@@ -1,0 +1,87 @@
+# Change directory and push the directory on the dir stack. This also recognizes some extensions su
+# has `cd -2` to cd to the second most recently visited directory.
+function _cd {
+    typeset dir=''
+    integer n=0
+    integer type=4
+
+    case $1 in
+    -|-1|2) # \cd -
+        n=_push_top
+        type=1
+        ;;
+    -[1-9]*([0-9])) # \cd -n
+        n=_push_top+${1#-}-1
+        type=2
+        ;;
+    1)  # keep present directory
+        print -r - "$PWD"
+        return
+        ;;
+    [1-9]*([0-9])) # \cd n
+        n=_push_top+${1}-2
+        type=2
+        ;;
+    *)
+        if (( _push_top <= 0 ))
+        then
+            n=_push_max
+            type=3
+        fi
+        ;;
+    esac
+
+    if (( type < 3 ))
+    then
+        if (( n >= _push_max + 1 ))
+        then
+            print -u2 cd: Directory stack not that deep.
+            return 1
+        else
+            dir="${_push_stack[n]}"
+        fi
+    fi
+
+    case $dir in
+    \~*) dir=$HOME${dir#\~}
+    esac
+
+    (( $# == 0 )) && set -- ~/
+    \cd "${dir:-$@}" || return 1
+
+    dir="${OLDPWD#$HOME/}"
+
+    # TODO: Generalize this so it works on every terminal that supports setting its title string.
+    case $TERM in
+    630)
+        print "\033[?${#PWD};2v$PWD\c"
+        ;;
+    esac
+
+    case "$dir" in
+    $HOME)
+        dir="~"
+        ;;
+    /*) ;;
+    *)  dir="~/$dir"
+        ;;
+    esac
+
+    case "$type" in
+    1)  # swap first two elements
+        _push_stack[_push_top]="$dir"
+        ;;
+    2|3)  # put $dir on top and shift down by one until top
+        integer i=_push_top
+        for dir in "$dir" "${_push_stack[@]}"
+        do (( i > n )) && break
+            _push_stack[i]="$dir"
+            (( i = i + 1 ))
+        done
+        ;;
+    4)  # push name
+        _push_stack[_push_top=_push_top - 1]="$dir"
+        ;;
+    esac
+    print -r - "$PWD"
+}

--- a/src/cmd/ksh93/functions/dirs
+++ b/src/cmd/ksh93/functions/dirs
@@ -1,108 +1,20 @@
-#
-# DIRECTORY MANIPULATION FUNCTIONS, REPLACES CD
-#
-# Uses global parameters _push_max _push_top _push_stack
-integer _push_max=${CDSTACK-32} _push_top=${CDSTACK-32}
-unalias cd
-alias cd=_cd
-# Display directory stack -- $HOME displayed as ~
-function dirs
-{
+# Display directory stack -- $HOME displayed as ~.
+function dirs {
     typeset dir="${PWD#$HOME/}"
     case $dir in
     $HOME)
         dir=\~
         ;;
-    /*) ;;
-    *)  dir=\~/$dir
+    /*)
+        ;;
+    *)
+        dir=\~/$dir
+        ;;
     esac
-    PS3=
+
+    PS3=''
     select i in "$dir" "${_push_stack[@]}"
-    do	:
+    do
+        :
     done < /dev/null
-}
-
-# Change directory and put directory on front of stack
-function _cd
-{
-    typeset dir=
-    integer n=0 type=4
-    case $1 in
-    -|-1|2) # \cd -
-        n=_push_top type=1
-        ;;
-    -[1-9]*([0-9])) # \cd -n
-        n=_push_top+${1#-}-1 type=2
-        ;;
-    1)  # keep present directory
-        print -r - "$PWD"
-	return
-        ;;      
-    [1-9]*([0-9])) # \cd n
-        n=_push_top+${1}-2 type=2
-        ;;
-    *)  if    ((_push_top <= 0))
-        then  type=3 n=_push_max
-        fi
-    esac
-    if    ((type<3))
-    then  if    ((n >= _push_max+1))
-          then  print -u2 cd: Directory stack not that deep.
-                return 1
-          else  dir=${_push_stack[n]}
-          fi
-    fi
-    case $dir in
-    \~*)   dir=$HOME${dir#\~}
-    esac
-    \cd "${dir:-$@}" >| /dev/null || return 1
-    dir=${OLDPWD#$HOME/}
-    case $TERM in
-    630)
-	    print "\033[?${#PWD};2v$PWD\c"
-	    ;;
-    esac
-    case $dir in
-    $HOME)
-        dir=\~
-        ;;
-    /*) ;;
-    *)  dir=\~/$dir
-    esac
-    case $type in
-    1)  # swap first two elements
-        _push_stack[_push_top]=$dir
-        ;;
-    2|3)  # put $dir on top and shift down by one until top
-        integer i=_push_top
-        for dir in "$dir" "${_push_stack[@]}"
-        do  ((i > n)) && break
-            _push_stack[i]=$dir
-            i=i+1
-        done
-        ;;
-    4)  # push name
-        _push_stack[_push_top=_push_top-1]=$dir
-        ;;
-    esac
-    print -r - "$PWD"
-}
-
-# Menu driven change directory command
-function mcd
-{
-    typeset dir="${PWD#$HOME/}"
-    case $dir in
-    $HOME)
-        dir=\~
-        ;;
-    /*) ;;
-    *)  dir=\~/$dir
-    esac
-    PS3='Select by number or enter a name: '
-    select dir in "$dir" "${_push_stack[@]}"
-    do  if    _cd $REPLY
-        then  return
-        fi
-    done
 }

--- a/src/cmd/ksh93/functions/mcd
+++ b/src/cmd/ksh93/functions/mcd
@@ -1,0 +1,20 @@
+# Menu driven change directory command.
+function mcd {
+    typeset dir="${PWD#$HOME/}"
+    case $dir in
+    $HOME) dir=\~
+        ;;
+    /*) ;;
+    *)  dir=\~/$dir
+        ;;
+    esac
+
+    PS3='Select by number or enter a name: '
+    select dir in "$dir" "${_push_stack[@]}"
+    do
+        if _cd $REPLY
+        then
+            return
+        fi
+    done
+}

--- a/src/cmd/ksh93/tests/attributes.sh
+++ b/src/cmd/ksh93/tests/attributes.sh
@@ -511,14 +511,21 @@ expected='typeset -a x=(a\=3 b\=4)'
 typeset -a x=( a=3 b=4)
 [[ $(typeset -p x) == "$expected" ]] || log_error 'assignment elements in typeset -a assignment not working'
 
-unset z
-z='typeset -a q=(a b c)'
-$SHELL -c "$z; [[ \$(typeset -pa) == '$z' ]]" || log_error 'typeset -pa does not list only index arrays'
-z='typeset -C z=(foo=bar)'
-$SHELL -c "$z; [[ \$(typeset -pC) == '$z' ]]" || log_error 'typeset -pC does not list only compound variables'
-unset y
-z='typeset -A y=([a]=foo)'
-$SHELL -c "$z; [[ \$(typeset -pA) == '$z' ]]" || log_error 'typeset -pA does not list only associative arrays'
+# We need to unset `push_stack` because it is defined automatically in each shell instance.
+expect='typeset -a q=(a b c)'
+actual=$($SHELL -c "$expect; unset _push_stack; typeset -pa")
+[[ "$expect" == "$actual" ]] || 
+    log_error 'typeset -pa does not list only index arrays' "$expect" "$actual"
+
+expect='typeset -C z=(foo=bar)'
+actual=$($SHELL -c "$expect; typeset -pC")
+[[ "$expect" == "$actual" ]] ||
+    log_error 'typeset -pC does not list only compound variables' "$expect" "$actual"
+
+expect='typeset -A y=([a]=foo)'
+actual=$($SHELL -c "$expect; typeset -pA");
+[[ "$expect" == "$actual" ]] ||
+    log_error 'typeset -pA does not list only associative arrays' "$expect" "$actual"
 
 $SHELL -c 'typeset -C arr=( aa bb cc dd )' &&
     log_error 'invalid compound variable assignment not reported'


### PR DESCRIPTION
User Andras Farkas <deepbluemistake@gmail.com> brought this issue to our
attention via a message on the ksh mailing list. There are two problems.
First, autoloaded functions `cd` and `mcd` aren't available until the
user uses the `dirs` command. So put each function definition in its own
autoloaded file. Second, the `_cd` function behaves incorrectly if you
invoke it with no arguments.

I'm ambivalent about the `_cd` behavior of always printing the selected
directory on stdout. Personally I think that is just noise. If the user
wants to be reminded what the CWD is they can put it in their prompt.
But I'm keeping that behavior for the moment to see how others feel and
because that is what the legacy implementation does which implies some
people think the behavior is useful.