### PR TITLE
Repair support for UnixWare 7.x, preliminary modern Mac OS X support

### DIFF
--- a/src/cmd/ss/Makefile
+++ b/src/cmd/ss/Makefile
@@ -4,7 +4,19 @@ LICENSE = since=1990,author=gsf
 
 ss :: RELEASE ss.c -lcs
 
-$(LIBDIR) :INSTALLDIR: group=kmem mode=ug+s,+x preserve=1 ssd
+# On systems such as UnixWare, sys owns /dev/kmem.
+$(LIBDIR) :INSTALLDIR: preserve=1 ssd
+	ignore $(CP) $(*) $(<)
+	if silent find /dev/kmem -group kmem >/dev/null 2>&1; then
+		if $(CHGRP) kmem $(<); then
+			ignore $(CHMOD) ug+s $(<)
+		fi
+	elif silent find /dev/kmem -group sys >/dev/null 2>&1; then
+		if $(CHGRP) sys $(<); then
+			ignore $(CHMOD) ug+s $(<)
+		fi
+	fi
+	ignore $(CHMOD) +x $(<)
 
 ssd :: ssd.8 ssd.c -lcs
 

--- a/src/cmd/ss/Mamfile
+++ b/src/cmd/ss/Mamfile
@@ -206,10 +206,18 @@ done ${INSTALLROOT}/lib generated
 make ${INSTALLROOT}/lib/ssd
 prev ${INSTALLROOT}/lib
 prev ssd
-setv group -Dgroup="kmem"
-setv mode -Dmode="ug+s,+x"
 setv preserve -Dpreserve
-exec - test '' = 'ssd' || ${STDCMP} 2>/dev/null -s ssd ${INSTALLROOT}/lib/ssd || { ${STDMV} ${INSTALLROOT}/lib/ssd ${INSTALLROOT}/lib/ssd.old 2>/dev/null || true; ${STDCP} ssd ${INSTALLROOT}/lib/ssd && { chgrp kmem ${INSTALLROOT}/lib/ssd || true ;} && chmod ug+s,+x ${INSTALLROOT}/lib/ssd ;}
+exec - ignore cp ssd ${INSTALLROOT}/lib/ssd
+exec - if silent find /dev/kmem -group kmem >/dev/null 2>&1; then
+exec - if chgrp kmem ${INSTALLROOT}/lib/ssd; then
+exec - ignore chmod ug+s ${INSTALLROOT}/lib/ssd
+exec - fi
+exec - elif silent find /dev/kmem -group sys >/dev/null 2>&1; then
+exec - if chgrp sys ${INSTALLROOT}/lib/ssd; then
+exec - ignore chmod ug+s ${INSTALLROOT}/lib/ssd
+exec - fi
+exec - fi
+exec - ignore chmod +x ${INSTALLROOT}/lib/ssd
 done ${INSTALLROOT}/lib/ssd generated
 make ${INSTALLROOT}/man/man8
 exec - if silent test ! -d ${INSTALLROOT}/man/man8

--- a/src/lib/libast/features/standards
+++ b/src/lib/libast/features/standards
@@ -1,141 +1,186 @@
 set stdio
