### PR TITLE
Fix handling of skipped directories

### DIFF
--- a/src/cmd/ksh93/tests/autoload.sh
+++ b/src/cmd/ksh93/tests/autoload.sh
@@ -1,0 +1,15 @@
+# Verify the behavior of autoloaded functions.
+
+# ====================
+# Verify that directories in the path search list which should be skipped (e.g., because they don't
+# exist) interacts correctly with autoloaded functions.
+#
+# See https://github.com/att/ast/issues/1454
+expect=$"Func cd called with |$TEST_DIR/usr|\n$TEST_DIR/usr"
+actual=$($SHELL "$TEST_ROOT/data/skipped_dir")
+actual_status=$?
+expect_status=0
+[[ $actual_status == $expect_status ]] ||
+    log_error "autoload function skipped dir test wrong status" "$expect_status" "$actual_status"
+[[ $actual == $expect ]] ||
+    log_error "autoload function skipped dir test wrong output" "$expect" "$actual"

--- a/src/cmd/ksh93/tests/data/skipped_dir
+++ b/src/cmd/ksh93/tests/data/skipped_dir
@@ -1,0 +1,15 @@
+# See https://github.com/att/ast/issues/1454
+
+mkdir -p "$TEST_DIR/usr/bin"
+print '#!/bin/sh' >"$TEST_DIR/usr/bin/cd"
+print 'builtin cd "$@"' >>"$TEST_DIR/usr/bin/cd"
+prefix="$TEST_DIR/ksh.$$"
+
+FPATH="$prefix/bad:$prefix/functions"
+mkdir -p "$prefix/functions"
+print 'function cd { echo "Func cd called with |$*|"; command cd "$@"; }' >"$prefix/functions/cd"
+typeset -fu cd
+
+PATH="/arglebargle:$PATH:$TEST_DIR/usr/bin:$TEST_DIR/bin"
+cd "$TEST_DIR/usr"
+pwd

--- a/src/cmd/ksh93/tests/meson.build
+++ b/src/cmd/ksh93/tests/meson.build
@@ -53,6 +53,7 @@ all_tests = [
     ['arrays.sh'],
     ['arrays2.sh'],
     ['attributes.sh'],
+    ['autoload.sh'],
     ['basic.sh', 90],
     ['bracket.sh'],
     ['builtins.sh'],


### PR DESCRIPTION
The bug in `path_opentype()` fixed by this commit may affect other
scenarios but we know it affects autoloaded functions. Hence the unit
test for that scenario.

Fixes #1454