### PR TITLE
Several fixes to enable AST/KSH to build on several systems

### DIFF
--- a/bin/execrate
+++ b/bin/execrate
@@ -1,3 +1,4 @@
+USAGE_LICENSE="[-author?Glenn Fowler <gsf@research.att.com>][-copyright?Copyright (c) 2002-2020 AT&T Intellectual Property][-license?http://www.eclipse.org/org/documents/epl-v10.html]"
 ########################################################################
 #                                                                      #
 #               This software is part of the ast package               #

--- a/bin/ignore
+++ b/bin/ignore
@@ -1,3 +1,22 @@
+########################################################################
+#                                                                      #
+#               This software is part of the ast package               #
+#          Copyright (c) 1994-2011 AT&T Intellectual Property          #
+#                      and is licensed under the                       #
+#                 Eclipse Public License, Version 1.0                  #
+#                    by AT&T Intellectual Property                     #
+#                                                                      #
+#                A copy of the License is available at                 #
+#          http://www.eclipse.org/org/documents/epl-v10.html           #
+#         (with md5 checksum b35adb5213ca9657e911e9befb180842)         #
+#                                                                      #
+#              Information and Software Systems Research               #
+#                            AT&T Research                             #
+#                           Florham Park NJ                            #
+#                                                                      #
+#                 Glenn Fowler <gsf@research.att.com>                  #
+#                                                                      #
+########################################################################
 # non-ksh script for the nmake ignore prefix
 # @(#)ignore (AT&T Research) 1992-08-11
 

--- a/bin/mamprobe
+++ b/bin/mamprobe
@@ -1,3 +1,22 @@
+########################################################################
+#                                                                      #
+#               This software is part of the ast package               #
+#          Copyright (c) 1994-2011 AT&T Intellectual Property          #
+#                      and is licensed under the                       #
+#                 Eclipse Public License, Version 1.0                  #
+#                    by AT&T Intellectual Property                     #
+#                                                                      #
+#                A copy of the License is available at                 #
+#          http://www.eclipse.org/org/documents/epl-v10.html           #
+#         (with md5 checksum b35adb5213ca9657e911e9befb180842)         #
+#                                                                      #
+#              Information and Software Systems Research               #
+#                            AT&T Research                             #
+#                           Florham Park NJ                            #
+#                                                                      #
+#                 Glenn Fowler <gsf@research.att.com>                  #
+#                                                                      #
+########################################################################
 ### this script contains archaic constructs that work with all sh variants ###
 # mamprobe - generate MAM cc probe info
 # Glenn Fowler <gsf@research.att.com>

--- a/bin/package
+++ b/bin/package
@@ -1,4 +1,23 @@
-USAGE_LICENSE="[-author?Glenn Fowler <gsf@research.att.com>][-copyright?Copyright (c) 1994-2012 AT&T Intellectual Property][-license?http://www.eclipse.org/org/documents/epl-v10.html]"
+USAGE_LICENSE="[-author?Glenn Fowler <gsf@research.att.com>][-copyright?Copyright (c) 1994-2020 AT&T Intellectual Property][-license?http://www.eclipse.org/org/documents/epl-v10.html]"
+########################################################################
+#                                                                      #
+#               This software is part of the ast package               #
+#          Copyright (c) 1994-2012 AT&T Intellectual Property          #
+#                      and is licensed under the                       #
+#                 Eclipse Public License, Version 1.0                  #
+#                    by AT&T Intellectual Property                     #
+#                                                                      #
+#                A copy of the License is available at                 #
+#          http://www.eclipse.org/org/documents/epl-v10.html           #
+#         (with md5 checksum b35adb5213ca9657e911e9befb180842)         #
+#                                                                      #
+#              Information and Software Systems Research               #
+#                            AT&T Research                             #
+#                           Florham Park NJ                            #
+#                                                                      #
+#                 Glenn Fowler <gsf@research.att.com>                  #
+#                                                                      #
+########################################################################
 ### this script contains archaic constructs that work with all sh variants ###
 # package - source and binary package control
 # Glenn Fowler <gsf@research.att.com>
