### PR TITLE
Change default build type to "minsize"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,9 @@
-project('ksh93', 'c', default_options: [
+project('ksh9', 'c', default_options: [
+    # This is the optimal production build type for this project. If you need
+    # a debug build you must explicitly run `meson --buildtype=debug`. This
+    # helps ensure that each distro (or user) gets a performance optimized build
+    # even if they don't know to add the `--buildtype=minsize` option.
+    'buildtype=minsize',
     'b_lundef=false',
     'default_library=static',
     'c_std=c99', # we require the C99 (aka ISO9899:1999) language standard

--- a/scripts/build-on-docker.sh
+++ b/scripts/build-on-docker.sh
@@ -18,7 +18,8 @@ mkdir build
 cd build
 
 echo ==== Configuring the build
-if ! meson -Dwarnings-are-errors=true --prefix="$(mktemp -dt ksh.XXXXXX)"
+if ! meson -Dwarnings-are-errors=true --prefix="$(mktemp -dt ksh.XXXXXX)" \
+    --buildtype=debug
 then
     cat meson-logs/meson-log.txt
     exit 1

--- a/scripts/build-on-macos.sh
+++ b/scripts/build-on-macos.sh
@@ -15,7 +15,8 @@ mkdir build
 cd build
 
 echo ==== Configuring the build
-if ! meson -Dwarnings-are-errors=true --prefix="$(mktemp -dt ksh.XXXXXX)"
+if ! meson -Dwarnings-are-errors=true --prefix="$(mktemp -dt ksh.XXXXXX)" \
+    --buildtype=debug
 then
     cat meson-logs/meson-log.txt
     exit 1


### PR DESCRIPTION
People (and distros) have been building ksh from this project using the
default "debug" build type since we switched from Nmake to Meson. That
results in a ksh program whose performance is far from optimal. So change
the default build type. If a debugging enabled binary is needed, such as
in a CI environment, it must be requested explicitly.

Related #1449