-if tst note{ _ALL_SOURCE & _POSIX_SOURCE & _POSIX_C_SOURCE & _XOPEN_SOURCE & __EXTENSIONS__ works }end compile{
-		#define _ALL_SOURCE	1
-		#define _POSIX_SOURCE	1
-		#define _POSIX_C_SOURCE	21000101L
-		#define _XOPEN_SOURCE	9900
-		#define _GNU_SOURCE	1
-		#define __EXTENSIONS__	1
+
+# Flag systems that omit necessary definitions such as u_long
+# when _POSIX_SOURCE or _XOPEN_SOURCE are defined.
+# Affected: Mac OS X, UnixWare.
+typ u_long
+
+if tst note{ _ALL_SOURCE & _POSIX_SOURCE & _POSIX_C_SOURCE & _XOPEN_SOURCE & _GNU_SOURCE & _DARWIN_C_SOURCE & __EXTENSIONS__ works }end compile{
+		#define _ALL_SOURCE		1
+		#define _POSIX_SOURCE		1
+		#define _POSIX_C_SOURCE		21000101L
+		#define _XOPEN_SOURCE		9900
+		#define _GNU_SOURCE		1
+		#define _DARWIN_C_SOURCE	1
+		#define __EXTENSIONS__		1
 		#include <sys/types.h>
 		#include <sys/stat.h>
 		#include <stdlib.h>
 		#include <unistd.h>
+		#include <fcntl.h>
+		#ifdef _typ_u_long
+		u_long x;
+		#endif
 	}end {
 		#ifndef _ALL_SOURCE
-		#define _ALL_SOURCE	1
+		#define _ALL_SOURCE		1
 		#endif
 		#ifndef _POSIX_SOURCE
-		#define _POSIX_SOURCE	1
+		#define _POSIX_SOURCE		1
 		#endif
 		#ifndef _POSIX_C_SOURCE
-		#define _POSIX_C_SOURCE	21000101L
+		#define _POSIX_C_SOURCE		21000101L
 		#endif
 		#ifndef _XOPEN_SOURCE
-		#define _XOPEN_SOURCE	9900
+		#define _XOPEN_SOURCE		9900
 		#endif
 		#ifndef _GNU_SOURCE
-		#define _GNU_SOURCE	1
+		#define _GNU_SOURCE		1
+		#endif
+		#ifndef _DARWIN_C_SOURCE
+		#define _DARWIN_C_SOURCE	1
 		#endif
 		#ifndef __EXTENSIONS__
-		#define __EXTENSIONS__	1
+		#define __EXTENSIONS__		1
 		#endif
 	}
-elif tst note{ _ALL_SOURCE & _POSIX_SOURCE & _XOPEN_SOURCE & __EXTENSIONS__ works }end compile{
-		#define _ALL_SOURCE	1
-		#define _POSIX_SOURCE	1
-		#define _XOPEN_SOURCE	9900
-		#define _GNU_SOURCE	1
-		#define __EXTENSIONS__	1
+elif tst note{ _ALL_SOURCE & _POSIX_SOURCE & _XOPEN_SOURCE & _GNU_SOURCE & _DARWIN_C_SOURCE & __EXTENSIONS__ works }end compile{
+		#define _ALL_SOURCE		1
+		#define _POSIX_SOURCE		1
+		#define _XOPEN_SOURCE		9900
+		#define _GNU_SOURCE		1
+		#define _DARWIN_C_SOURCE	1
+		#define __EXTENSIONS__		1
 		#include <sys/types.h>
 		#include <sys/stat.h>
 		#include <stdlib.h>
 		#include <unistd.h>
+		#include <fcntl.h>
+		#ifdef _typ_u_long
+		u_long x;
+		#endif
 	}end {
 		#ifndef _ALL_SOURCE
-		#define _ALL_SOURCE	1
+		#define _ALL_SOURCE		1
 		#endif
 		#ifndef _POSIX_SOURCE
-		#define _POSIX_SOURCE	1
+		#define _POSIX_SOURCE		1
 		#endif
 		#ifndef _XOPEN_SOURCE
-		#define _XOPEN_SOURCE	9900
+		#define _XOPEN_SOURCE		9900
 		#endif
 		#ifndef _GNU_SOURCE
-		#define _GNU_SOURCE	1
+		#define _GNU_SOURCE		1
+		#endif
+		#ifndef _DARWIN_C_SOURCE
+		#define _DARWIN_C_SOURCE	1
 		#endif
 		#ifndef __EXTENSIONS__
-		#define __EXTENSIONS__	1
+		#define __EXTENSIONS__		1
 		#endif
 	}
-elif tst note{ _POSIX_SOURCE & _POSIX_C_SOURCE & _XOPEN_SOURCE & __EXTENSIONS__ works }end compile{
-		#define _POSIX_SOURCE	1
-		#define _POSIX_C_SOURCE	21000101L
-		#define _XOPEN_SOURCE	9900
-		#define _GNU_SOURCE	1
-		#define __EXTENSIONS__	1
+elif tst note{ _POSIX_SOURCE & _POSIX_C_SOURCE & _XOPEN_SOURCE & _GNU_SOURCE & _DARWIN_C_SOURCE & __EXTENSIONS__ works }end compile{
+		#define _POSIX_SOURCE		1
+		#define _POSIX_C_SOURCE		21000101L
+		#define _XOPEN_SOURCE		9900
+		#define _GNU_SOURCE		1
+		#define _DARWIN_C_SOURCE	1
+		#define __EXTENSIONS__		1
 		#include <sys/types.h>
 		#include <sys/stat.h>
 		#include <stdlib.h>
 		#include <unistd.h>
+		#include <fcntl.h>
+		#ifdef _typ_u_long
+		u_long x;
+		#endif
 	}end {
 		#ifndef _POSIX_SOURCE
-		#define _POSIX_SOURCE	1
+		#define _POSIX_SOURCE		1
 		#endif
 		#ifndef _POSIX_C_SOURCE
-		#define _POSIX_C_SOURCE	21000101L
+		#define _POSIX_C_SOURCE		21000101L
 		#endif
 		#ifndef _XOPEN_SOURCE
-		#define _XOPEN_SOURCE	9900
+		#define _XOPEN_SOURCE		9900
 		#endif
 		#ifndef _GNU_SOURCE
-		#define _GNU_SOURCE	1
+		#define _GNU_SOURCE		1
+		#endif
+		#ifndef _DARWIN_C_SOURCE
+		#define _DARWIN_C_SOURCE	1
 		#endif
 		#ifndef __EXTENSIONS__
-		#define __EXTENSIONS__	1
+		#define __EXTENSIONS__		1
 		#endif
 	}
 elif tst note{ _POSIX_SOURCE & _XOPEN_SOURCE & __EXTENSIONS__ works }end compile{
-		#define _POSIX_SOURCE	1
-		#define _XOPEN_SOURCE	1
-		#define __EXTENSIONS__	1
+		#define _POSIX_SOURCE		1
+		#define _XOPEN_SOURCE		1
+		#define __EXTENSIONS__		1
 		#include <sys/types.h>
 		#include <sys/stat.h>
 		#include <stdlib.h>
 		#include <unistd.h>
+		#include <fcntl.h>
+		#ifdef _typ_u_long
+		u_long x;
+		#endif
 	}end {
 		#ifndef _POSIX_SOURCE
-		#define _POSIX_SOURCE	1
+		#define _POSIX_SOURCE		1
 		#endif
 		#ifndef _XOPEN_SOURCE
-		#define _XOPEN_SOURCE	1
+		#define _XOPEN_SOURCE		1
 		#endif
 		#ifndef __EXTENSIONS__
-		#define __EXTENSIONS__	1
+		#define __EXTENSIONS__		1
 		#endif
 	}
 elif tst note{ _XOPEN_SOURCE & __EXTENSIONS__ works }end compile{
-		#define _XOPEN_SOURCE	1
-		#define __EXTENSIONS__	1
+		#define _XOPEN_SOURCE		1
+		#define __EXTENSIONS__		1
 		#include <sys/types.h>
 		#include <sys/stat.h>
 		#include <stdlib.h>
 		#include <unistd.h>
+		#include <fcntl.h>
+		#ifdef _typ_u_long
+		u_long x;
+		#endif
 	}end {
 		#ifndef _XOPEN_SOURCE
-		#define _XOPEN_SOURCE	1
+		#define _XOPEN_SOURCE		1
 		#endif
 		#ifndef __EXTENSIONS__
-		#define __EXTENSIONS__	1
+		#define __EXTENSIONS__		1
 		#endif
 	}
 elif tst note{ _XOPEN_SOURCE works }end compile{
-		#define _XOPEN_SOURCE	1
+		#define _XOPEN_SOURCE		1
 		#include <sys/types.h>
 		#include <sys/stat.h>
 		#include <stdlib.h>
 		#include <unistd.h>
+		#include <fcntl.h>
+		#ifdef _typ_u_long
+		u_long x;
+		#endif
 	}end {
 		#ifndef _XOPEN_SOURCE
-		#define _XOPEN_SOURCE	1
+		#define _XOPEN_SOURCE		1
 		#endif
 	}
 else tst note{ __EXTENSIONS__ works }end compile{
-		#define __EXTENSIONS__	1
+		#define __EXTENSIONS__		1
 		#include <sys/types.h>
 		#include <sys/stat.h>
+		#ifdef _typ_u_long
+		u_long x;
+		#endif
 	}end {
 		#ifndef __EXTENSIONS__
-		#define __EXTENSIONS__	1
+		#define __EXTENSIONS__		1
 		#endif
 	}
 endif
@@ -149,23 +194,7 @@ if tst -D_ISOC99_SOURCE -lm note{ _ISOC99_SOURCE plays nice }end link{
 		int main() { return signbit(-0.0); }
 	}end {
 		#ifndef _ISOC99_SOURCE
-		#define _ISOC99_SOURCE	1
+		#define _ISOC99_SOURCE		1
 		#endif
 	}
 endif
-
-cat{
-
-/*
- * this is a nasty game we all play to honor standards symbol visibility
- * it would help if all implementations had
- *	_KITCHEN_SINK_SOURCE
- * that enabled all symbols from the latest implemented standards
- * that's probably the most useful but least portable request
- */
-
-#if __MACH__
-#undef  _POSIX_SOURCE
-#endif
-
-}end


### PR DESCRIPTION
* src/cmd/ss/Makefile: Properly handle sys ownership of /dev/kmem.
* src/cmd/ss/Mamfile: Regenerate Mamfile.
* src/lib/libast/features/standards:
- Add heuristic (u_long availability) for systems that hide rather
  than reveal functionality in the presence of _POSIX_SOURCE, etc.
- Define _DARWIN_C_SOURCE, like _GNU_SOURCE, to enable the full range
  of definitions on Mac OS X systems.
- Due to the above, remove __MACH__ (Mac OS X)-specific hack.