@@ -5576,6 +5595,18 @@ make|view)
 	do	s=$INITROOT/$c.$t
 		test -x "$s" || continue
 		onpath $c ||
+		case `ls -t "$b" "$s" 2>/dev/null` in
+		$b*)	;;
+		$s*)	$exec cp "$s" "$b"
+			note update $b
+			;;
+		esac
+	done
+	c=ar
+	b=$INSTALLROOT/bin/$c
+	for t in $h
+	do	s=$INITROOT/$c.$t
+		test -x "$s" || continue
 		case `ls -t "$b" "$s" 2>/dev/null` in
 		$b*)	;;
 		$s*)	$exec cp "$s" "$b"

--- a/bin/silent
+++ b/bin/silent
@@ -1,3 +1,22 @@
+########################################################################
+#                                                                      #
+#               This software is part of the ast package               #
+#          Copyright (c) 1994-2011 AT&T Intellectual Property          #
+#                      and is licensed under the                       #
+#                 Eclipse Public License, Version 1.0                  #
+#                    by AT&T Intellectual Property                     #
+#                                                                      #
+#                A copy of the License is available at                 #
+#          http://www.eclipse.org/org/documents/epl-v10.html           #
+#         (with md5 checksum b35adb5213ca9657e911e9befb180842)         #
+#                                                                      #
+#              Information and Software Systems Research               #
+#                            AT&T Research                             #
+#                           Florham Park NJ                            #
+#                                                                      #
+#                 Glenn Fowler <gsf@research.att.com>                  #
+#                                                                      #
+########################################################################
 # non-ksh stub for the nmake silent prefix
 # @(#)silent (AT&T Research) 1992-08-11
 

