### PR TITLE
Add instructions for installing with MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,17 @@ that ship packages for current development version.
 TBD
 
 ### macOS
-TBD
+Using [MacPorts](https://www.macports.org), the latest stable version can be installed using:
+
+```
+sudo port install ksh
+```
+
+Alternately, a development version can be installed using:
+
+```
+sudo port install ksh-devel
+```
 
 
 ## Contributing changes to the source code


### PR DESCRIPTION
This updates the readme to add instructions for installing KornShell with MacPorts. (I'm the maintainer of ksh in MacPorts, and I just updated it to the latest versions.) Feel free to reword it if needed.