### PR TITLE
change for gcc v10

### DIFF
--- a/src/cmd/INIT/make.probe
+++ b/src/cmd/INIT/make.probe
@@ -45,6 +45,7 @@ case `gcc -v 2>&1 | egrep gcc.version` in
 *version' '7*) probe_shared_nostart= ;;
 *version' '8*) probe_shared_nostart= ;;
 *version' '9*) probe_shared_nostart= ;;
+*version' '10*) probe_shared_nostart= ;;
 esac
 probe_shared_registry='"-update_registry $probe_shared_registry_file"'
 probe_shared_registry_file='registry.ld'

--- a/src/cmd/std/ps.c
+++ b/src/cmd/std/ps.c
@@ -1223,7 +1223,10 @@ addpid(Pssent_t* pe, register char* s)
 				break;
 			errno = 0;
 			n = strtol(t, &e, 0);
-			if (errno || n <= 0 || n > PID_MAX || *e)
+// deleting check for PID_MAX because on linux this relies on kernel instance
+// and the system will reject bad pids any way
+//			if (errno || n <= 0 || n > PID_MAX || *e)
+			if (errno || n <= 0 || *e)
 			{
 				error(2, "%s: invalid pid", t);
 				continue;

--- a/src/lib/libast/misc/cmdarg.c
+++ b/src/lib/libast/misc/cmdarg.c
@@ -129,6 +129,14 @@ cmdopen_20120411(char** argv, int argmax, int size, const char* argpat, Cmddisc_
 		n += sizeof(char**) + strlen(*p) + 1;
 	if ((x = strtol(astconf("ARG_MAX", NiL, NiL), NiL, 0)) <= 0)
 		x = ARG_MAX;
+
+#ifdef __linux__
+	// adjust for linux, perhaps page alignment is going on
+	// causes problems to tw when selecting many files
+	if (x > getpagesize () * 50)
+		x -= getpagesize ();
+#endif
+
 	if (size <= 0 || size > x)
 		size = x;
 	sh = pathshell();

--- a/src/lib/libast/sfio/sfputr.c
+++ b/src/lib/libast/sfio/sfputr.c
@@ -105,7 +105,9 @@ int		rc;	/* record separator.	*/
 			break;
 		}
 
-#if _lib_memccpy && !__ia64 /* these guys may never get it right */
+//#if _lib_memccpy && !__ia64 /* these guys may never get it right */
+// using memccpy here causes crashes - assuming overlap between src and dst
+#if 0
 		if((ps = (uchar*)memccpy(ps,s,'\0',p)) != NIL(uchar*))
 			ps -= 1;
 		else	ps  = f->next+p;


### PR DESCRIPTION
change to ps.c to remote pid size check
change to sfputr.c to disable use of memccpy
change to cmdarg.c to adjust argument length calc. due to failures in tw