--- a/lib/package/CONVERT.mk
+++ b/lib/package/CONVERT.mk
@@ -1,0 +1,260 @@
+/*
+ * {automake|configure} => {nmake|iffe} conversion support
+ *
+ * The first command line target overrides the default original source
+ * directory name $(MAKEFILE:D). The hard work is in the makefile using
+ * these assertions, since it must (manually) provide the nmake makefiles
+ * and config equivalent iffe scripts. The conversion makefile is typically
+ * named lib/package/PACKAGE.cvt in an ast package $PACKAGEROOT directory,
+ * and the conversion is run from the $PACKAGEROOT directory, e.g.:
+ *
+ *	nmake -I lib/package -f PACKAGE-VERSION/PACKAGE.cvt
+ *
+ * The conversion requires the ast nmake, pax and tw commands.
+ *
+ * After the conversion you will be liberated from ./configure, *.in,
+ * *.am, automake, autom4te, libtool, make depend, and makefile
+ * recursion ordering. You can build from $PACKAGEROOT using the ast
+ * package(1) (which sets up the { HOSTTYPE PATH VPATH } environment):
+ *
+ *	package make
+ *
+ * or cd into any arch/$HOSTTYPE/src subdirectory and rebuild that portion
+ * of the hierarchy with the ast nmake(1) (after setting PATH and VPATH):
+ *
+ *	nmake
+ *
+ * The conversion assertions are:
+ *
+ *	package :CONVERT: file ...
+ *
+ *	    files in the original source directory are copied
+ *	    and converted into the ./src and ./lib subdirectories 
+ *	    the default original source directory is ./original
+ *
+ *		package	package name
+ *		file	original source file that must exist
+ *
+ *	:OMIT: pattern
+ *
+ *	    files matching pattern are not copied into the converted
+ *	    directory
+ *
+ *		pattern	ksh pattern of files to omit
+ *
+ *	:COPY: from to [ file ... ]
+ *
+ *	    files in the from directory are copied to the to directory
+ *	    the action may contain :MOVE: exceptions to the copy
+ *
+ *		from	original directory subdirectory
+ *			  . names the original directory
+ *			 .. names the 
+ *		to	converted subdirectory
+ *			  libNAME => src/lib/libNAME
+ *			     NAME => src/cmd/NAME
+ *		file	files or files in subdirectories to be copied;
+ *			explicit files are copied to the to directory;
+ *			if no files are specified then the from hierarchy
+ *			is recursively copied to the converted directory
+ *
+ *	:MOVE: to file ...
+ *
+ *	    :COPY: assertion exceptions placed in the assertion's action
+ *
+ *		to	files or subdirectory files are copied to this directory
+ *		file	file or files in subdirectories to be copied
+ *
+ *	:FILE: to file <<!
+ *	contents
+ *	!
+ *
+ *	    the :FILE: action is copied to the named file in the to directory
+ *	    the :FILE: action is usually specified using the here syntax to
+ *	    avoid make comment, quote and variable expansion
+ *
+ *	:EDIT: to file ... | - pattern <<!
+ *	edit script
+ *	!
+ *
+ *	    the :EDIT: action is an ed(1) script applied to each file in the
+ *	    to directory after it has been copied from the original source
+ *	    directory; if to is - then the :EDIT: action is a sed(1) script
+ *	    that is applied to all files matching the file pattern during the
+ *	    copy from the original source directory; a file may be subject to
+ *	    both a sed(1) and ed(1) :EDIT:; the :EDIT: action is usually
+ *	    specified using the here syntax to avoid make comment, quote and
+ *	    variable expansion
+ */
+
+.CONVERT.ID. = "@(#)$Id: CONVERT (AT&T Research) 2004-03-19 $"
+
+set nojobs noscan nowriteobject writestate=$$(MAKEFILE).ms
+
+package = $(PWD:B)
+here = !-=-=-=-=-!
+hierarchy = src src/cmd src/lib
+omit = .*|*.?(l)[ao]
+original = $(MAKEFILE:D)
+showedit = $(-debug:?p??)
+
+CPFLAGS = -u
+PAXFLAGS = -u -v
+STDEDFLAGS = -
+TW = tw
+TWFLAGS = -CP
+
+all  : .VIRTUAL file
+file : .VIRTUAL edit
+edit : .VIRTUAL copy
+copy : .VIRTUAL init
+init : .VIRTUAL
+
+.MAKEINIT : .cvt.init
+
+.cvt.init : .MAKE .VIRTUAL .FORCE
+	local D
+	if D = "$(~.ARGS:O=1)"
+		if "$(D:T>FD)"
+			original := $(D)
+			.ARGS : .CLEAR $(~.ARGS:O>1)
+		end
+	end
+
+.cvt.filter =
+.cvt.package =
+
+.cvt.atom : .FUNCTION
+	local N V
+	V := $(%:O=1)
+	let .cvt.$(V) = .cvt.$(V) + 1
+	return .cvt.$(V).$(.cvt.$(V))
+
+.cvt.omit : .FUNCTION
+	return -s',^\(\(?K)?(*/)($(omit))?(/*))$,,$(showedit)'
+
+.cvt.to : .FUNCTION
+	if "$(%)" == "."
+		return src
+	end
+	if "$(%)" == "*/*"
+		return src/$(%)
+	end
+	if "$(%)" == "lib*"
+		return src/lib/$(%)
+	end
+	return src/cmd/$(%)
+
+":CONVERT:" : .MAKE .OPERATOR
+	local I
+	package := $(<)
+	I := $(hierarchy:C,$,/Makefile)
+	init : .cvt.verify $(I)
+	$(I) : .ACCEPT
+		test -d $(<:D) || $(MKDIR) -p $(<:D)
+		echo :MAKE: > $(<)
+	.cvt.verify : .MAKE .FORCE .REPEAT
+		local I
+		if I = "$(.cvt.package:T!=F)"
+			error 3 $(original): not a $(package) source directory: missing $(I)
+		end
+	.cvt.package := $(>:C,^,$$(original)/,)
+
+":COPY:" : .MAKE .OPERATOR
+	local F T I A
+	F := $(>:O=1)
+	T := $(.cvt.to $(>:O=2))
+	A := $(.cvt.atom copy)
+	copy : $(A)
+	$(A) : .VIRTUAL
+	if F == "."
+		$(A) : $(T)
+		$(T) :
+			test -d $(<) || $(MKDIR) -p $(<)
+		for I $(>:O>2)
+			eval
+			$$(A) : $(I:D=$(T):B:S)
+			$(I:D=$(T):B:S) : $$(original)/$(I)
+				$$(CP) $$(CPFLAGS) $$(*) $$(<)
+			end
+		end
+	elif "$(F:T=FF)" || "$(F:N=*.(pax|t[bg]z))"
+		eval
+		$$(A) : $$(F)
+			test -d $(T) || $$(MKDIR) -p $(T)
+			cd $(T)
+			$$(PAX) $$(PAXFLAGS) -rf $$(*:P=A) -s ',^$(>:O=2)/*,,' $(.cvt.omit) $(.cvt.filter)
+		end
+	else
+		F := $$(original)/$(F)
+		if ! "$(@:V)"
+			eval
+			$$(A) : .FORCE
+				test -d $(T) || $$(MKDIR) -p $(T)
+				cd $(F:V)
+				$$(TW) $$(TWFLAGS) | $$(PAX) $$(PAXFLAGS) -rw $(.cvt.omit) $(.cvt.filter) $(T:P=A)
+			end
+		else
+			.cvt.move =
+			: $(@:V:@R)
+			eval
+			$$(A) : .FORCE
+				test -d $(T) || $$(MKDIR) -p $(T)
+				cd $(F:V)
+				$$(TW) $$(TWFLAGS) | $$(PAX) $$(PAXFLAGS) -rw $(.cvt.omit) $(.cvt.move) $(.cvt.filter) $(T:P=A)
+			end
+		end
+	end
+
+":EDIT:" : .MAKE .OPERATOR
+	local A D F
+	D := $(>:O=1)
+	if D == "-"
+		A := ^$(>:O=2)^$$(SED) -e $(@:Q:/'\n'/ -e /G)
+		.cvt.filter += --action=$(A:@Q)
+	else
+		D := $(.cvt.to $(D))
+		F := $(>:O>1:C,^,$(D)/,)
+		edit : $(F)
+		eval
+		$$(F) :
+			$$(STDED) $$(STDEDFLAGS) $$(<) <<'$(here)'
+			$(@:V)
+			w
+			q
+			$(here)
+		end
+	end
+
+":FILE:" : .MAKE .OPERATOR
+	local ( D F ) $(>)
+	local A
+	A := $(.cvt.atom file)
+	$(A) := $(@:V)
+	D := $(.cvt.to $(D))
+	file : $(D)/$(F)
+	eval
+	$$(D)/$$(F) :
+		test -d $$(<:D) || $$(MKDIR) -p $$(<:D)
+		cat > $$(<) <<'$(here)'
+		$$($(A):V)
+		$(here)
+	end
+
+":MOVE:" : .MAKE .OPERATOR
+	local T I
+	T := ../../../$(.cvt.to $(>:O=1))
+	for I $(>:O>1)
+		if I == "*/"
+			.cvt.move += -s',^\(\(?K)$(I)),$(T)/,$(showedit)'
+			.cvt.move += -s',^\(\(?K)$(I:C%/$%%))$,,$(showedit)'
+		else
+			.cvt.move += -s',^\(\(?K)$(I))$,$(T)/$(I:B:S),$(showedit)'
+		end
+	end
+
+":OMIT:" : .MAKE .OPERATOR
+	local P
+	for P $(>)
+		omit := $(omit)|$(P)
+	end

