### PR TITLE
Fix for test failures when home directory is not available

### DIFF
--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -476,14 +476,15 @@ $SHELL <<- \EOF
     cd
     [[ $(pwd) == "$home" ]]
 EOF
-ret=$?
-if [[ ! -d ~$USER ]]
+if [[ $? != 0 ]]
 then
-    log_warning "skipping test of cd with no arguments if home directory does not exist"
-else
-    [[ $ret == 0 ]] || log_error 'cd with no arguments fails if HOME is unset'
+    if [[ -d ~$USER ]]
+    then
+        log_error 'cd with no arguments fails if HOME is unset'
+    else
+        log_warning "ignoring test of cd with no arguments if home directory does not exist"
+    fi
 fi
-unset ret
 
 cd "$TEST_DIR"
 if mkdir -p f1

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -476,15 +476,14 @@ $SHELL <<- \EOF
     cd
     [[ $(pwd) == "$home" ]]
 EOF
-if [[ $? != 0 ]]
+ret=$?
+if [[ ! -d ~$USER ]]
 then
-    if [[ ! -d $home ]]
-    then
-        log_warning "home directory does not exist"
-    else
-        log_error 'cd with no arguments fails if HOME is unset'
-    fi
+    log_warning "skipping test of cd with no arguments if home directory does not exist"
+else
+    [[ $ret == 0 ]] || log_error 'cd with no arguments fails if HOME is unset'
 fi
+unset ret
 
 cd "$TEST_DIR"
 if mkdir -p f1
@@ -504,10 +503,10 @@ fi
 # Regression test for https://github.com/att/ast/issues/1391
 expect="$(print ~$(id -un))"
 actual=$(unset HOME; $SHELL -c 'cd /; cd ~; pwd')
-# If the home directory for the user doesn't exist, then print a warning
+# If the home directory for the user doesn't exist, then skip test
 if [[ ! -d $expect ]]
 then
-    log_warning "home directory does not exist: $expect"
+    log_warning "skipping test of bare ~ expansion when home directory does not exist: $expect"
 else
     [[ $actual == $expect ]] || log_error "bare ~ expansion with unset HOME" "$expect" "$actual"
 fi

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -476,7 +476,15 @@ $SHELL <<- \EOF
     cd
     [[ $(pwd) == "$home" ]]
 EOF
-[[ $? == 0 ]] || log_error 'cd with no arguments fails if HOME is unset'
+if [[ $? != 0 ]]
+then
+    if [[ ! -d $home ]]
+    then
+        log_warning "home directory does not exist"
+    else
+        log_error 'cd with no arguments fails if HOME is unset'
+    fi
+fi
 
 cd "$TEST_DIR"
 if mkdir -p f1
@@ -496,7 +504,13 @@ fi
 # Regression test for https://github.com/att/ast/issues/1391
 expect="$(print ~$(id -un))"
 actual=$(unset HOME; $SHELL -c 'cd /; cd ~; pwd')
-[[ $actual == $expect ]] || log_error "bare ~ expansion with unset HOME" "$expect" "$actual"
+# If the home directory for the user doesn't exist, then print a warning
+if [[ ! -d $expect ]]
+then
+    log_warning "home directory does not exist: $expect"
+else
+    [[ $actual == $expect ]] || log_error "bare ~ expansion with unset HOME" "$expect" "$actual"
+fi
 
 # =======
 TESTDIRSYMLINK="$TEST_DIR/testdirsymlink"


### PR DESCRIPTION
I've noticed that in some build environments (such as the Debian CI CD infra) that uses docker, the home directory is not available, and so some tests fail. I've been able to recreate this locally when using chroot-based environments for validating Debian package builds. In such cases 'cd' throws an error as there's no home directory to cd to, however, I think this is the desired behavior, so I've added a check for this in the tests to stop the tests from failing in those cases and show a warning. Please review this approach and see if this makes sense or if you see any issues with this. I've tested this on Linux with and without a valid home directory and tests pass. Thanks.