### PR TITLE
Fix functionality of printf %H

### DIFF
--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -431,12 +431,11 @@ static_fn char *fmthtml(Shell_t *shp, const char *string, int flags) {
                 sfputr(shp->stk, "&amp", ';');
             } else if (c == '"') {
                 sfputr(shp->stk, "&quot", ';');
+            /* Add this back when an XML-oriented output flag is added. */
+            /*
             } else if (c == '\'') {
                 sfputr(shp->stk, "&apos", ';');
-            } else if (c == ' ') {
-                sfputr(shp->stk, "&nbsp", ';');
-            } else if (!isprint(c) && c != '\n' && c != '\r') {
-                sfprintf(shp->stk, "&#%X;", c);
+            */
             } else {
                 sfputc(shp->stk, c);
             }

--- a/src/cmd/ksh93/tests/b_printf.sh
+++ b/src/cmd/ksh93/tests/b_printf.sh
@@ -42,7 +42,7 @@ unset foo
 # %H     A %H format can be used instead of %s to cause characters in arg that are special in HTML
 #        and XML to be output as their entity name.  The alternate flag # formats the output for
 #        use as a URI.
-if [[ $(printf '%H\n' $'<>"& \'\tabc') != '&lt;&gt;&quot;&amp;&nbsp;&apos;&#9;abc' ]]
+if [[ $(printf '%H\n' '<>"&abc') != '&lt;&gt;&quot;&amp;abc' ]]
 then
     log_error 'printf %H not working'
 fi
@@ -136,7 +136,7 @@ printf "%Z" | od | head -n1 | grep -q "000000 *$" || log_error "printf %Z does n
 
 #     %(html)q
 #           Equivalent to %H.
-if [[ $(printf '%(html)q\n' $'<>"& \'\tabc') != '&lt;&gt;&quot;&amp;&nbsp;&apos;&#9;abc' ]]
+if [[ $(printf '%(html)q\n' '<>"&abc') != '&lt;&gt;&quot;&amp;abc' ]]
 then
     log_error 'printf %(html)q not working'
 fi


### PR DESCRIPTION
The man page says %H is meant to produce text valid for use in both HTML and XML.  The current behavior is both invalid for HTML and invalid for XML. &nbsp; is invalid in XML.  &apos; is invalid in HTML (not including HTML5)
Thus, I eliminate the invalid entities here, making it so that the output of printf %H is valid in both HTML and XML. This is backwards-incompatible as for ksh, but it has to be, since it was implemented wrong to begin with.  Fortunately, this doesn't affect compatibility with POSIX printf. ;D

%#H is already in use for making valid URIs...  So I don't know what to do to make a %something which will also include &apos; for XML.  What flag could we use for printf to print in a more XML-oriented way? i.e. to be the same as this functionality post-diff, but with &apos; added back.

I've tested the behavior of ksh itself, but haven't tested the tests.  Please test the tests for me.