--- a/src/cmd/3d/Makefile
+++ b/src/cmd/3d/Makefile
@@ -1,3 +1,4 @@
+if CC.HOSTTYPE == "no_build"
 /*
  * 3d fs library
  *
@@ -101,3 +102,9 @@ terminal FEATURE/eaccess FEATURE/hack
 	$(BINDIR)/3d $(SHELL) $(REGRESS) $(REGRESSFLAGS) $(*)
 
 :: sys.tab
+
+else
+
+:NOTHING:
+
+end

--- a/src/cmd/INIT/ar.linux.i386-64
+++ b/src/cmd/INIT/ar.linux.i386-64
@@ -1,0 +1,6 @@
+: stupid stupid stupid to require a non-standard option for ar to work : 2009-10-06 :
+
+case $1 in
+*x*) /usr/bin/ar "$@" ;;
+*)   /usr/bin/ar U"$@" ;;
+esac

--- a/src/cmd/INIT/cc.linux.aarch64
+++ b/src/cmd/INIT/cc.linux.aarch64
@@ -1,0 +1,9 @@
+: linux.aarch64 cc wrapper : 2006-02-14 :
+
+HOSTTYPE=linux.aarch64
+
+case " $* " in
+*" -dumpmachine "*) echo $HOSTTYPE; exit ;;
+esac
+
+/usr/bin/cc -P "$@"

--- a/src/cmd/INIT/cc.linux.i386-64
+++ b/src/cmd/INIT/cc.linux.i386-64
@@ -1,0 +1,9 @@
+: linux.i386-64 cc wrapper : 2006-02-14 :
+
+HOSTTYPE=linux.i386-64
+
+case " $* " in
+*" -dumpmachine "*) echo $HOSTTYPE; exit ;;
+esac
+
+/usr/bin/cc -P "$@"

--- a/src/cmd/INIT/make.probe
+++ b/src/cmd/INIT/make.probe
@@ -40,6 +40,12 @@ probe_no_protect="'-fno-stack-protector -fno-stack-protector-all' -GS-"
 probe_readonly="-R -Krodata -xMerge -Wa,-r"
 probe_shared="'' -G -b -c -shared -Wl,dll"
 probe_shared_name="-Wl,-soname= -h"
+probe_shared_nostart="-nostartfiles"
+case `gcc -v 2>&1 | egrep gcc.version` in
+*version' '7*) probe_shared_nostart= ;;
+*version' '8*) probe_shared_nostart= ;;
+*version' '9*) probe_shared_nostart= ;;
+esac
 probe_shared_registry='"-update_registry $probe_shared_registry_file"'
 probe_shared_registry_file='registry.ld'
 probe_shared_registry_path="\$(LIBDIR)/$probe_shared_registry_file"
@@ -708,6 +714,37 @@ case $cc_dll:$cc_pic:$so:$dynamic:$static in
 		esac
 		dld=$xx
 		shared=$1
+		# does -nostartfiles make sense for C?
+		case $plusplus in
+		'')	z=`wc -c < xxx$dll`
+			eval set x $probe_shared_nostart
+			while	:
+			do	shift
+				case $# in
+				0)	break ;;
+				esac
+				rm -f xxx$dll
+				if	$dld $shared $1 -o xxx$dll shared.$obj 2>e && test -r xxx$dll
+				then	case `wc -c < xxx$dll` in
+					$z)	;;
+					*)	if	test -s e
+						then	case `cat e` in
+							*[Ee][Rr][Rr][Oo][Rr]*|*[Ww][Aa][Rr][Nn][Ii][Nn][Gg]*|*[Oo][Pp][Tt][Ii][Oo][Nn]*)
+								continue
+								;;
+							esac
+						fi
+						case $shared in
+						'')	shared=$1 ;;
+						*)	shared="$shared $1" ;;
+						esac
+						break
+						;;
+					esac
+				fi
+			done
+			;;
+		esac
 		case $cc_dll in
 		"")	cc_dll=$cc_dll_def ;;
 		esac

--- a/src/cmd/INIT/package.sh
+++ b/src/cmd/INIT/package.sh
@@ -5601,6 +5601,18 @@ make|view)
 			;;
 		esac
 	done
+	c=ar
+	b=$INSTALLROOT/bin/$c
+	for t in $h
+	do	s=$INITROOT/$c.$t
+		test -x "$s" || continue
+		case `ls -t "$b" "$s" 2>/dev/null` in
+		$b*)	;;
+		$s*)	$exec cp "$s" "$b"
+			note update $b
+			;;
+		esac
+	done
 # following code stubbed out just in case ar.ibm.risc is needed
 #	c=ar
 #	b=$INSTALLROOT/bin/$c

--- a/src/cmd/builtin/builtin.c
+++ b/src/cmd/builtin/builtin.c
@@ -25,3 +25,8 @@
  */
 
 #include <cmd.h>
+
+// @lkoutsofios added to prevent this file from being optimized out
+int _do_not_opt_out (void) {
+    sfprintf (sfstderr, "unreachable");
+}

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -1007,7 +1007,7 @@ static int escape(register Emacs_t* ep,register genchar *out,int count)
 			else if(i=='=' || (i=='\\' && out[cur-1]=='/'))
 			{
 				draw(ep,REFRESH);
-				if(count>0)
+				if(count>0 || i=='\\')
 					ep->ed->e_tabcount=0;
 				else
 				{

--- a/src/lib/libast/comp/realpath.c
+++ b/src/lib/libast/comp/realpath.c
@@ -44,5 +44,10 @@ extern int		resolvepath(const char*, char*, size_t);
 extern char*
 realpath(const char* file, char* path)
 {
+	// @lkoutsofios path may be NULL
+	if (!path) {
+	    	if (!(path = malloc (PATH_MAX)))
+        		return NULL;
+	}
 	return resolvepath(file, path, PATH_MAX) > 0 ? path : (char*)0;
 }

--- a/src/lib/libast/features/stdio
+++ b/src/lib/libast/features/stdio
@@ -6,8 +6,6 @@ cat{
 	#define _FILE_DEFINED	1
 	#define _FILE_defined	1
 	#define _FILEDEFED	1
-	#define __FILE_defined  1
-	#define ____FILE_defined    1
 
 	#ifndef __FILE_TAG
 	#define __FILE_TAG	_sfio_s

--- a/src/lib/libast/features/vmalloc
+++ b/src/lib/libast/features/vmalloc
@@ -191,7 +191,7 @@ tst	malloc_hook note{ gnu malloc hooks work }end execute{
 	        __realloc_hook = test_realloc_hook;
 	}
 
-	void    (*__malloc_initialize_hook)(void) = test_initialize_hook;
+	typeof (__malloc_initialize_hook) __malloc_initialize_hook = test_initialize_hook;
 
 	int main()
 	{

--- a/src/lib/libast/include/ast.h
+++ b/src/lib/libast/include/ast.h
@@ -58,20 +58,8 @@ struct _sfio_s;
 #ifndef	__FILE_typedef
 #define __FILE_typedef	1
 #endif
-#ifndef	_FILE_DEFINED
-#define _FILE_DEFINED   1
-#endif
-#ifndef	_FILE_defined
-#define _FILE_defined   1
-#endif
 #ifndef _FILEDEFED
 #define _FILEDEFED	1
-#endif
-#ifndef __FILE_defined
-#define __FILE_defined  1
-#endif
-#ifndef ____FILE_defined
-#define ____FILE_defined  1
 #endif
 #endif
 

--- a/src/lib/libast/include/ast_std.h
+++ b/src/lib/libast/include/ast_std.h
@@ -76,6 +76,25 @@ struct _sfio_s;
 #undef	FILE
 #endif
 
+#ifndef FILE
+#ifndef _SFIO_H
+struct _sfio_s;
+#endif
+#define FILE            struct _sfio_s
+#ifndef __FILE_typedef
+#define __FILE_typedef  1
+#endif
+#ifndef _FILEDEFED
+#define _FILEDEFED      1
+#endif
+#ifndef ____FILE_defined
+#define ____FILE_defined 1
+#endif
+#ifndef __FILE_defined
+#define __FILE_defined 1
+#endif
+#endif
+
 /* locale stuff */
 
 #if !_hdr_locale

--- a/src/lib/libast/sfio/sfflsbuf.c
+++ b/src/lib/libast/sfio/sfflsbuf.c
@@ -96,7 +96,7 @@ int	c;	/* if c>=0, c is also written out */
 		isall = SFISALL(f,isall);
 		if((w = SFWR(f,data,n,f->disc)) > 0)
 		{	if((n -= w) > 0) /* save unwritten data, then resume */
-				memcpy((char*)f->data,(char*)data+w,n);
+				memmove((char*)f->data,(char*)data+w,n);
 			written += w;
 			f->next = f->data+n;
 			if(c < 0 && (!isall || n == 0))

--- a/src/lib/libast/sfio/sfmove.c
+++ b/src/lib/libast/sfio/sfmove.c
@@ -190,7 +190,7 @@ reg int		rc;	/* record separator */
 		{	/* move left-over to read stream */
 			if(w > fr->size)
 				w = fr->size;
-			memcpy((Void_t*)fr->data,(Void_t*)cp,w);
+			memmove((Void_t*)fr->data,(Void_t*)cp,w);
 			fr->endb = fr->data+w;
 			if((w = endb - (cp+w)) > 0)
 				(void)SFSK(fr,(Sfoff_t)(-w),SEEK_CUR,fr->disc);
@@ -200,7 +200,7 @@ reg int		rc;	/* record separator */
 		{	if(direct == SF_WRITE)
 				fw->next += r;
 			else if(r <= (fw->endb-fw->next) )
-			{	memcpy((Void_t*)fw->next,(Void_t*)next,r);
+			{	memmove((Void_t*)fw->next,(Void_t*)next,r);
 				fw->next += r;
 			}
 			else if((w = SFWRITE(fw,(Void_t*)next,r)) != r)

--- a/src/lib/libast/sfio/sfpool.c
+++ b/src/lib/libast/sfio/sfpool.c
@@ -138,7 +138,7 @@ int		n;	/* current position in pool	*/
 			else	/* write failed, recover buffer then quit */
 			{	if(w > 0)
 				{	v -= w;
-					memcpy(head->data,(head->data+w),v);
+					memmove(head->data,(head->data+w),v);
 				}
 				head->next = head->data+v;
 				goto done;
@@ -147,7 +147,7 @@ int		n;	/* current position in pool	*/
 
 		/* move data from head to f */
 		if((head->data+k) != f->data )
-			memcpy(f->data,(head->data+k),v);
+			memmove(f->data,(head->data+k),v);
 		f->next = f->data+v;
 	}
 

--- a/src/lib/libast/sfio/sfrd.c
+++ b/src/lib/libast/sfio/sfrd.c
@@ -201,7 +201,7 @@ Sfdisc_t*	disc;
 				if(buf)
 				{	if(n > (size_t)(r-a))
 						n = (ssize_t)(r-a);
-					memcpy(buf,f->next,n);
+					memmove(buf,f->next,n);
 					f->next += n;
 				}
 				else	n = f->endb - f->next;

--- a/src/lib/libast/sfio/sfread.c
+++ b/src/lib/libast/sfio/sfread.c
@@ -92,7 +92,7 @@ size_t		n;	/* number of bytes to be read. 	*/
 		{	if(r > (ssize_t)n)
 				r = (ssize_t)n;
 			if(s != f->next)
-				memcpy(s, f->next, r);
+				memmove(s, f->next, r);
 			f->next += r;
 			s += r;
 			n -= r;

--- a/src/lib/libast/sfio/sfvscanf.c
+++ b/src/lib/libast/sfio/sfvscanf.c
@@ -247,7 +247,7 @@ Void_t*		mbs;	/* multibyte parsing state	*/
 	/* shift left data so that there will be more room to back up on error.
 	   this won't help streams with small buffers - c'est la vie! */
 	if(sc->d > sc->f->data && (n = sc->endd - sc->d) > 0 && n < SFMBMAX)
-	{	memcpy(sc->f->data, sc->d, n);
+	{	memmove(sc->f->data, sc->d, n);
 		if(sc->f->endr == sc->f->endb)
 			sc->f->endr = sc->f->data+n;
 		if(sc->f->endw == sc->f->endb)

--- a/src/lib/libast/vmalloc/malloc.c
+++ b/src/lib/libast/vmalloc/malloc.c
@@ -823,7 +823,7 @@ static void vm_initialize_hook(void)
 	__realloc_hook = vm_realloc_hook;
 }
 
-void	(*__malloc_initialize_hook)(void) = vm_initialize_hook;
+typeof (__malloc_initialize_hook) __malloc_initialize_hook = vm_initialize_hook;
 
 #if 0 /* 2012-02-29 this may be needed to cover shared libs */
 

--- a/src/lib/libcmd/tail.c
+++ b/src/lib/libcmd/tail.c
@@ -28,7 +28,7 @@
  */
 
 static const char usage[] =
-"+[-?\n@(#)$Id: tail (AT&T Research) 2012-06-19 $\n]"
+"+[-?\n@(#)$Id: tail (AT&T Research) 2012-10-10 $\n]"
 USAGE_LICENSE
 "[+NAME?tail - output trailing portion of one or more files ]"
 "[+DESCRIPTION?\btail\b copies one or more input files to standard output "
@@ -424,7 +424,7 @@ b_tail(int argc, char** argv, Shbltin_t* context)
 	Tail_t*			files;
 	Tv_t			tv;
 
-	cmdinit(argc, argv, context, ERROR_CATALOG, 0);
+	cmdinit(argc, argv, context, ERROR_CATALOG, ERROR_NOTIFY);
 	for (;;)
 	{
 		switch (n = optget(argv, usage))
@@ -639,7 +639,7 @@ b_tail(int argc, char** argv, Shbltin_t* context)
 		{
 			if (n)
 				n = 0;
-			else if (sh_checksig(context) || tvsleep(&tv, NiL))
+			else if (sh_checksig(context) || tvsleep(&tv, NiL) && sh_checksig(context))
 			{
 				error_info.errors++;
 				break;
@@ -686,11 +686,13 @@ b_tail(int argc, char** argv, Shbltin_t* context)
 					{
 						i = 3;
 						while (--i && stat(fp->name, &st))
-							if (sh_checksig(context) || tvsleep(&tv, NiL))
+							if (sh_checksig(context))
 							{
 								error_info.errors++;
 								goto done;
 							}
+							else
+								tvsleep(&tv, NiL);
 						if (i && (fp->dev != st.st_dev || fp->ino != st.st_ino) && !init(fp, 0, 0, flags, &format))
 						{
 							if (!(flags & SILENT))

--- a/src/lib/libexpr/expr.h
+++ b/src/lib/libexpr/expr.h
@@ -49,6 +49,10 @@
 #include <exparse.h>
 #if defined(YYSTYPE) || defined(yystype)
 #define EXSTYPE		YYSTYPE
+#else
+#if defined(YYSTYPE) || defined(YYSTYPE_IS_DECLARED)
+#define EXSTYPE		YYSTYPE
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
these changes should enable AST/KSH to build on several linux systems,
including Ubuntu 16,18,19 openSuSE 15 and Tumbleweed and Centos 7,8 (maybe 6)

quick build instructions:
- cd to the ast directory
- run: ./bin/package make

this should build without errors, but if you get a Memory Fault
it may be caused by an incompatibility between /bin/ksh and the
KSH plugins. if this happens edit arch/*/bin/.paths and add 'no'
in front of the PLUGIN_LIB line. then run ./bin/package make again.

the initial build should also work using bash:

bash ./bin/package make SHELL=/bin/bash

but I haven't tried it recently.

lkoutsofios
